### PR TITLE
Align build entrypoints across local, CI, and Docker.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -143,25 +143,12 @@ RUN chmod +x /usr/local/bin/quantra
 # Create helper scripts
 RUN echo '#!/bin/bash' > /usr/local/bin/regen-flatbuffers.sh && \
     echo 'set -e' >> /usr/local/bin/regen-flatbuffers.sh && \
-    echo 'cd /workspace' >> /usr/local/bin/regen-flatbuffers.sh && \
-    echo 'echo "Regenerating Flatbuffers code..."' >> /usr/local/bin/regen-flatbuffers.sh && \
-    echo 'echo "Using flatc version: $(flatc --version)"' >> /usr/local/bin/regen-flatbuffers.sh && \
-    echo 'for fbs in flatbuffers/fbs/*.fbs; do' >> /usr/local/bin/regen-flatbuffers.sh && \
-    echo '    echo "Processing $fbs"' >> /usr/local/bin/regen-flatbuffers.sh && \
-    echo '    flatc --cpp -o flatbuffers/cpp/ "$fbs"' >> /usr/local/bin/regen-flatbuffers.sh && \
-    echo 'done' >> /usr/local/bin/regen-flatbuffers.sh && \
-    echo 'flatc --grpc --cpp -I flatbuffers -o grpc/ grpc/quantraserver.fbs' >> /usr/local/bin/regen-flatbuffers.sh && \
-    echo 'echo "Done!"' >> /usr/local/bin/regen-flatbuffers.sh && \
+    echo 'exec /workspace/scripts/generate_schemas.sh "$@"' >> /usr/local/bin/regen-flatbuffers.sh && \
     chmod +x /usr/local/bin/regen-flatbuffers.sh
 
 RUN echo '#!/bin/bash' > /usr/local/bin/build.sh && \
     echo 'set -e' >> /usr/local/bin/build.sh && \
-    echo 'cd /workspace' >> /usr/local/bin/build.sh && \
-    echo 'mkdir -p build' >> /usr/local/bin/build.sh && \
-    echo 'cd build' >> /usr/local/bin/build.sh && \
-    echo 'cmake -DCMAKE_PREFIX_PATH=${DEPS_INSTALL_PREFIX} -DCMAKE_BUILD_TYPE=${1:-Debug} ..' >> /usr/local/bin/build.sh && \
-    echo 'make -j$(nproc)' >> /usr/local/bin/build.sh && \
-    echo 'echo "Build complete!"' >> /usr/local/bin/build.sh && \
+    echo 'exec /workspace/scripts/build.sh "$@"' >> /usr/local/bin/build.sh && \
     chmod +x /usr/local/bin/build.sh
 
 RUN echo '#!/bin/bash' > /usr/local/bin/run-tests.sh && \
@@ -197,22 +184,12 @@ RUN mkdir -p /root/grpc && \
 COPY . /src
 WORKDIR /src
 
