### PR TITLE
CI: install Python test dependencies before run_all_tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,4 +44,4 @@ jobs:
             -v "$GITHUB_WORKSPACE:/workspace" \
             -w /workspace \
             "$CI_IMAGE" \
-            bash -lc 'export DEPS_INSTALL_PREFIX=/opt/quantra-deps && ./scripts/build.sh Release && bash tests/run_all_tests.sh'
+            bash -lc 'export DEPS_INSTALL_PREFIX=/opt/quantra-deps && python3 -m pip install --break-system-packages --no-cache-dir requests QuantLib && ./scripts/build.sh Release && bash tests/run_all_tests.sh'


### PR DESCRIPTION
## What changed
- 

## Why
- 

## Tests
- [ ] CI passed
- [ ] Relevant local tests run (`tests/run_all_tests.sh` or subset)

## API/Contract impact
- [ ] No API change
- [ ] Backward-compatible API change
- [ ] Breaking API change (major version required)

## Docs
- [ ] Not needed
- [ ] Updated (`README`, `docs/VERSIONING.md`, etc.)
