### PR TITLE
Fix crash and CPU exhaustion from malformed pricing requests

### DIFF
--- a/src/mappers/bootstrap_curves_mapper.cpp
+++ b/src/mappers/bootstrap_curves_mapper.cpp
@@ -85,6 +85,10 @@ std::vector<QuantLib::Date> extractPillarDates(
             QuantLib::Date startDate = calendar.advance(referenceDate, startPeriod);
             maturityDate = calendar.advance(startDate, tenor);
         } else if (auto future = point->point_as_FutureHelper()) {
+            if (!future->future_start_date()) {
+                QUANTRA_INVALID_ARGUMENT(
+                    "FutureHelper.future_start_date is required");
+            }
             QuantLib::Date startDate = DateToQL(future->future_start_date()->str());
             maturityDate = calendar.advance(
                 startDate, QuantLib::Period(future->future_months(), QuantLib::Months));

--- a/src/parsers/schedule_parser.cpp
+++ b/src/parsers/schedule_parser.cpp
@@ -2,15 +2,70 @@
 
 #include "error.h"
 
+namespace {
+
+// Cap on the implied number of schedule periods (span / period length).
+// Without it a tiny request (e.g. 1901->2199 Daily, ~108k dates) pins the
+// single-threaded worker for the full gRPC deadline. Kept consistent with
+// the range-grid cap in grid_utils (BuildRangeGrid default maxPoints=50000);
+// comfortably above any legitimate instrument (50y weekly ~ 2600 periods).
+constexpr long kMaxSchedulePeriods = 50000;
+
+// Conservative (lower-bound) days per period so the estimate never
+// over-rejects: Months uses 28, Years uses 365.
+long approxDaysPerPeriod(const QuantLib::Period &period)
+{
+    switch (period.units())
+    {
+    case QuantLib::Days:
+        return period.length();
+    case QuantLib::Weeks:
+        return 7L * period.length();
+    case QuantLib::Months:
+        return 28L * period.length();
+    case QuantLib::Years:
+        return 365L * period.length();
+    default:
+        return 0; // unknown unit: skip the cap, let QuantLib validate
+    }
+}
+
+} // namespace
+
 std::shared_ptr<QuantLib::Schedule> ScheduleParser::parse(const quantra::Schedule *schedule)
 {
     if (schedule == NULL)
         QUANTRA_INVALID_ARGUMENT("Schedule not found");
+    if (!schedule->effective_date())
+        QUANTRA_INVALID_ARGUMENT("Schedule.effective_date is required");
+    if (!schedule->termination_date())
+        QUANTRA_INVALID_ARGUMENT("Schedule.termination_date is required");
+
+    const QuantLib::Date effective = DateToQL(schedule->effective_date()->str());
+    const QuantLib::Date termination = DateToQL(schedule->termination_date()->str());
+    const QuantLib::Period period =
+        FrequencyToPeriod(FrequencyToQL(schedule->frequency()));
+
+    const long spanDays = termination - effective;
+    const long periodDays = approxDaysPerPeriod(period);
+    if (periodDays > 0 && spanDays > 0)
+    {
+        const long impliedPeriods = spanDays / periodDays;
+        if (impliedPeriods > kMaxSchedulePeriods)
+        {
+            QUANTRA_INVALID_ARGUMENT(
+                "Schedule too large: " + std::to_string(impliedPeriods) +
+                " implied periods between " + schedule->effective_date()->str() +
+                " and " + schedule->termination_date()->str() +
+                " at the requested frequency (limit " +
+                std::to_string(kMaxSchedulePeriods) + ")");
+        }
+    }
 
     return std::make_shared<QuantLib::Schedule>(
-        DateToQL(schedule->effective_date()->str()),
-        DateToQL(schedule->termination_date()->str()),
-        FrequencyToPeriod(FrequencyToQL(schedule->frequency())),
+        effective,
+        termination,
+        period,
         CalendarToQL(schedule->calendar()),
         ConventionToQL(schedule->convention()),
         ConventionToQL(schedule->termination_date_convention()),

--- a/src/parsers/term_structure_point_parser.cpp
+++ b/src/parsers/term_structure_point_parser.cpp
@@ -125,6 +125,10 @@ std::shared_ptr<RateHelper> TermStructurePointParser::parse(
 
         auto q = resolveQuote(rateValue, point->quote_id(), quotes, quantra::QuoteType_Curve, bump);
 
+        if (!point->future_start_date()) {
+            QUANTRA_INVALID_ARGUMENT("FutureHelper.future_start_date is required");
+        }
+
         return std::make_shared<FuturesRateHelper>(
             q,
             DateToQL(point->future_start_date()->str()),
@@ -232,6 +236,10 @@ std::shared_ptr<RateHelper> TermStructurePointParser::parse(
         }
 
         auto q = resolveQuote(px, point->quote_id(), quotes, quantra::QuoteType_Curve, bump);
+
+        if (!point->issue_date()) {
+            QUANTRA_INVALID_ARGUMENT("BondHelper.issue_date is required");
+        }
 
         return std::make_shared<FixedRateBondHelper>(
             q,

--- a/tests/contract/error_contract_test.py
+++ b/tests/contract/error_contract_test.py
@@ -99,6 +99,54 @@ def _ec_flip_model_type(new_type):
     return f
 
 
+def _ec_del_curve_point_field(point_type, field):
+    """Drop `field` from the first curve helper of `point_type` (A5 repro).
+
+    Pre-fix these requests SIGSEGV'd the worker (null flatbuffers::String
+    deref); post-fix they must return a clean INVALID_ARGUMENT and leave the
+    server alive for the rest of the suite.
+    """
+    def f(req):
+        for curve in req["pricing"]["rates"]["curves"]:
+            for p in curve.get("points", []):
+                if p.get("point_type") == point_type:
+                    p["point"].pop(field, None)
+                    return req
+        raise AssertionError(f"no {point_type} point found in request")
+    return f
+
+
+def _ec_future_helper_missing_start_date():
+    """Replace the first curve point with a FutureHelper that omits
+    future_start_date (optional in the schema, deref'd by the parser). A5."""
+    def f(req):
+        req["pricing"]["rates"]["curves"][0]["points"][0] = {
+            "point_type": "FutureHelper",
+            "point": {
+                "rate": 0.02,
+                "future_months": 3,
+                "calendar": "TARGET",
+                "business_day_convention": "ModifiedFollowing",
+                "day_counter": "Actual360",
+            },
+        }
+        return req
+    return f
+
+
+def _ec_abusive_schedule(arr_key, product_key):
+    """Stretch the product schedule to ~300 years Daily (F1 repro: ~108k
+    implied periods). Must be rejected fast with INVALID_ARGUMENT instead of
+    pinning the worker for the full gRPC deadline."""
+    def f(req):
+        sch = req[arr_key][0][product_key]["schedule"]
+        sch["effective_date"] = "1901/01/02"
+        sch["termination_date"] = "2199/12/30"
+        sch["frequency"] = "Daily"
+        return req
+    return f
+
+
 def _ec_unimplemented_curve_point():
     # Replace the first curve's first point with a schema-ready-but-unbuilt
     # helper (FxSwapHelper). The point parses into a valid FlatBuffer, then the
@@ -148,6 +196,15 @@ SCENARIOS = [
      "swaption_request.json", 400, _ec_del_field("swaptions", "model")),
     ("ec:400 fixed_rate_bond missing discounting_curve field", "fixed_rate_bond",
      "fixed_rate_bond_request.json", 400, _ec_del_field("bonds", "discounting_curve")),
+    # ---- 400 INVALID_ARGUMENT: A5 null-deref guards (optional date fields
+    #      omitted on curve helpers; pre-guard these crashed the worker) ----
+    ("ec:400 fixed_rate_bond curve BondHelper missing issue_date", "fixed_rate_bond",
+     "fixed_rate_bond_request.json", 400, _ec_del_curve_point_field("BondHelper", "issue_date")),
+    ("ec:400 fixed_rate_bond curve FutureHelper missing future_start_date", "fixed_rate_bond",
+     "fixed_rate_bond_request.json", 400, _ec_future_helper_missing_start_date()),
+    # ---- 400 INVALID_ARGUMENT: F1 unbounded schedule generation guard ----
+    ("ec:400 fixed_rate_bond 300y daily schedule rejected", "fixed_rate_bond",
+     "fixed_rate_bond_request.json", 400, _ec_abusive_schedule("bonds", "fixed_rate_bond")),
     # ---- 501 UNIMPLEMENTED: valid request, feature not built yet ----
     ("ec:501 swaption curve uses unimplemented helper", "swaption",
      "swaption_request.json", 501, _ec_unimplemented_curve_point()),
@@ -164,6 +221,14 @@ SCENARIOS = [
      "sample_vol_surfaces_request.json", 200,
      _ec_set_field("queries", "vol_id", "no_such_vol_surface_xyz"),
      _ec_body_has_per_item_error("vol_id", "no_such_vol_surface_xyz")),
+    # ---- bootstrap-curves A5 guard: the curve build and the mapper's
+    #      pillar-date extraction both deref FutureHelper.future_start_date;
+    #      pre-guard this request SIGSEGV'd the worker. Post-guard it must be
+    #      a clean INVALID_ARGUMENT (curve-parse guard fires at the transport
+    #      level before the per-query error fold). ----
+    ("ec:400 bootstrap_curves FutureHelper missing future_start_date",
+     "bootstrap_curves", "bootstrap_curves_tenor_grid.json", 400,
+     _ec_future_helper_missing_start_date()),
 ]
 
 


### PR DESCRIPTION
Two input-validation guards that stop a single malformed request from taking down or pinning a worker.

- **Crash fix:** several optional date fields (`FutureHelper.future_start_date`, `BondHelper.issue_date`, `Schedule.effective_date`/`termination_date`) were dereferenced without a presence check, so a well-formed request that omitted one **segfaulted the worker**. They are now null-checked and return `INVALID_ARGUMENT`.
- **DoS fix:** schedule generation had no bound on span/frequency, so a tiny request (e.g. a ~300-year daily schedule) pinned the single-threaded worker for the full request deadline. `ScheduleParser` now caps the implied number of periods (50000) and returns `INVALID_ARGUMENT`.

+4 error-contract scenarios. Full test suite green in Docker (325 cases). No schema/wire change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)