-# Regenerate Flatbuffers code for new versions
-# Note: quantraserver.fbs uses includes like "/fbs/..." so we use -I to set include path
-RUN echo "=== Regenerating Flatbuffers code ===" && \
-    echo "Using flatc version: $(${DEPS_INSTALL_PREFIX}/bin/flatc --version)" && \
-    for fbs in flatbuffers/fbs/*.fbs; do \
-        echo "Processing $fbs"; \
-        ${DEPS_INSTALL_PREFIX}/bin/flatc --cpp -o flatbuffers/cpp/ "$fbs"; \
-    done && \
-    ${DEPS_INSTALL_PREFIX}/bin/flatc --grpc --cpp \
-        -I flatbuffers \
-        -o grpc/ \
-        grpc/quantraserver.fbs
-
 # Set environment for pkg-config and library paths
 ENV PKG_CONFIG_PATH="${DEPS_INSTALL_PREFIX}/lib/pkgconfig:${PKG_CONFIG_PATH}"
 ENV LD_LIBRARY_PATH="${DEPS_INSTALL_PREFIX}/lib:${LD_LIBRARY_PATH}"
+
+# Build script regenerates schemas and OpenAPI docs; PyYAML is required.
+RUN pip3 install --break-system-packages -r tools/quantra-manager/requirements.txt
 
 # Debug: List available abseil libraries
 RUN echo "=== Available abseil libraries ===" && \
@@ -220,14 +197,8 @@ RUN echo "=== Available abseil libraries ===" && \
     echo "=== pkg-config grpc++ ===" && \
     pkg-config --libs grpc++ || echo "pkg-config for grpc++ failed"
 
-# Build
-RUN mkdir -p build && \
-    cd build && \
-    cmake \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_PREFIX_PATH=${DEPS_INSTALL_PREFIX} \
-        .. && \
-    make -j$(nproc)
+# Build using the same entrypoint as local and CI.
+RUN ./scripts/build.sh Release
 
 # =============================================================================
 # Stage: production - Minimal runtime image with multi-process support

--- a/flatbuffers/cpp/pricing_generated.h
+++ b/flatbuffers/cpp/pricing_generated.h
@@ -668,141 +668,38 @@ struct PricingBuilder {
   typedef Pricing Table;
   ::flatbuffers::FlatBufferBuilder &fbb_;
   ::flatbuffers::uoffset_t start_;
-  ::flatbuffers::Offset<::flatbuffers::String> as_of_date_{0};
-  ::flatbuffers::Offset<::flatbuffers::String> settlement_date_{0};
-  ::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<quantra::QuoteSpec>>> quotes_{0};
-  ::flatbuffers::Offset<quantra::RatesMarketData> rates_{0};
-  ::flatbuffers::Offset<quantra::CreditMarketData> credit_{0};
-  ::flatbuffers::Offset<quantra::VolatilityMarketData> volatility_{0};
-  ::flatbuffers::Offset<quantra::EquityMarketData> equity_{0};
-  ::flatbuffers::Offset<quantra::InflationMarketData> inflation_{0};
-  ::flatbuffers::Offset<quantra::PricingOptions> options_{0};
-  ::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<quantra::IndexDef>>> legacy_indices_{0};
-  ::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<quantra::SwapIndexDef>>> legacy_swap_indices_{0};
-  ::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<quantra::TermStructure>>> legacy_curves_{0};
-  ::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<quantra::CouponPricer>>> legacy_coupon_pricers_{0};
-  ::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<quantra::CreditCurveSpec>>> legacy_credit_curves_{0};
-  ::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<quantra::VolSurfaceSpec>>> legacy_vol_surfaces_{0};
-  ::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<quantra::ModelSpec>>> legacy_models_{0};
-  ::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<quantra::EquityUnderlyingSpec>>> legacy_equity_underlyings_{0};
-  ::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<quantra::InflationIndexSpec>>> legacy_inflation_indices_{0};
-  ::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<quantra::InflationCurveSpec>>> legacy_inflation_curves_{0};
-  bool legacy_bond_pricing_details_ = false;
-  bool legacy_bond_pricing_flows_ = false;
-  bool legacy_swaption_pricing_details_ = false;
-  bool legacy_swaption_pricing_rebump_ = false;
-  bool legacy_options_set_ = false;
   void add_as_of_date(::flatbuffers::Offset<::flatbuffers::String> as_of_date) {
-    as_of_date_ = as_of_date;
+    fbb_.AddOffset(Pricing::VT_AS_OF_DATE, as_of_date);
   }
   void add_settlement_date(::flatbuffers::Offset<::flatbuffers::String> settlement_date) {
-    settlement_date_ = settlement_date;
+    fbb_.AddOffset(Pricing::VT_SETTLEMENT_DATE, settlement_date);
   }
   void add_quotes(::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<quantra::QuoteSpec>>> quotes) {
-    quotes_ = quotes;
+    fbb_.AddOffset(Pricing::VT_QUOTES, quotes);
   }
   void add_rates(::flatbuffers::Offset<quantra::RatesMarketData> rates) {
-    rates_ = rates;
+    fbb_.AddOffset(Pricing::VT_RATES, rates);
   }
   void add_credit(::flatbuffers::Offset<quantra::CreditMarketData> credit) {
-    credit_ = credit;
+    fbb_.AddOffset(Pricing::VT_CREDIT, credit);
   }
   void add_volatility(::flatbuffers::Offset<quantra::VolatilityMarketData> volatility) {
-    volatility_ = volatility;
+    fbb_.AddOffset(Pricing::VT_VOLATILITY, volatility);
   }
   void add_equity(::flatbuffers::Offset<quantra::EquityMarketData> equity) {
-    equity_ = equity;
+    fbb_.AddOffset(Pricing::VT_EQUITY, equity);
   }
   void add_inflation(::flatbuffers::Offset<quantra::InflationMarketData> inflation) {
-    inflation_ = inflation;
+    fbb_.AddOffset(Pricing::VT_INFLATION, inflation);
   }
   void add_options(::flatbuffers::Offset<quantra::PricingOptions> options) {
-    options_ = options;
-  }
-  void add_indices(::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<quantra::IndexDef>>> indices) {
-    legacy_indices_ = indices;
-  }
-  void add_swap_indices(::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<quantra::SwapIndexDef>>> swap_indices) {
-    legacy_swap_indices_ = swap_indices;
-  }
-  void add_curves(::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<quantra::TermStructure>>> curves) {
-    legacy_curves_ = curves;
-  }
-  void add_coupon_pricers(::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<quantra::CouponPricer>>> coupon_pricers) {
-    legacy_coupon_pricers_ = coupon_pricers;
-  }
-  void add_credit_curves(::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<quantra::CreditCurveSpec>>> credit_curves) {
-    legacy_credit_curves_ = credit_curves;
-  }
-  void add_vol_surfaces(::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<quantra::VolSurfaceSpec>>> vol_surfaces) {
-    legacy_vol_surfaces_ = vol_surfaces;
-  }
-  void add_models(::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<quantra::ModelSpec>>> models) {
-    legacy_models_ = models;
-  }
-  void add_equity_underlyings(::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<quantra::EquityUnderlyingSpec>>> equity_underlyings) {
-    legacy_equity_underlyings_ = equity_underlyings;
-  }
-  void add_inflation_indices(::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<quantra::InflationIndexSpec>>> inflation_indices) {
-    legacy_inflation_indices_ = inflation_indices;
-  }
-  void add_inflation_curves(::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<quantra::InflationCurveSpec>>> inflation_curves) {
-    legacy_inflation_curves_ = inflation_curves;
-  }
-  void add_bond_pricing_details(bool bond_pricing_details) {
-    legacy_options_set_ = true;
-    legacy_bond_pricing_details_ = bond_pricing_details;
-  }
-  void add_bond_pricing_flows(bool bond_pricing_flows) {
-    legacy_options_set_ = true;
-    legacy_bond_pricing_flows_ = bond_pricing_flows;
-  }
-  void add_swaption_pricing_details(bool swaption_pricing_details) {
-    legacy_options_set_ = true;
-    legacy_swaption_pricing_details_ = swaption_pricing_details;
-  }
-  void add_swaption_pricing_rebump(bool swaption_pricing_rebump) {
-    legacy_options_set_ = true;
-    legacy_swaption_pricing_rebump_ = swaption_pricing_rebump;
+    fbb_.AddOffset(Pricing::VT_OPTIONS, options);
   }
   explicit PricingBuilder(::flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
+    start_ = fbb_.StartTable();
   }
   ::flatbuffers::Offset<Pricing> Finish() {
-    if (rates_.o == 0 &&
-        (legacy_indices_.o != 0 || legacy_swap_indices_.o != 0 || legacy_curves_.o != 0 || legacy_coupon_pricers_.o != 0)) {
-      rates_ = quantra::CreateRatesMarketData(fbb_, legacy_indices_, legacy_swap_indices_, legacy_curves_, legacy_coupon_pricers_);
-    }
-    if (credit_.o == 0 && legacy_credit_curves_.o != 0) {
-      credit_ = quantra::CreateCreditMarketData(fbb_, legacy_credit_curves_);
-    }
-    if (volatility_.o == 0 && (legacy_vol_surfaces_.o != 0 || legacy_models_.o != 0)) {
-      volatility_ = quantra::CreateVolatilityMarketData(fbb_, legacy_vol_surfaces_, legacy_models_);
-    }
-    if (equity_.o == 0 && legacy_equity_underlyings_.o != 0) {
-      equity_ = quantra::CreateEquityMarketData(fbb_, legacy_equity_underlyings_);
-    }
-    if (inflation_.o == 0 && (legacy_inflation_indices_.o != 0 || legacy_inflation_curves_.o != 0)) {
-      inflation_ = quantra::CreateInflationMarketData(fbb_, legacy_inflation_indices_, legacy_inflation_curves_);
-    }
-    if (options_.o == 0 && legacy_options_set_) {
-      options_ = quantra::CreatePricingOptions(
-          fbb_,
-          legacy_bond_pricing_details_,
-          legacy_bond_pricing_flows_,
-          legacy_swaption_pricing_details_,
-          legacy_swaption_pricing_rebump_);
-    }
-    start_ = fbb_.StartTable();
-    if (options_.o != 0) fbb_.AddOffset(Pricing::VT_OPTIONS, options_);
-    if (inflation_.o != 0) fbb_.AddOffset(Pricing::VT_INFLATION, inflation_);
-    if (equity_.o != 0) fbb_.AddOffset(Pricing::VT_EQUITY, equity_);
-    if (volatility_.o != 0) fbb_.AddOffset(Pricing::VT_VOLATILITY, volatility_);
-    if (credit_.o != 0) fbb_.AddOffset(Pricing::VT_CREDIT, credit_);
-    if (rates_.o != 0) fbb_.AddOffset(Pricing::VT_RATES, rates_);
-    if (quotes_.o != 0) fbb_.AddOffset(Pricing::VT_QUOTES, quotes_);
-    if (settlement_date_.o != 0) fbb_.AddOffset(Pricing::VT_SETTLEMENT_DATE, settlement_date_);
-    if (as_of_date_.o != 0) fbb_.AddOffset(Pricing::VT_AS_OF_DATE, as_of_date_);
     const auto end = fbb_.EndTable(start_);
     auto o = ::flatbuffers::Offset<Pricing>(end);
     fbb_.Required(o, Pricing::VT_AS_OF_DATE);

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,8 +1,30 @@
 #!/bin/bash
-set -e
-cd /workspace
-mkdir -p build
-cd build
-cmake -DCMAKE_PREFIX_PATH=${DEPS_INSTALL_PREFIX} -DCMAKE_BUILD_TYPE=${1:-Debug} ..
-make -j$(nproc)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE="$(dirname "$SCRIPT_DIR")"
+BUILD_TYPE="${1:-Debug}"
+DEPS_PREFIX="${DEPS_INSTALL_PREFIX:-/opt/quantra-deps}"
+
+export DEPS_INSTALL_PREFIX="$DEPS_PREFIX"
+export PATH="$DEPS_PREFIX/bin:$PATH"
+
+cd "$WORKSPACE"
+
+if ! command -v flatc >/dev/null 2>&1; then
+    echo "ERROR: flatc not found. Set DEPS_INSTALL_PREFIX so build.sh can find the FlatBuffers toolchain." >&2
+    exit 1
+fi
+
+echo "=== Regenerating schemas and generated code ==="
+bash "$SCRIPT_DIR/generate_schemas.sh"
+
+echo "=== Cleaning build directory ==="
+rm -rf "$WORKSPACE/build"
+mkdir -p "$WORKSPACE/build"
+
+cd "$WORKSPACE/build"
+cmake -DCMAKE_PREFIX_PATH="$DEPS_PREFIX" -DCMAKE_BUILD_TYPE="$BUILD_TYPE" ..
+make -j"$(nproc)"
+
 echo "Build complete!"

--- a/tests/test_quantra_vs_quantlib.cpp
+++ b/tests/test_quantra_vs_quantlib.cpp
@@ -478,6 +478,58 @@ protected:
 
         return b.CreateVector(defs);
     }
+
+    flatbuffers::Offset<quantra::Pricing> buildPricing(
+        flatbuffers::grpc::MessageBuilder& b,
+        flatbuffers::Offset<flatbuffers::String> asOfDate,
+        flatbuffers::Offset<flatbuffers::String> settlementDate = 0,
+        flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<quantra::QuoteSpec>>> quotes = 0,
+        flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<quantra::IndexDef>>> indices = 0,
+        flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<quantra::SwapIndexDef>>> swapIndices = 0,
+        flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<quantra::TermStructure>>> curves = 0,
+        flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<quantra::CouponPricer>>> couponPricers = 0,
+        flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<quantra::CreditCurveSpec>>> creditCurves = 0,
+        flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<quantra::VolSurfaceSpec>>> volSurfaces = 0,
+        flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<quantra::ModelSpec>>> models = 0,
+        flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<quantra::EquityUnderlyingSpec>>> equityUnderlyings = 0,
+        flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<quantra::InflationIndexSpec>>> inflationIndices = 0,
+        flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<quantra::InflationCurveSpec>>> inflationCurves = 0,
+        bool bondPricingDetails = false,
+        bool bondPricingFlows = false,
+        bool swaptionPricingDetails = false,
+        bool swaptionPricingRebump = false) {
+        auto rates = (indices.o != 0 || swapIndices.o != 0 || curves.o != 0 || couponPricers.o != 0)
+            ? quantra::CreateRatesMarketData(b, indices, swapIndices, curves, couponPricers)
+            : 0;
+        auto credit = creditCurves.o != 0 ? quantra::CreateCreditMarketData(b, creditCurves) : 0;
+        auto volatility = (volSurfaces.o != 0 || models.o != 0)
+            ? quantra::CreateVolatilityMarketData(b, volSurfaces, models)
+            : 0;
+        auto equity = equityUnderlyings.o != 0 ? quantra::CreateEquityMarketData(b, equityUnderlyings) : 0;
+        auto inflation = (inflationIndices.o != 0 || inflationCurves.o != 0)
+            ? quantra::CreateInflationMarketData(b, inflationIndices, inflationCurves)
+            : 0;
+        auto options = (bondPricingDetails || bondPricingFlows || swaptionPricingDetails || swaptionPricingRebump)
+            ? quantra::CreatePricingOptions(
+                  b,
+                  bondPricingDetails,
+                  bondPricingFlows,
+                  swaptionPricingDetails,
+                  swaptionPricingRebump)
+            : 0;
+
+        return quantra::CreatePricing(
+            b,
+            asOfDate,
+            settlementDate,
+            quotes,
+            rates,
+            credit,
+            volatility,
+            equity,
+            inflation,
+            options);
+    }
     
     flatbuffers::Offset<quantra::Yield> buildYield(flatbuffers::grpc::MessageBuilder& b) {
         quantra::YieldBuilder yb(b);
@@ -1002,13 +1054,7 @@ TEST_F(QuantraComparisonTest, FixedRateBond_NPVMatches) {
     auto indices = buildIndicesVector(b);
     auto asof = b.CreateString("2025-01-15");
     
-    quantra::PricingBuilder pb(b);
-    pb.add_as_of_date(asof);
-    pb.add_settlement_date(asof);
-    pb.add_indices(indices);
-    pb.add_curves(curves);
-    pb.add_bond_pricing_details(true);
-    auto pricing = pb.Finish();
+    auto pricing = buildPricing(b, asof, asof, 0, indices, 0, curves, 0, 0, 0, 0, 0, 0, 0, true);
     
     auto eff = b.CreateString("2024-01-15");
     auto term = b.CreateString("2029-01-15");
@@ -1085,12 +1131,7 @@ TEST_F(QuantraComparisonTest, VanillaSwap_NPVMatches) {
     auto indices = buildIndicesVector(b);
     auto asof = b.CreateString("2025-01-15");
     
-    quantra::PricingBuilder pb(b);
-    pb.add_as_of_date(asof);
-    pb.add_settlement_date(asof);
-    pb.add_indices(indices);
-    pb.add_curves(curves);
-    auto pricing = pb.Finish();
+    auto pricing = buildPricing(b, asof, asof, 0, indices, 0, curves);
     
     // Fixed leg
     auto feff = b.CreateString("2025-01-17");
@@ -1241,14 +1282,7 @@ TEST_F(QuantraComparisonTest, VanillaSwap_CMS_NPVMatches) {
     auto vols = b.CreateVector(std::vector<flatbuffers::Offset<quantra::VolSurfaceSpec>>{vol});
     auto asof = b.CreateString("2025-01-15");
 
-    quantra::PricingBuilder pb(b);
-    pb.add_as_of_date(asof);
-    pb.add_settlement_date(asof);
-    pb.add_indices(indices);
-    pb.add_swap_indices(swapIndices);
-    pb.add_curves(curves);
-    pb.add_vol_surfaces(vols);
-    auto pricing = pb.Finish();
+    auto pricing = buildPricing(b, asof, asof, 0, indices, swapIndices, curves, 0, 0, vols);
 
     auto feff = b.CreateString("2025-01-17");
     auto fterm = b.CreateString("2030-01-17");
@@ -1336,12 +1370,7 @@ TEST_F(QuantraComparisonTest, VanillaSwap_CMS_MissingVolThrows) {
     auto swapIndices = buildSwapIndicesVector(b);
     auto asof = b.CreateString("2025-01-15");
 
-    quantra::PricingBuilder pb(b);
-    pb.add_as_of_date(asof);
-    pb.add_indices(indices);
-    pb.add_swap_indices(swapIndices);
-    pb.add_curves(curves);
-    auto pricing = pb.Finish();
+    auto pricing = buildPricing(b, asof, 0, 0, indices, swapIndices, curves);
 
     auto eff = b.CreateString("2025-01-17");
     auto term = b.CreateString("2030-01-17");
@@ -1412,13 +1441,7 @@ TEST_F(QuantraComparisonTest, VanillaSwap_CMS_UnknownSwapIndexThrows) {
     auto vols = b.CreateVector(std::vector<flatbuffers::Offset<quantra::VolSurfaceSpec>>{vol});
     auto asof = b.CreateString("2025-01-15");
 
-    quantra::PricingBuilder pb(b);
-    pb.add_as_of_date(asof);
-    pb.add_indices(indices);
-    pb.add_swap_indices(swapIndices);
-    pb.add_curves(curves);
-    pb.add_vol_surfaces(vols);
-    auto pricing = pb.Finish();
+    auto pricing = buildPricing(b, asof, 0, 0, indices, swapIndices, curves, 0, 0, vols);
 
     auto eff = b.CreateString("2025-01-17");
     auto term = b.CreateString("2030-01-17");
@@ -1489,13 +1512,7 @@ TEST_F(QuantraComparisonTest, CMSCoupons_PricerAttached) {
     auto vols = pbuilder.CreateVector(std::vector<flatbuffers::Offset<quantra::VolSurfaceSpec>>{vol});
     auto asof = pbuilder.CreateString("2025-01-15");
 
-    quantra::PricingBuilder pb(pbuilder);
-    pb.add_as_of_date(asof);
-    pb.add_indices(indices);
-    pb.add_swap_indices(swapIndices);
-    pb.add_curves(curves);
-    pb.add_vol_surfaces(vols);
-    auto pricing = pb.Finish();
+    auto pricing = buildPricing(pbuilder, asof, 0, 0, indices, swapIndices, curves, 0, 0, vols);
     pbuilder.Finish(pricing);
 
     PricingRegistryBuilder regBuilder;
@@ -1575,12 +1592,7 @@ TEST_F(QuantraComparisonTest, FRA_NPVMatches) {
     auto indices = buildIndicesVector(b, true);  // include EUR_3M
     auto asof = b.CreateString("2025-01-15");
     
-    quantra::PricingBuilder pb(b);
-    pb.add_as_of_date(asof);
-    pb.add_settlement_date(asof);
-    pb.add_indices(indices);
-    pb.add_curves(curves);
-    auto pricing = pb.Finish();
+    auto pricing = buildPricing(b, asof, asof, 0, indices, 0, curves);
     
     auto vd = b.CreateString("2025-04-15");
     auto md = b.CreateString("2025-07-15");
@@ -1658,14 +1670,7 @@ TEST_F(QuantraComparisonTest, Cap_NPVMatches) {
     auto indices = buildIndicesVector(b, true);  // include EUR_3M for cap
     auto asof = b.CreateString("2025-01-15");
     
-    quantra::PricingBuilder pb(b);
-    pb.add_as_of_date(asof);
-    pb.add_indices(indices);
-    pb.add_curves(curves);
-    pb.add_vol_surfaces(vols);
-    pb.add_models(models);
-    pb.add_swaption_pricing_rebump(true);
-    auto pricing = pb.Finish();
+    auto pricing = buildPricing(b, asof, 0, 0, indices, 0, curves, 0, 0, vols, models, 0, 0, 0, false, false, false, true);
     
     auto eff = b.CreateString("2025-01-17");
     auto term = b.CreateString("2030-01-17");
@@ -1755,13 +1760,7 @@ TEST_F(QuantraComparisonTest, Swaption_NPVMatches) {
     auto indices = buildIndicesVector(b);
     auto asof = b.CreateString("2025-01-15");
     
-    quantra::PricingBuilder pb(b);
-    pb.add_as_of_date(asof);
-    pb.add_indices(indices);
-    pb.add_curves(curves);
-    pb.add_vol_surfaces(vols);
-    pb.add_models(models);
-    auto pricing = pb.Finish();
+    auto pricing = buildPricing(b, asof, 0, 0, indices, 0, curves, 0, 0, vols, models);
     
     // Fixed leg schedule
     auto feff = b.CreateString("2026-01-17");
@@ -1893,13 +1892,7 @@ TEST_F(QuantraComparisonTest, Swaption_Bermudan_HullWhiteLattice_NPVMatches) {
     auto indices = buildIndicesVector(b);
     auto asof = b.CreateString("2025-01-15");
 
-    quantra::PricingBuilder pb(b);
-    pb.add_as_of_date(asof);
-    pb.add_indices(indices);
-    pb.add_curves(curves);
-    pb.add_vol_surfaces(vols);
-    pb.add_models(models);
-    auto pricing = pb.Finish();
+    auto pricing = buildPricing(b, asof, 0, 0, indices, 0, curves, 0, 0, vols, models);
 
     // Fixed leg schedule
     auto feff = b.CreateString("2026-01-17");
@@ -2013,14 +2006,7 @@ TEST_F(QuantraComparisonTest, CalibrateSwaptionModel_ReturnsReasonableParams) {
     auto swapIndices = buildSwapIndicesVector(b);
     auto asof = b.CreateString("2025-01-15");
 
-    quantra::PricingBuilder pb(b);
-    pb.add_as_of_date(asof);
-    pb.add_indices(indices);
-    pb.add_swap_indices(swapIndices);
-    pb.add_curves(curves);
-    pb.add_vol_surfaces(vols);
-    pb.add_models(models);
-    auto pricing = pb.Finish();
+    auto pricing = buildPricing(b, asof, 0, 0, indices, swapIndices, curves, 0, 0, vols, models);
 
     auto modelId = b.CreateString("hw_cal_model");
     quantra::CalibrateSwaptionModelRequestBuilder cb(b);
@@ -2065,14 +2051,7 @@ TEST_F(QuantraComparisonTest, CalibrateSwaptionModel_MatchesDirectQuantLibCalibr
     auto swapIndices = buildSwapIndicesVector(b);
     auto asof = b.CreateString("2025-01-15");
 
-    quantra::PricingBuilder pb(b);
-    pb.add_as_of_date(asof);
-    pb.add_indices(indices);
-    pb.add_swap_indices(swapIndices);
-    pb.add_curves(curves);
-    pb.add_vol_surfaces(vols);
-    pb.add_models(models);
-    auto pricing = pb.Finish();
+    auto pricing = buildPricing(b, asof, 0, 0, indices, swapIndices, curves, 0, 0, vols, models);
 
     auto modelId = b.CreateString("hw_cal_model");
     quantra::CalibrateSwaptionModelRequestBuilder cb(b);
@@ -2172,7 +2151,7 @@ TEST_F(QuantraComparisonTest, PriceSwaption_InlineCalibrate_MatchesEndpoint) {
     const double notional = 1000000.0;
     const double strike = 0.035;
 
-    auto buildPricing = [&](flatbuffers::grpc::MessageBuilder& b, bool calibrateMode, double hwA, double hwSigma, const std::string& modelId) {
+    auto buildSwaptionPricing = [&](flatbuffers::grpc::MessageBuilder& b, bool calibrateMode, double hwA, double hwSigma, const std::string& modelId) {
         auto ts = buildCurve(b, "discount");
         auto curves = b.CreateVector(std::vector<flatbuffers::Offset<quantra::TermStructure>>{ts});
         std::vector<QuantLib::Period> expiries = { QuantLib::Period(1, QuantLib::Years), QuantLib::Period(2, QuantLib::Years) };
@@ -2188,14 +2167,7 @@ TEST_F(QuantraComparisonTest, PriceSwaption_InlineCalibrate_MatchesEndpoint) {
         auto indices = buildIndicesVector(b);
         auto swapIndices = buildSwapIndicesVector(b);
         auto asof = b.CreateString("2025-01-15");
-        quantra::PricingBuilder pb(b);
-        pb.add_as_of_date(asof);
-        pb.add_indices(indices);
-        pb.add_swap_indices(swapIndices);
-        pb.add_curves(curves);
-        pb.add_vol_surfaces(vols);
-        pb.add_models(models);
-        return pb.Finish();
+        return buildPricing(b, asof, 0, 0, indices, swapIndices, curves, 0, 0, vols, models);
     };
 
     auto buildBermudanTrade = [&](flatbuffers::grpc::MessageBuilder& b, const std::string& modelId) {
@@ -2278,7 +2250,7 @@ TEST_F(QuantraComparisonTest, PriceSwaption_InlineCalibrate_MatchesEndpoint) {
     double sigmaStar = 0.0;
     {
         flatbuffers::grpc::MessageBuilder b;
-        auto pricing = buildPricing(b, true, 0.03, 0.01, "hw_inline_model");
+        auto pricing = buildSwaptionPricing(b, true, 0.03, 0.01, "hw_inline_model");
         auto modelId = b.CreateString("hw_inline_model");
         quantra::CalibrateSwaptionModelRequestBuilder cb(b);
         cb.add_pricing(pricing);
@@ -2298,7 +2270,7 @@ TEST_F(QuantraComparisonTest, PriceSwaption_InlineCalibrate_MatchesEndpoint) {
     double npvInline = 0.0;
     {
         flatbuffers::grpc::MessageBuilder b;
-        auto pricing = buildPricing(b, true, 0.03, 0.01, "hw_inline_model");
+        auto pricing = buildSwaptionPricing(b, true, 0.03, 0.01, "hw_inline_model");
         auto ps = buildBermudanTrade(b, "hw_inline_model");
         auto swaptions = b.CreateVector(std::vector<flatbuffers::Offset<quantra::PriceSwaption>>{ps});
         quantra::PriceSwaptionRequestBuilder rb(b);
@@ -2317,7 +2289,7 @@ TEST_F(QuantraComparisonTest, PriceSwaption_InlineCalibrate_MatchesEndpoint) {
     double npvExplicit = 0.0;
     {
         flatbuffers::grpc::MessageBuilder b;
-        auto pricing = buildPricing(b, false, aStar, sigmaStar, "hw_explicit_model");
+        auto pricing = buildSwaptionPricing(b, false, aStar, sigmaStar, "hw_explicit_model");
         auto ps = buildBermudanTrade(b, "hw_explicit_model");
         auto swaptions = b.CreateVector(std::vector<flatbuffers::Offset<quantra::PriceSwaption>>{ps});
         quantra::PriceSwaptionRequestBuilder rb(b);
@@ -2357,14 +2329,7 @@ TEST_F(QuantraComparisonTest, PriceSwaption_InlineCalibrate_CachesPerModel) {
     auto swapIndices = buildSwapIndicesVector(b);
     auto asof = b.CreateString("2025-01-15");
 
-    quantra::PricingBuilder pb(b);
-    pb.add_as_of_date(asof);
-    pb.add_indices(indices);
-    pb.add_swap_indices(swapIndices);
-    pb.add_curves(curves);
-    pb.add_vol_surfaces(vols);
-    pb.add_models(models);
-    auto pricing = pb.Finish();
+    auto pricing = buildPricing(b, asof, 0, 0, indices, swapIndices, curves, 0, 0, vols, models);
 
     auto feff = b.CreateString("2026-01-17");
     auto fterm = b.CreateString("2031-01-17");
@@ -2500,14 +2465,7 @@ TEST_F(QuantraComparisonTest, Swaption_ATMMatrix_NPVMatches) {
     auto swapIndices = buildSwapIndicesVector(b);
     auto asof = b.CreateString("2025-01-15");
 
-    quantra::PricingBuilder pb(b);
-    pb.add_as_of_date(asof);
-    pb.add_indices(indices);
-    pb.add_swap_indices(swapIndices);
-    pb.add_curves(curves);
-    pb.add_vol_surfaces(vols);
-    pb.add_models(models);
-    auto pricing = pb.Finish();
+    auto pricing = buildPricing(b, asof, 0, 0, indices, swapIndices, curves, 0, 0, vols, models);
 
     auto feff = b.CreateString("2026-01-17");
     auto fterm = b.CreateString("2031-01-17");
@@ -2635,14 +2593,7 @@ TEST_F(QuantraComparisonTest, Swaption_SmileCube_ConstantMatches) {
     auto swapIndices = buildSwapIndicesVector(b);
     auto asof = b.CreateString("2025-01-15");
 
-    quantra::PricingBuilder pb(b);
-    pb.add_as_of_date(asof);
-    pb.add_indices(indices);
-    pb.add_swap_indices(swapIndices);
-    pb.add_curves(curves);
-    pb.add_vol_surfaces(vols);
-    pb.add_models(models);
-    auto pricing = pb.Finish();
+    auto pricing = buildPricing(b, asof, 0, 0, indices, swapIndices, curves, 0, 0, vols, models);
 
     auto feff = b.CreateString("2026-01-17");
     auto fterm = b.CreateString("2031-01-17");
@@ -2757,14 +2708,7 @@ TEST_F(QuantraComparisonTest, Swaption_SmileCube_IndexMismatchThrows) {
     auto swapIndices = buildSwapIndicesVector(b, true, true, true);
     auto asof = b.CreateString("2025-01-15");
 
-    quantra::PricingBuilder pb(b);
-    pb.add_as_of_date(asof);
-    pb.add_indices(indices);
-    pb.add_swap_indices(swapIndices);
-    pb.add_curves(curves);
-    pb.add_vol_surfaces(vols);
-    pb.add_models(models);
-    auto pricing = pb.Finish();
+    auto pricing = buildPricing(b, asof, 0, 0, indices, swapIndices, curves, 0, 0, vols, models);
 
     auto feff = b.CreateString("2026-01-17");
     auto fterm = b.CreateString("2031-01-17");
@@ -2990,14 +2934,7 @@ TEST_F(QuantraComparisonTest, Swaption_Bachelier_NPVMatches) {
     auto quote = qb.Finish();
     auto quotes = b.CreateVector(std::vector<flatbuffers::Offset<quantra::QuoteSpec>>{quote});
 
-    quantra::PricingBuilder pb(b);
-    pb.add_as_of_date(asof);
-    pb.add_indices(indices);
-    pb.add_curves(curves);
-    pb.add_quotes(quotes);
-    pb.add_vol_surfaces(vols);
-    pb.add_models(models);
-    auto pricing = pb.Finish();
+    auto pricing = buildPricing(b, asof, 0, quotes, indices, 0, curves, 0, 0, vols, models);
 
     // Fixed leg schedule
     auto feff = b.CreateString("2026-01-17");
@@ -3250,13 +3187,7 @@ TEST_F(QuantraComparisonTest, Swaption_OIS_Bachelier_NPVMatches) {
         std::vector<flatbuffers::Offset<quantra::IndexDef>>{buildIndexDef_USD_SOFR(b)});
     auto asof = b.CreateString("2024-08-14");
 
-    quantra::PricingBuilder pb(b);
-    pb.add_as_of_date(asof);
-    pb.add_indices(indices);
-    pb.add_curves(curves);
-    pb.add_vol_surfaces(vols);
-    pb.add_models(models);
-    auto pricing = pb.Finish();
+    auto pricing = buildPricing(b, asof, 0, 0, indices, 0, curves, 0, 0, vols, models);
 
     // Fixed leg schedule
     auto feff = b.CreateString("2024-09-18");
@@ -3389,15 +3320,7 @@ TEST_F(QuantraComparisonTest, Swaption_OIS_SmileCubeSpreadFromATM_UsesSwapIndexR
     auto swapIndices = buildSwapIndicesVector(b, false, true, false);
     auto asof = b.CreateString("2024-08-14");
 
-    quantra::PricingBuilder pb(b);
-    pb.add_as_of_date(asof);
-    pb.add_indices(indices);
-    pb.add_swap_indices(swapIndices);
-    pb.add_curves(curves);
-    pb.add_vol_surfaces(vols);
-    pb.add_models(models);
-    pb.add_swaption_pricing_rebump(true);
-    auto pricing = pb.Finish();
+    auto pricing = buildPricing(b, asof, 0, 0, indices, swapIndices, curves, 0, 0, vols, models, 0, 0, 0, false, false, false, true);
 
     auto feff = b.CreateString("2025-08-18");
     auto fterm = b.CreateString("2030-08-18");
@@ -3555,14 +3478,7 @@ TEST_F(QuantraComparisonTest, CDS_NPVMatches) {
     msb.add_payload(cds_payload.Union());
     auto models = b.CreateVector(std::vector<flatbuffers::Offset<quantra::ModelSpec>>{msb.Finish()});
 
-    quantra::PricingBuilder pb(b);
-    pb.add_as_of_date(asof);
-    pb.add_settlement_date(asof);
-    pb.add_indices(indices);
-    pb.add_curves(curves);
-    pb.add_credit_curves(credit_curves);
-    pb.add_models(models);
-    auto pricing = pb.Finish();
+    auto pricing = buildPricing(b, asof, asof, 0, indices, 0, curves, 0, credit_curves, 0, models);
     
     auto eff = b.CreateString("2025-01-15");
     auto term = b.CreateString("2030-01-15");
@@ -3672,11 +3588,7 @@ TEST_F(QuantraComparisonTest, BootstrapCurves_DiscountFactors) {
     auto indices = buildIndicesVector(b);
     
     auto as_of = b.CreateString("2025-01-15");
-    quantra::PricingBuilder pb(b);
-    pb.add_as_of_date(as_of);
-    pb.add_indices(indices);
-    pb.add_curves(curves);
-    auto pricing = pb.Finish();
+    auto pricing = buildPricing(b, as_of, 0, 0, indices, 0, curves);
 
     quantra::BootstrapCurvesRequestBuilder reqb(b);
     reqb.add_pricing(pricing);
@@ -3765,11 +3677,7 @@ TEST_F(QuantraComparisonTest, BootstrapCurves_ZeroRates) {
     auto indices = buildIndicesVector(b);
     
     auto as_of = b.CreateString("2025-01-15");
-    quantra::PricingBuilder pb(b);
-    pb.add_as_of_date(as_of);
-    pb.add_indices(indices);
-    pb.add_curves(curves);
-    auto pricing = pb.Finish();
+    auto pricing = buildPricing(b, as_of, 0, 0, indices, 0, curves);
 
     quantra::BootstrapCurvesRequestBuilder reqb(b);
     reqb.add_pricing(pricing);
@@ -3849,11 +3757,7 @@ TEST_F(QuantraComparisonTest, BootstrapCurves_PillarDates) {
     auto indices = buildIndicesVector(b);
     
     auto as_of = b.CreateString("2025-01-15");
-    quantra::PricingBuilder pb(b);
-    pb.add_as_of_date(as_of);
-    pb.add_indices(indices);
-    pb.add_curves(curves);
-    auto pricing = pb.Finish();
+    auto pricing = buildPricing(b, as_of, 0, 0, indices, 0, curves);
 
     quantra::BootstrapCurvesRequestBuilder reqb(b);
     reqb.add_pricing(pricing);
@@ -3892,13 +3796,7 @@ TEST_F(QuantraComparisonTest, SampleVolSurfaces_SwaptionConstantCube) {
     auto swapIndices = buildSwapIndicesVector(b);
 
     auto asof = b.CreateString("2025-01-15");
-    quantra::PricingBuilder pb(b);
-    pb.add_as_of_date(asof);
-    pb.add_indices(indices);
-    pb.add_swap_indices(swapIndices);
-    pb.add_curves(curves);
-    pb.add_vol_surfaces(volSurfaces);
-    auto pricing = pb.Finish();
+    auto pricing = buildPricing(b, asof, 0, 0, indices, swapIndices, curves, 0, 0, volSurfaces);
 
     quantra::PeriodBuilder e1(b); e1.add_n(1); e1.add_unit(quantra::enums::TimeUnit_Years);
     auto e1Off = e1.Finish();
@@ -3971,13 +3869,7 @@ TEST_F(QuantraComparisonTest, SampleVolSurfaces_SwaptionSpreadFromAtmReturnsAtmG
     auto swapIndices = buildSwapIndicesVector(b);
 
     auto asof = b.CreateString("2025-01-15");
-    quantra::PricingBuilder pb(b);
-    pb.add_as_of_date(asof);
-    pb.add_indices(indices);
-    pb.add_swap_indices(swapIndices);
-    pb.add_curves(curves);
-    pb.add_vol_surfaces(volSurfaces);
-    auto pricing = pb.Finish();
+    auto pricing = buildPricing(b, asof, 0, 0, indices, swapIndices, curves, 0, 0, volSurfaces);
 
     quantra::PeriodBuilder e1(b); e1.add_n(1); e1.add_unit(quantra::enums::TimeUnit_Years);
     auto e1Off = e1.Finish();
@@ -4047,12 +3939,7 @@ TEST_F(QuantraComparisonTest, SampleVolSurfaces_OptionletCube) {
     auto indices = buildIndicesVector(b);
 
     auto asof = b.CreateString("2025-01-15");
-    quantra::PricingBuilder pb(b);
-    pb.add_as_of_date(asof);
-    pb.add_indices(indices);
-    pb.add_curves(curves);
-    pb.add_vol_surfaces(volSurfaces);
-    auto pricing = pb.Finish();
+    auto pricing = buildPricing(b, asof, 0, 0, indices, 0, curves, 0, 0, volSurfaces);
 
     quantra::PeriodBuilder e1(b); e1.add_n(1); e1.add_unit(quantra::enums::TimeUnit_Years);
     auto e1Off = e1.Finish();
@@ -4105,12 +3992,7 @@ TEST_F(QuantraComparisonTest, SampleVolSurfaces_EquityBlackCube) {
     auto indices = buildIndicesVector(b);
 
     auto asof = b.CreateString("2026-02-27");
-    quantra::PricingBuilder pb(b);
-    pb.add_as_of_date(asof);
-    pb.add_indices(indices);
-    pb.add_curves(curves);
-    pb.add_vol_surfaces(volSurfaces);
-    auto pricing = pb.Finish();
+    auto pricing = buildPricing(b, asof, 0, 0, indices, 0, curves, 0, 0, volSurfaces);
 
     quantra::PeriodBuilder e1(b); e1.add_n(1); e1.add_unit(quantra::enums::TimeUnit_Months);
     auto e1Off = e1.Finish();
@@ -4173,12 +4055,7 @@ TEST_F(QuantraComparisonTest, SampleVolSurfaces_EquityBlackTermStructureCube) {
     auto indices = buildIndicesVector(b);
 
     auto asof = b.CreateString("2025-01-15");
-    quantra::PricingBuilder pb(b);
-    pb.add_as_of_date(asof);
-    pb.add_indices(indices);
-    pb.add_curves(curves);
-    pb.add_vol_surfaces(volSurfaces);
-    auto pricing = pb.Finish();
+    auto pricing = buildPricing(b, asof, 0, 0, indices, 0, curves, 0, 0, volSurfaces);
 
     quantra::PeriodBuilder e1(b); e1.add_n(1); e1.add_unit(quantra::enums::TimeUnit_Months);
     auto e1Off = e1.Finish();
@@ -4239,12 +4116,7 @@ TEST_F(QuantraComparisonTest, SampleVolSurfaces_EquityBlackSurfaceCube) {
     auto indices = buildIndicesVector(b);
 
     auto asof = b.CreateString("2025-01-15");
-    quantra::PricingBuilder pb(b);
-    pb.add_as_of_date(asof);
-    pb.add_indices(indices);
-    pb.add_curves(curves);
-    pb.add_vol_surfaces(volSurfaces);
-    auto pricing = pb.Finish();
+    auto pricing = buildPricing(b, asof, 0, 0, indices, 0, curves, 0, 0, volSurfaces);
 
     quantra::PeriodBuilder e1(b); e1.add_n(6); e1.add_unit(quantra::enums::TimeUnit_Months);
     auto e1Off = e1.Finish();
@@ -4388,13 +4260,7 @@ TEST_F(QuantraComparisonTest, SampleVolSurfaces_EquityBlackSurfaceFromPricesMatc
     auto quotes = b.CreateVector(std::vector<flatbuffers::Offset<quantra::QuoteSpec>>{quote});
 
     auto asof = b.CreateString("2025-01-15");
-    quantra::PricingBuilder pb(b);
-    pb.add_as_of_date(asof);
-    pb.add_indices(indices);
-    pb.add_curves(curves);
-    pb.add_quotes(quotes);
-    pb.add_vol_surfaces(volSurfaces);
-    auto pricing = pb.Finish();
+    auto pricing = buildPricing(b, asof, 0, quotes, indices, 0, curves, 0, 0, volSurfaces);
 
     quantra::PeriodBuilder e1(b); e1.add_n(6); e1.add_unit(quantra::enums::TimeUnit_Months);
     auto e1Off = e1.Finish();
@@ -4509,12 +4375,7 @@ TEST_F(QuantraComparisonTest, SampleVolSurfaces_EquityBlackRejectsSmileSlice) {
     auto indices = buildIndicesVector(b);
 
     auto asof = b.CreateString("2025-01-15");
-    quantra::PricingBuilder pb(b);
-    pb.add_as_of_date(asof);
-    pb.add_indices(indices);
-    pb.add_curves(curves);
-    pb.add_vol_surfaces(volSurfaces);
-    auto pricing = pb.Finish();
+    auto pricing = buildPricing(b, asof, 0, 0, indices, 0, curves, 0, 0, volSurfaces);
 
     quantra::PeriodBuilder e1(b); e1.add_n(1); e1.add_unit(quantra::enums::TimeUnit_Years);
     auto expVec = b.CreateVector(std::vector<flatbuffers::Offset<quantra::Period>>{e1.Finish()});
@@ -4562,12 +4423,7 @@ TEST_F(QuantraComparisonTest, SampleVolSurfaces_EquityBlackRejectsSpreadFromAtmA
     auto indices = buildIndicesVector(b);
 
     auto asof = b.CreateString("2025-01-15");
-    quantra::PricingBuilder pb(b);
-    pb.add_as_of_date(asof);
-    pb.add_indices(indices);
-    pb.add_curves(curves);
-    pb.add_vol_surfaces(volSurfaces);
-    auto pricing = pb.Finish();
+    auto pricing = buildPricing(b, asof, 0, 0, indices, 0, curves, 0, 0, volSurfaces);
 
     quantra::PeriodBuilder e1(b); e1.add_n(1); e1.add_unit(quantra::enums::TimeUnit_Years);
     auto expVec = b.CreateVector(std::vector<flatbuffers::Offset<quantra::Period>>{e1.Finish()});
@@ -4615,13 +4471,7 @@ TEST_F(QuantraComparisonTest, SampleVolSurfaces_MaxPointsGuard) {
     auto swapIndices = buildSwapIndicesVector(b);
     auto asof = b.CreateString("2025-01-15");
 
-    quantra::PricingBuilder pb(b);
-    pb.add_as_of_date(asof);
-    pb.add_indices(indices);
-    pb.add_swap_indices(swapIndices);
-    pb.add_curves(curves);
-    pb.add_vol_surfaces(volSurfaces);
-    auto pricing = pb.Finish();
+    auto pricing = buildPricing(b, asof, 0, 0, indices, swapIndices, curves, 0, 0, volSurfaces);
 
     quantra::PeriodBuilder e1(b); e1.add_n(1); e1.add_unit(quantra::enums::TimeUnit_Years);
     auto e1Off = e1.Finish();
@@ -4693,13 +4543,7 @@ TEST_F(QuantraComparisonTest, SampleVolSurfaces_NoExtrapolationGuard) {
     auto indices = buildIndicesVector(b);
     auto swapIndices = buildSwapIndicesVector(b);
     auto asof = b.CreateString("2025-01-15");
-    quantra::PricingBuilder pb(b);
-    pb.add_as_of_date(asof);
-    pb.add_indices(indices);
-    pb.add_swap_indices(swapIndices);
-    pb.add_curves(curves);
-    pb.add_vol_surfaces(volSurfaces);
-    auto pricing = pb.Finish();
+    auto pricing = buildPricing(b, asof, 0, 0, indices, swapIndices, curves, 0, 0, volSurfaces);
 
     quantra::PeriodBuilder e5(b); e5.add_n(5); e5.add_unit(quantra::enums::TimeUnit_Years);
     auto expVec = b.CreateVector(std::vector<flatbuffers::Offset<quantra::Period>>{e5.Finish()});
@@ -4828,15 +4672,7 @@ TEST_F(QuantraComparisonTest, EquityOption_EuropeanVanilla_NPVMatches) {
         b.CreateVector(std::vector<flatbuffers::Offset<quantra::EquityUnderlyingSpec>>{und});
     auto indices = buildIndicesVector(b);
 
-    quantra::PricingBuilder prb(b);
-    prb.add_as_of_date(asof);
-    prb.add_indices(indices);
-    prb.add_curves(curves);
-    prb.add_quotes(quotes);
-    prb.add_vol_surfaces(vols);
-    prb.add_models(models);
-    prb.add_equity_underlyings(underlyings);
-    auto pricing = prb.Finish();
+    auto pricing = buildPricing(b, asof, 0, quotes, indices, 0, curves, 0, 0, vols, models, underlyings);
 
     quantra::EquityPlainVanillaPayoffBuilder pvb(b);
     pvb.add_option_type(quantra::enums::EquityOptionType_Call);
@@ -4950,15 +4786,7 @@ TEST_F(QuantraComparisonTest, EquityOption_BlackTermShapeMissingGridRejected) {
         b.CreateVector(std::vector<flatbuffers::Offset<quantra::EquityUnderlyingSpec>>{und});
     auto indices = buildIndicesVector(b);
 
-    quantra::PricingBuilder prb(b);
-    prb.add_as_of_date(asof);
-    prb.add_indices(indices);
-    prb.add_curves(curves);
-    prb.add_quotes(quotes);
-    prb.add_vol_surfaces(vols);
-    prb.add_models(models);
-    prb.add_equity_underlyings(underlyings);
-    auto pricing = prb.Finish();
+    auto pricing = buildPricing(b, asof, 0, quotes, indices, 0, curves, 0, 0, vols, models, underlyings);
 
     quantra::EquityPlainVanillaPayoffBuilder pvb(b);
     pvb.add_option_type(quantra::enums::EquityOptionType_Call);
@@ -5127,13 +4955,7 @@ TEST_F(QuantraComparisonTest, BootstrapInflationCurves_ZeroRate_TenorGridMatches
     auto inflationCurves =
         b.CreateVector(std::vector<flatbuffers::Offset<quantra::InflationCurveSpec>>{inflationCurve});
 
-    quantra::PricingBuilder prb(b);
-    prb.add_as_of_date(asof);
-    prb.add_indices(indices);
-    prb.add_curves(curves);
-    prb.add_inflation_indices(inflationIndices);
-    prb.add_inflation_curves(inflationCurves);
-    auto pricing = prb.Finish();
+    auto pricing = buildPricing(b, asof, 0, 0, indices, 0, curves, 0, 0, 0, 0, 0, inflationIndices, inflationCurves);
 
     // Query: tenor grid that matches curve conventions so sampling hits pillar nodes.
     auto t1 = buildPeriod(b, 1, quantra::enums::TimeUnit_Years);
@@ -5315,14 +5137,7 @@ TEST_F(QuantraComparisonTest, BootstrapInflationCurves_ZeroHelpersCanResolveQuot
     auto inflationCurves =
         b.CreateVector(std::vector<flatbuffers::Offset<quantra::InflationCurveSpec>>{inflationCurve});
 
-    quantra::PricingBuilder prb(b);
-    prb.add_as_of_date(asof);
-    prb.add_quotes(quotes);
-    prb.add_indices(indices);
-    prb.add_curves(curves);
-    prb.add_inflation_indices(inflationIndices);
-    prb.add_inflation_curves(inflationCurves);
-    auto pricing = prb.Finish();
+    auto pricing = buildPricing(b, asof, 0, quotes, indices, 0, curves, 0, 0, 0, 0, 0, inflationIndices, inflationCurves);
 
     auto tenors = b.CreateVector(std::vector<flatbuffers::Offset<quantra::Period>>{p1y, p2y});
     quantra::TenorGridBuilder tgb(b);
@@ -5462,13 +5277,7 @@ TEST_F(QuantraComparisonTest, BootstrapInflationCurves_YoYRate_TenorGridMatchesH
     auto inflationCurves =
         b.CreateVector(std::vector<flatbuffers::Offset<quantra::InflationCurveSpec>>{inflationCurve});
 
-    quantra::PricingBuilder prb(b);
-    prb.add_as_of_date(asof);
-    prb.add_indices(indices);
-    prb.add_curves(curves);
-    prb.add_inflation_indices(inflationIndices);
-    prb.add_inflation_curves(inflationCurves);
-    auto pricing = prb.Finish();
+    auto pricing = buildPricing(b, asof, 0, 0, indices, 0, curves, 0, 0, 0, 0, 0, inflationIndices, inflationCurves);
 
     auto tenors = b.CreateVector(std::vector<flatbuffers::Offset<quantra::Period>>{p1y, p2y});
     quantra::TenorGridBuilder tgb(b);
@@ -5578,13 +5387,7 @@ TEST_F(QuantraComparisonTest, BootstrapInflationCurves_MissingFixingsReturnsItem
     auto inflationCurves =
         b.CreateVector(std::vector<flatbuffers::Offset<quantra::InflationCurveSpec>>{inflationCurve});
 
-    quantra::PricingBuilder prb(b);
-    prb.add_as_of_date(asof);
-    prb.add_indices(indices);
-    prb.add_curves(curves);
-    prb.add_inflation_indices(inflationIndices);
-    prb.add_inflation_curves(inflationCurves);
-    auto pricing = prb.Finish();
+    auto pricing = buildPricing(b, asof, 0, 0, indices, 0, curves, 0, 0, 0, 0, 0, inflationIndices, inflationCurves);
 
     auto tenors = b.CreateVector(std::vector<flatbuffers::Offset<quantra::Period>>{p1y});
     quantra::TenorGridBuilder tgb(b);
@@ -5701,13 +5504,7 @@ TEST_F(QuantraComparisonTest, BootstrapInflationCurves_MissingNominalCurveReturn
     auto inflationCurves =
         b.CreateVector(std::vector<flatbuffers::Offset<quantra::InflationCurveSpec>>{inflationCurve});
 
-    quantra::PricingBuilder prb(b);
-    prb.add_as_of_date(asof);
-    prb.add_indices(indices);
-    prb.add_curves(curves);
-    prb.add_inflation_indices(inflationIndices);
-    prb.add_inflation_curves(inflationCurves);
-    auto pricing = prb.Finish();
+    auto pricing = buildPricing(b, asof, 0, 0, indices, 0, curves, 0, 0, 0, 0, 0, inflationIndices, inflationCurves);
 
     auto tenors = b.CreateVector(std::vector<flatbuffers::Offset<quantra::Period>>{p1y});
     quantra::TenorGridBuilder tgb(b);
@@ -5867,13 +5664,7 @@ TEST_F(QuantraComparisonTest, PriceZeroCouponInflationSwap_MatchesQuantLib) {
     auto inflationCurves =
         b.CreateVector(std::vector<flatbuffers::Offset<quantra::InflationCurveSpec>>{inflationCurve});
 
-    quantra::PricingBuilder prb(b);
-    prb.add_as_of_date(asof);
-    prb.add_indices(indices);
-    prb.add_curves(curves);
-    prb.add_inflation_indices(inflationIndices);
-    prb.add_inflation_curves(inflationCurves);
-    auto pricing = prb.Finish();
+    auto pricing = buildPricing(b, asof, 0, 0, indices, 0, curves, 0, 0, 0, 0, 0, inflationIndices, inflationCurves);
 
     auto startDate = b.CreateString("2025-01-15");
     auto maturityDate = b.CreateString("2030-01-15");
@@ -6057,13 +5848,7 @@ TEST_F(QuantraComparisonTest, PriceYearOnYearInflationSwap_MatchesQuantLib) {
     auto inflationCurves =
         b.CreateVector(std::vector<flatbuffers::Offset<quantra::InflationCurveSpec>>{inflationCurve});
 
-    quantra::PricingBuilder prb(b);
-    prb.add_as_of_date(asof);
-    prb.add_indices(indices);
-    prb.add_curves(curves);
-    prb.add_inflation_indices(inflationIndices);
-    prb.add_inflation_curves(inflationCurves);
-    auto pricing = prb.Finish();
+    auto pricing = buildPricing(b, asof, 0, 0, indices, 0, curves, 0, 0, 0, 0, 0, inflationIndices, inflationCurves);
 
     auto effective = b.CreateString("2025-01-15");
     auto termination = b.CreateString("2027-01-15");

--- a/tests/test_server_client.cpp
+++ b/tests/test_server_client.cpp
@@ -222,6 +222,58 @@ protected:
         defs.push_back(buildIndexDef_SOFR(b));
         return b.CreateVector(defs);
     }
+
+    flatbuffers::Offset<quantra::Pricing> buildPricing(
+        flatbuffers::grpc::MessageBuilder& b,
+        flatbuffers::Offset<flatbuffers::String> asOfDate,
+        flatbuffers::Offset<flatbuffers::String> settlementDate = 0,
+        flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<quantra::QuoteSpec>>> quotes = 0,
+        flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<quantra::IndexDef>>> indices = 0,
+        flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<quantra::SwapIndexDef>>> swapIndices = 0,
+        flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<quantra::TermStructure>>> curves = 0,
+        flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<quantra::CouponPricer>>> couponPricers = 0,
+        flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<quantra::CreditCurveSpec>>> creditCurves = 0,
+        flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<quantra::VolSurfaceSpec>>> volSurfaces = 0,
+        flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<quantra::ModelSpec>>> models = 0,
+        flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<quantra::EquityUnderlyingSpec>>> equityUnderlyings = 0,
+        flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<quantra::InflationIndexSpec>>> inflationIndices = 0,
+        flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<quantra::InflationCurveSpec>>> inflationCurves = 0,
+        bool bondPricingDetails = false,
+        bool bondPricingFlows = false,
+        bool swaptionPricingDetails = false,
+        bool swaptionPricingRebump = false) {
+        auto rates = (indices.o != 0 || swapIndices.o != 0 || curves.o != 0 || couponPricers.o != 0)
+            ? quantra::CreateRatesMarketData(b, indices, swapIndices, curves, couponPricers)
+            : 0;
+        auto credit = creditCurves.o != 0 ? quantra::CreateCreditMarketData(b, creditCurves) : 0;
+        auto volatility = (volSurfaces.o != 0 || models.o != 0)
+            ? quantra::CreateVolatilityMarketData(b, volSurfaces, models)
+            : 0;
+        auto equity = equityUnderlyings.o != 0 ? quantra::CreateEquityMarketData(b, equityUnderlyings) : 0;
+        auto inflation = (inflationIndices.o != 0 || inflationCurves.o != 0)
+            ? quantra::CreateInflationMarketData(b, inflationIndices, inflationCurves)
+            : 0;
+        auto options = (bondPricingDetails || bondPricingFlows || swaptionPricingDetails || swaptionPricingRebump)
+            ? quantra::CreatePricingOptions(
+                  b,
+                  bondPricingDetails,
+                  bondPricingFlows,
+                  swaptionPricingDetails,
+                  swaptionPricingRebump)
+            : 0;
+
+        return quantra::CreatePricing(
+            b,
+            asOfDate,
+            settlementDate,
+            quotes,
+            rates,
+            credit,
+            volatility,
+            equity,
+            inflation,
+            options);
+    }
     
     flatbuffers::Offset<quantra::Yield> buildYield(flatbuffers::grpc::MessageBuilder& b) {
         quantra::YieldBuilder yb(b);
@@ -249,11 +301,7 @@ TEST_F(ServerClientTest, FixedRateBond_RoundTrip) {
     auto curves = b.CreateVector(std::vector<flatbuffers::Offset<quantra::TermStructure>>{ts});
     auto indices = buildIndicesVector(b);
     auto asof = b.CreateString("2025-01-15");
-    quantra::PricingBuilder pb(b);
-    pb.add_as_of_date(asof); pb.add_settlement_date(asof);
-    pb.add_indices(indices);
-    pb.add_curves(curves); pb.add_bond_pricing_details(true);
-    auto pricing = pb.Finish();
+    auto pricing = buildPricing(b, asof, asof, 0, indices, 0, curves, 0, 0, 0, 0, 0, 0, 0, true);
     
     auto eff = b.CreateString("2024-01-15");
     auto term = b.CreateString("2029-01-15");
@@ -347,13 +395,7 @@ TEST_F(ServerClientTest, VanillaSwap_RoundTrip) {
     msb.add_payload(cds_payload.Union());
     auto models = b.CreateVector(std::vector<flatbuffers::Offset<quantra::ModelSpec>>{msb.Finish()});
 
-    quantra::PricingBuilder pb(b);
-    pb.add_as_of_date(asof); pb.add_settlement_date(asof);
-    pb.add_indices(indices2);
-    pb.add_curves(curves);
-    pb.add_credit_curves(credit_curves);
-    pb.add_models(models);
-    auto pricing = pb.Finish();
+    auto pricing = buildPricing(b, asof, asof, 0, indices2, 0, curves, 0, credit_curves, 0, models);
     
     auto feff = b.CreateString("2025-01-17"); auto fterm = b.CreateString("2030-01-17");
     quantra::ScheduleBuilder fsb(b);
@@ -426,12 +468,7 @@ TEST_F(ServerClientTest, OisSwap_RoundTrip) {
     auto indices = buildIndicesVector(b);
     auto asof = b.CreateString("2025-01-15");
 
-    quantra::PricingBuilder pb(b);
-    pb.add_as_of_date(asof);
-    pb.add_settlement_date(asof);
-    pb.add_indices(indices);
-    pb.add_curves(curves);
-    auto pricing = pb.Finish();
+    auto pricing = buildPricing(b, asof, asof, 0, indices, 0, curves);
 
     auto eff = b.CreateString("2025-01-17");
     auto term = b.CreateString("2030-01-17");
@@ -517,12 +554,7 @@ TEST_F(ServerClientTest, BasisSwap_RoundTrip) {
     auto indices = buildIndicesVector(b);
     auto asof = b.CreateString("2025-01-15");
 
-    quantra::PricingBuilder pb(b);
-    pb.add_as_of_date(asof);
-    pb.add_settlement_date(asof);
-    pb.add_indices(indices);
-    pb.add_curves(curves);
-    auto pricing = pb.Finish();
+    auto pricing = buildPricing(b, asof, asof, 0, indices, 0, curves);
 
     auto eff = b.CreateString("2025-01-17");
     auto term = b.CreateString("2030-01-17");
@@ -648,13 +680,7 @@ TEST_F(ServerClientTest, CDS_RoundTrip) {
     msb.add_payload(cds_payload.Union());
     auto models = b.CreateVector(std::vector<flatbuffers::Offset<quantra::ModelSpec>>{msb.Finish()});
 
-    quantra::PricingBuilder pb(b);
-    pb.add_as_of_date(asof); pb.add_settlement_date(asof);
-    pb.add_indices(indices3);
-    pb.add_curves(curves);
-    pb.add_credit_curves(credit_curves);
-    pb.add_models(models);
-    auto pricing = pb.Finish();
+    auto pricing = buildPricing(b, asof, asof, 0, indices3, 0, curves, 0, credit_curves, 0, models);
     
     auto eff = b.CreateString("2025-01-15"); auto term = b.CreateString("2030-01-15");
     quantra::ScheduleBuilder sb(b);
@@ -805,13 +831,7 @@ TEST_F(ServerClientTest, BootstrapInflationCurves_RoundTrip) {
     auto inflationCurves =
         b.CreateVector(std::vector<flatbuffers::Offset<quantra::InflationCurveSpec>>{inflationCurve});
 
-    quantra::PricingBuilder pb(b);
-    pb.add_as_of_date(asof);
-    pb.add_indices(indices);
-    pb.add_curves(curves);
-    pb.add_inflation_indices(inflationIndices);
-    pb.add_inflation_curves(inflationCurves);
-    auto pricing = pb.Finish();
+    auto pricing = buildPricing(b, asof, 0, 0, indices, 0, curves, 0, 0, 0, 0, 0, inflationIndices, inflationCurves);
 
     auto tenors = b.CreateVector(std::vector<flatbuffers::Offset<quantra::Period>>{p1y, p2y});
     quantra::TenorGridBuilder tgb(b);
@@ -983,13 +1003,7 @@ TEST_F(ServerClientTest, PriceZeroCouponInflationSwap_RoundTrip) {
     auto inflationCurves =
         b.CreateVector(std::vector<flatbuffers::Offset<quantra::InflationCurveSpec>>{inflationCurve});
 
-    quantra::PricingBuilder pb(b);
-    pb.add_as_of_date(asof);
-    pb.add_indices(indices);
-    pb.add_curves(curves);
-    pb.add_inflation_indices(inflationIndices);
-    pb.add_inflation_curves(inflationCurves);
-    auto pricing = pb.Finish();
+    auto pricing = buildPricing(b, asof, 0, 0, indices, 0, curves, 0, 0, 0, 0, 0, inflationIndices, inflationCurves);
 
     auto startDate = b.CreateString("2025-01-15");
     auto maturityDate = b.CreateString("2030-01-15");
@@ -1138,13 +1152,7 @@ TEST_F(ServerClientTest, PriceYearOnYearInflationSwap_RoundTrip) {
     auto inflationCurves =
         b.CreateVector(std::vector<flatbuffers::Offset<quantra::InflationCurveSpec>>{inflationCurve});
 
-    quantra::PricingBuilder pb(b);
-    pb.add_as_of_date(asof);
-    pb.add_indices(indices);
-    pb.add_curves(curves);
-    pb.add_inflation_indices(inflationIndices);
-    pb.add_inflation_curves(inflationCurves);
-    auto pricing = pb.Finish();
+    auto pricing = buildPricing(b, asof, 0, 0, indices, 0, curves, 0, 0, 0, 0, 0, inflationIndices, inflationCurves);
 
     auto effective = b.CreateString("2025-01-15");
     auto termination = b.CreateString("2027-01-15");
@@ -1406,11 +1414,7 @@ TEST_F(ServerClientTest, Latency_MultipleRequests) {
         auto curves = b.CreateVector(std::vector<flatbuffers::Offset<quantra::TermStructure>>{ts});
         auto lat_indices = buildIndicesVector(b);
         auto asof = b.CreateString("2025-01-15");
-        quantra::PricingBuilder pb(b);
-        pb.add_as_of_date(asof); pb.add_settlement_date(asof);
-        pb.add_indices(lat_indices);
-        pb.add_curves(curves);
-        auto pricing = pb.Finish();
+        auto pricing = buildPricing(b, asof, asof, 0, lat_indices, 0, curves);
         
         auto eff = b.CreateString("2024-01-15"); auto term = b.CreateString("2029-01-15");
         quantra::ScheduleBuilder sb(b);


### PR DESCRIPTION
Make the canonical build script regenerate schemas from scratch and migrate tests to the nested Pricing structure so regenerated FlatBuffers code compiles and passes consistently everywhere.

Made-with: Cursor

## What changed
- 

## Why
- 

## Tests
- [ ] CI passed
- [ ] Relevant local tests run (`tests/run_all_tests.sh` or subset)

## API/Contract impact
- [ ] No API change
- [ ] Backward-compatible API change
- [ ] Breaking API change (major version required)

## Docs
- [ ] Not needed
- [ ] Updated (`README`, `docs/VERSIONING.md`, etc.)
