### PR TITLE
Fix release container binary path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -225,7 +225,8 @@ COPY --from=builder /opt/quantra-deps/lib /opt/quantra-deps/lib
 COPY --from=builder /etc/ld.so.conf.d/quantra-deps.conf /etc/ld.so.conf.d/
 RUN ldconfig
 
-COPY --from=builder /src/build/server/sync_server /app/sync_server
+RUN mkdir -p /app/build/server
+COPY --from=builder /src/build/server/sync_server /app/build/server/sync_server
 
 # Install quantra process manager with dependencies
 COPY tools/quantra-manager/requirements.txt /tmp/quantra-requirements.txt


### PR DESCRIPTION
## What changed
- 

## Why
- 

## Tests
- [ ] CI passed
- [ ] Relevant local tests run (`tests/run_all_tests.sh` or subset)

## API/Contract impact
- [ ] No API change
- [ ] Backward-compatible API change
- [ ] Breaking API change (major version required)

## Docs
- [ ] Not needed
- [ ] Updated (`README`, `docs/versioning.md`, etc.)
