### PR TITLE
Fix GitHub Buildx cache setup

### DIFF
--- a/.github/workflows/build-ci-base-image.yml
+++ b/.github/workflows/build-ci-base-image.yml
@@ -32,6 +32,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push dev-stage image
         uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
## What changed
- 

## Why
- 

## Tests
- [ ] CI passed
- [ ] Relevant local tests run (`tests/run_all_tests.sh` or subset)

## API/Contract impact
- [ ] No API change
- [ ] Backward-compatible API change
- [ ] Breaking API change (major version required)

## Docs
- [ ] Not needed
- [ ] Updated (`README`, `docs/VERSIONING.md`, etc.)
