### PR TITLE
Propagate real error text over gRPC + tag logs with request id

### DIFF
--- a/src/transport/call_data_base.h
+++ b/src/transport/call_data_base.h
@@ -2,8 +2,10 @@
 #define QUANTRASERVER_CALL_DATA_BASE_H
 
 #include <grpcpp/grpcpp.h>
+#include <cstddef>
 #include <exception>
 #include <iostream>
+#include <map>
 #include <memory>
 #include <string>
 #include <typeinfo>
@@ -17,6 +19,38 @@
 
 // Use quantra namespace for QuantraServer
 using quantra::QuantraServer;
+
+namespace quantra { namespace transport {
+
+// gRPC trailers (which carry the status message) are size-capped well below this;
+// keep the real cause text but never blow the trailer budget.
+constexpr std::size_t kMaxStatusMessageLen = 4096;
+
+// Build the gRPC status message from an exception's text: carry the REAL cause to
+// the caller, capping over-long text so the underlying reason still survives.
+inline std::string ErrorStatusMessage(const char *what)
+{
+    std::string msg = (what != nullptr) ? what : "";
+    if (msg.size() > kMaxStatusMessageLen)
+    {
+        msg.resize(kMaxStatusMessageLen);
+        msg += " ...[truncated]";
+    }
+    return msg;
+}
+
+// Extract the caller's request id from inbound gRPC metadata for log tagging.
+// Returns "-" when `x-request-id` is absent so logs grep uniformly.
+inline std::string RequestId(
+    const std::multimap<grpc::string_ref, grpc::string_ref> &metadata)
+{
+    auto it = metadata.find(grpc::string_ref("x-request-id"));
+    if (it != metadata.end())
+        return std::string(it->second.data(), it->second.size());
+    return "-";
+}
+
+}} // namespace quantra::transport
 
 /**
  * CallData - Base class for all async handlers.
@@ -60,7 +94,10 @@ public:
                 return;
             }
 
-            std::shared_ptr<flatbuffers::grpc::MessageBuilder> builder = 
+            const std::string request_id =
+                quantra::transport::RequestId(ctx_.client_metadata());
+
+            std::shared_ptr<flatbuffers::grpc::MessageBuilder> builder =
                 std::make_shared<flatbuffers::grpc::MessageBuilder>();
             try
             {
@@ -72,6 +109,7 @@ public:
                               << " type=" << typeid(Message).name()
                               << " peer=" << ctx_.peer()
                               << " bytes=" << request_msg.size()
+                              << " request_id=" << request_id
                               << std::endl;
                     status_ = FINISH;
                     responder_.FinishWithError(
@@ -92,6 +130,7 @@ public:
                               << " response_type=" << typeid(Response).name()
                               << " peer=" << ctx_.peer()
                               << " bytes=" << reply_.size()
+                              << " request_id=" << request_id
                               << std::endl;
                     status_ = FINISH;
                     responder_.FinishWithError(
@@ -109,9 +148,10 @@ public:
                           << " type=" << typeid(Message).name()
                           << " peer=" << ctx_.peer()
                           << " error=" << e.what()
+                          << " request_id=" << request_id
                           << std::endl;
                 status_ = FINISH;
-                auto status = grpc::Status(grpc::StatusCode::ABORTED, "QuantLib error");
+                auto status = grpc::Status(grpc::StatusCode::ABORTED, quantra::transport::ErrorStatusMessage(e.what()));
                 responder_.FinishWithError(status, this);
             }
             catch (QuantraNotFound &e)
@@ -120,6 +160,7 @@ public:
                           << " type=" << typeid(Message).name()
                           << " peer=" << ctx_.peer()
                           << " error=" << e.what()
+                          << " request_id=" << request_id
                           << std::endl;
                 status_ = FINISH;
                 auto status = grpc::Status(grpc::StatusCode::NOT_FOUND, e.what());
@@ -131,6 +172,7 @@ public:
                           << " type=" << typeid(Message).name()
                           << " peer=" << ctx_.peer()
                           << " error=" << e.what()
+                          << " request_id=" << request_id
                           << std::endl;
                 status_ = FINISH;
                 auto status = grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, e.what());
@@ -142,6 +184,7 @@ public:
                           << " type=" << typeid(Message).name()
                           << " peer=" << ctx_.peer()
                           << " error=" << e.what()
+                          << " request_id=" << request_id
                           << std::endl;
                 status_ = FINISH;
                 auto status = grpc::Status(grpc::StatusCode::UNIMPLEMENTED, e.what());
@@ -153,9 +196,10 @@ public:
                           << " type=" << typeid(Message).name()
                           << " peer=" << ctx_.peer()
                           << " error=" << e.what()
+                          << " request_id=" << request_id
                           << std::endl;
                 status_ = FINISH;
-                auto status = grpc::Status(grpc::StatusCode::ABORTED, "Quantra error");
+                auto status = grpc::Status(grpc::StatusCode::ABORTED, quantra::transport::ErrorStatusMessage(e.what()));
                 responder_.FinishWithError(status, this);
             }
             catch (std::exception &e)
@@ -164,9 +208,10 @@ public:
                           << " type=" << typeid(Message).name()
                           << " peer=" << ctx_.peer()
                           << " error=" << e.what()
+                          << " request_id=" << request_id
                           << std::endl;
                 status_ = FINISH;
-                auto status = grpc::Status(grpc::StatusCode::ABORTED, "Unknown error");
+                auto status = grpc::Status(grpc::StatusCode::ABORTED, quantra::transport::ErrorStatusMessage(e.what()));
                 responder_.FinishWithError(status, this);
             }
             catch (...)
@@ -174,6 +219,7 @@ public:
                 std::cerr << "[grpc] non-std exception while handling request"
                           << " type=" << typeid(Message).name()
                           << " peer=" << ctx_.peer()
+                          << " request_id=" << request_id
                           << std::endl;
                 status_ = FINISH;
                 auto status = grpc::Status(grpc::StatusCode::ABORTED, "Unknown error");

--- a/tests/integration/test_server_client.cpp
+++ b/tests/integration/test_server_client.cpp
@@ -13,6 +13,7 @@
 
 #include "quantraserver.grpc.fb.h"
 #include "quantraserver_generated.h"
+#include "call_data_base.h"
 #include "price_fixed_rate_bond_request_generated.h"
 #include "price_vanilla_swap_request_generated.h"
 #include "price_zero_coupon_inflation_swap_request_generated.h"
@@ -1467,3 +1468,32 @@ TEST_F(ServerClientTest, Latency_MultipleRequests) {
 }
 
 }} // namespace
+
+TEST(CallDataHelpers, RequestIdDefaultsToDashWhenAbsent) {
+    std::multimap<grpc::string_ref, grpc::string_ref> md;
+    EXPECT_EQ(quantra::transport::RequestId(md), "-");
+}
+
+TEST(CallDataHelpers, RequestIdExtractsHeader) {
+    std::multimap<grpc::string_ref, grpc::string_ref> md;
+    md.emplace(grpc::string_ref("x-request-id"), grpc::string_ref("req-abc-123"));
+    EXPECT_EQ(quantra::transport::RequestId(md), "req-abc-123");
+}
+
+TEST(CallDataHelpers, ErrorStatusMessageCarriesRealCause) {
+    const char *cause = "negative time (-0.5) given";
+    EXPECT_EQ(quantra::transport::ErrorStatusMessage(cause), std::string(cause));
+    EXPECT_NE(quantra::transport::ErrorStatusMessage(cause), std::string("QuantLib error"));
+}
+
+TEST(CallDataHelpers, ErrorStatusMessageHandlesNull) {
+    EXPECT_EQ(quantra::transport::ErrorStatusMessage(nullptr), std::string(""));
+}
+
+TEST(CallDataHelpers, ErrorStatusMessageCapsLongTextButKeepsCause) {
+    std::string big(quantra::transport::kMaxStatusMessageLen + 100, 'x');
+    std::string out = quantra::transport::ErrorStatusMessage(big.c_str());
+    // capped to budget (+ small truncation marker), and the real cause text survives at the front
+    EXPECT_LE(out.size(), quantra::transport::kMaxStatusMessageLen + 32);
+    EXPECT_EQ(out.compare(0, 10, std::string(10, 'x')), 0);
+}


### PR DESCRIPTION
Backlog **P2 (a)** — engine error-message propagation.

## Problem
`CallDataGeneric::Proceed` caught pricing exceptions, logged the real `e.what()` to stderr, but returned a CONSTANT gRPC status message — so callers only ever saw "QuantLib error" / "Quantra error" / "Unknown error", never the actual cause (e.g. "negative time … reference date February 9th, 2026").

## Change (only `src/transport/call_data_base.h`)
- The three ABORTED branches (`QuantLib::Error`, `QuantraError`, `std::exception`) now put the real `e.what()` into the gRPC status **message**. **Codes unchanged.** New inline helper `ErrorStatusMessage()` caps over-long text (4096) but keeps the cause. The not-found / invalid-argument / not-implemented branches already carried `e.what()` and are **untouched**.
- Read `x-request-id` from inbound gRPC metadata (`RequestId()`, returns `-` when absent) and tag **every** server log line with `request_id=<id>` for cross-service tracing.

## Tests
5 `CallDataHelpers` unit tests added to `tests/integration/test_server_client.cpp` (cause passthrough, cap-keeps-cause, null, request-id extraction + `-` default).

## Validation
Full gate run in the `quantraserver:test` Docker image: **7/7 PASS, 321 cases** (Suite 2: 13→18).

Scope: only `call_data_base.h` + the integration test. No schema/proto/build/other-transport changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
