### PR TITLE
Make the yield-curve cache exact for all curve types, then enable it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -268,6 +268,13 @@ ENV QUANTRA_STATE_DIR=/app/.quantra
 ENV QUANTRA_ENVOY_ADMIN=http://127.0.0.1:9901
 ENV QUANTRA_FBS_DIR=/app/flatbuffers/fbs
 ENV QUANTRA_FBS_INCLUDE_DIR=/app/flatbuffers/fbs
+# Enable the pricing-engine result caches in the shipped image (audit G1).
+# Safe now the freeze paths are value-exact for every curve type (B1-B3, B7):
+# a cache hit is byte-identical to a miss, so identical requests skip
+# re-bootstrapping. Production stage ONLY — the test gate runs in the deps/dev
+# image and starts its own cache-OFF/cache-ON server pairs explicitly.
+ENV QUANTRA_CURVE_CACHE_ENABLED=1
+ENV QUANTRA_SABR_CACHE_ENABLED=1
 
 EXPOSE 50051 8080
 

--- a/examples/data/fixed_rate_bond_zerorate_request.json
+++ b/examples/data/fixed_rate_bond_zerorate_request.json
@@ -1,0 +1,188 @@
+{
+  "pricing": {
+    "as_of_date": "2024-08-14",
+    "settlement_date": "2024-08-16",
+    "rates": {
+      "curves": [
+        {
+          "id": "usd_zero_curve",
+          "day_counter": "Actual365Fixed",
+          "interpolator": "Linear",
+          "reference_date": "2024-08-14",
+          "bootstrap_trait": "Discount",
+          "points": [
+            {
+              "point_type": "ZeroRatePoint",
+              "point": {
+                "zero_rate": 0.0452,
+                "calendar": "UnitedStatesGovernmentBond",
+                "business_day_convention": "Following",
+                "compounding": "Continuous",
+                "frequency": "Annual",
+                "date": "2024-08-14"
+              }
+            },
+            {
+              "point_type": "ZeroRatePoint",
+              "point": {
+                "zero_rate": 0.0450,
+                "calendar": "UnitedStatesGovernmentBond",
+                "business_day_convention": "Following",
+                "compounding": "Continuous",
+                "frequency": "Annual",
+                "tenor": {
+                  "n": 6,
+                  "unit": "Months"
+                }
+              }
+            },
+            {
+              "point_type": "ZeroRatePoint",
+              "point": {
+                "zero_rate": 0.0438,
+                "calendar": "UnitedStatesGovernmentBond",
+                "business_day_convention": "Following",
+                "compounding": "Continuous",
+                "frequency": "Annual",
+                "tenor": {
+                  "n": 1,
+                  "unit": "Years"
+                }
+              }
+            },
+            {
+              "point_type": "ZeroRatePoint",
+              "point": {
+                "zero_rate": 0.0412,
+                "calendar": "UnitedStatesGovernmentBond",
+                "business_day_convention": "Following",
+                "compounding": "Continuous",
+                "frequency": "Annual",
+                "tenor": {
+                  "n": 2,
+                  "unit": "Years"
+                }
+              }
+            },
+            {
+              "point_type": "ZeroRatePoint",
+              "point": {
+                "zero_rate": 0.0398,
+                "calendar": "UnitedStatesGovernmentBond",
+                "business_day_convention": "Following",
+                "compounding": "Continuous",
+                "frequency": "Annual",
+                "tenor": {
+                  "n": 3,
+                  "unit": "Years"
+                }
+              }
+            },
+            {
+              "point_type": "ZeroRatePoint",
+              "point": {
+                "zero_rate": 0.0391,
+                "calendar": "UnitedStatesGovernmentBond",
+                "business_day_convention": "Following",
+                "compounding": "Continuous",
+                "frequency": "Annual",
+                "tenor": {
+                  "n": 5,
+                  "unit": "Years"
+                }
+              }
+            },
+            {
+              "point_type": "ZeroRatePoint",
+              "point": {
+                "zero_rate": 0.0396,
+                "calendar": "UnitedStatesGovernmentBond",
+                "business_day_convention": "Following",
+                "compounding": "Continuous",
+                "frequency": "Annual",
+                "tenor": {
+                  "n": 7,
+                  "unit": "Years"
+                }
+              }
+            },
+            {
+              "point_type": "ZeroRatePoint",
+              "point": {
+                "zero_rate": 0.0405,
+                "calendar": "UnitedStatesGovernmentBond",
+                "business_day_convention": "Following",
+                "compounding": "Continuous",
+                "frequency": "Annual",
+                "tenor": {
+                  "n": 10,
+                  "unit": "Years"
+                }
+              }
+            },
+            {
+              "point_type": "ZeroRatePoint",
+              "point": {
+                "zero_rate": 0.0421,
+                "calendar": "UnitedStatesGovernmentBond",
+                "business_day_convention": "Following",
+                "compounding": "Continuous",
+                "frequency": "Annual",
+                "tenor": {
+                  "n": 15,
+                  "unit": "Years"
+                }
+              }
+            },
+            {
+              "point_type": "ZeroRatePoint",
+              "point": {
+                "zero_rate": 0.0429,
+                "calendar": "UnitedStatesGovernmentBond",
+                "business_day_convention": "Following",
+                "compounding": "Continuous",
+                "frequency": "Annual",
+                "tenor": {
+                  "n": 20,
+                  "unit": "Years"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "options": {
+      "bond_pricing_details": true,
+      "bond_pricing_flows": true
+    }
+  },
+  "bonds": [
+    {
+      "fixed_rate_bond": {
+        "settlement_days": 2,
+        "face_amount": 100,
+        "rate": 0.0425,
+        "accrual_day_counter": "ActualActualBond",
+        "payment_convention": "ModifiedFollowing",
+        "redemption": 100,
+        "issue_date": "2020/02/15",
+        "schedule": {
+          "calendar": "UnitedStatesGovernmentBond",
+          "effective_date": "2020/02/15",
+          "termination_date": "2035/02/15",
+          "frequency": "Semiannual",
+          "convention": "Unadjusted",
+          "termination_date_convention": "Unadjusted",
+          "date_generation_rule": "Backward"
+        }
+      },
+      "discounting_curve": "usd_zero_curve",
+      "yield": {
+        "day_counter": "Actual360",
+        "compounding": "Compounded",
+        "frequency": "Annual"
+      }
+    }
+  ]
+}

--- a/src/market/curve_bootstrapper.cpp
+++ b/src/market/curve_bootstrapper.cpp
@@ -351,34 +351,50 @@ BootstrappedCurves CurveBootstrapper::bootstrapAll(
 
             cache.stats().bootstraps++;
 
-            // Serialize once; reused for both the L2 store and (for Discount
-            // curves) the frozen L1 reconstruction below.
-            auto serialized = CurveSerializer::serialize(curve, ts);
+            // Freeze/serialize ONLY when the serializer can extract the
+            // curve's actual bootstrap pillars (a PiecewiseYieldCurve built by
+            // TermStructureParser). Otherwise — e.g. a ZeroRatePoint curve,
+            // which is an InterpolatedZeroCurve — serialize() would fall back
+            // to weekly resampling, and an L1/L2 hit would serve an
+            // approximation of the user's nodes instead of the real curve
+            // (audit B7). Such curves cache the LIVE curve (value-exact, same
+            // as the non-Discount-trait branch) and skip the L2 store.
+            bool exactPillars = CurveSerializer::canSerializeExactly(curve, ts);
 
-            // Cache a frozen, dependency-free curve in L1 for subsequent hits.
-            // A live PiecewiseYieldCurve observes its helpers, which observe the
-            // discount-curve handle; relinking that handle on a later request
-            // (even to identical data) marks the cached curve dirty and forces a
-            // full re-bootstrap on next use. The reconstructed
-            // InterpolatedDiscountCurve holds only pillar dates and discount
-            // factors — it observes nothing, so it never re-bootstraps.
-            // Only Discount-trait curves reconstruct bit-exactly; other traits
-            // fall back to caching the live curve (today's behavior).
             std::shared_ptr<QuantLib::YieldTermStructure> toCacheL1 = curve;
-            if (ts->bootstrap_trait() == quantra::enums::BootstrapTrait_Discount) {
-                try {
-                    toCacheL1 = CurveSerializer::reconstruct(serialized);
-                } catch (const std::exception&) {
-                    // reconstruct() fails closed on data it cannot rebuild
-                    // exactly; cache the live curve instead (pre-freeze
-                    // behavior) rather than failing the request.
-                    toCacheL1 = curve;
+            if (exactPillars) {
+                // Serialize once; reused for both the L2 store and (for
+                // Discount curves) the frozen L1 reconstruction below.
+                auto serialized = CurveSerializer::serialize(curve, ts);
+
+                // Cache a frozen, dependency-free curve in L1 for subsequent
+                // hits. A live PiecewiseYieldCurve observes its helpers, which
+                // observe the discount-curve handle; relinking that handle on
+                // a later request (even to identical data) marks the cached
+                // curve dirty and forces a full re-bootstrap on next use. The
+                // reconstructed InterpolatedDiscountCurve holds only pillar
+                // dates and discount factors — it observes nothing, so it
+                // never re-bootstraps.
+                // Only Discount-trait curves reconstruct bit-exactly; other
+                // traits fall back to caching the live curve (today's
+                // behavior).
+                if (ts->bootstrap_trait() == quantra::enums::BootstrapTrait_Discount) {
+                    try {
+                        toCacheL1 = CurveSerializer::reconstruct(serialized);
+                    } catch (const std::exception&) {
+                        // reconstruct() fails closed on data it cannot rebuild
+                        // exactly; cache the live curve instead (pre-freeze
+                        // behavior) rather than failing the request.
+                        toCacheL1 = curve;
+                    }
                 }
+
+                // Store in L2 (serialized DFs — for future Redis). Gated on
+                // exactPillars for the same reason as the freeze: resampled
+                // data must never be reconstructed and served on an L2 hit.
+                cache.backend().putL2(key, serialized);
             }
             cache.backend().putL1(key, toCacheL1);
-
-            // Store in L2 (serialized DFs — for future Redis)
-            cache.backend().putL2(key, serialized);
 
             cache.logEvent(id, key, "MISS_BOOTSTRAP", bootMs);
 

--- a/src/market/curve_serializer.h
+++ b/src/market/curve_serializer.h
@@ -36,12 +36,34 @@ class CurveSerializer {
 public:
 
     /**
+     * True iff serialize() can extract the curve's ACTUAL bootstrap pillars,
+     * i.e. the curve is a PiecewiseYieldCurve matching the TermStructure's
+     * (trait, interpolator) so reconstruct(serialize(...)) reproduces it
+     * value-exactly at and between pillars.
+     *
+     * Curves built any other way — e.g. a ZeroRatePoint curve, which is an
+     * InterpolatedZeroCurve — would be WEEKLY-RESAMPLED by serialize()'s
+     * fallback, an approximation that must never be served on a cache hit
+     * (audit B7). Callers must check this before caching serialized/frozen
+     * data; when false, cache the live curve instead.
+     */
+    static bool canSerializeExactly(
+        const std::shared_ptr<QuantLib::YieldTermStructure>& curve,
+        const quantra::TermStructure* ts)
+    {
+        std::vector<QuantLib::Date> pillars;
+        return tryExtractPillars(curve, ts, pillars);
+    }
+
+    /**
      * Extract pillar dates + DFs from a bootstrapped curve.
      *
      * Attempts to extract actual pillar nodes from PiecewiseYieldCurve by
      * trying all supported (Trait, Interpolator) combinations. Falls back to
-     * dense sampling only if downcast fails (shouldn't happen for curves
-     * built by TermStructureParser).
+     * dense weekly sampling if the downcast fails — an APPROXIMATION of the
+     * live curve. Callers that cache the result must gate on
+     * canSerializeExactly() first so the fallback is never served on a
+     * cache hit (audit B7).
      */
     static CachedCurveData serialize(
         const std::shared_ptr<QuantLib::YieldTermStructure>& curve,

--- a/tests/caching/cache_correctness_test.py
+++ b/tests/caching/cache_correctness_test.py
@@ -59,11 +59,24 @@ CASES = [
          "cds_request.json", "cds_list"),
     Case("bootstrap_curves_forward", "bootstrap_curves",
          "bootstrap_curves_forward.json", None),
+    # ZeroRatePoint discount curve (audit B7): built as an InterpolatedZeroCurve,
+    # NOT a PiecewiseYieldCurve, so the freeze path cannot extract exact pillars.
+    # A cache hit must serve the LIVE curve — never a weekly-resampled
+    # reconstruction — or the bond's semiannual coupons (which fall between the
+    # user's zero nodes and off the weekly resample grid) drift on a hit.
+    Case("fixed_rate_bond_zerorate", "fixed_rate_bond",
+         "fixed_rate_bond_zerorate_request.json", "bonds"),
 ]
 
 # The product whose log we probe to prove the cache engaged. Any cacheable row
 # works; the fixed-rate bond bootstraps a single deposit/bond curve.
 ENGAGED_CASE = CASES[0]
+
+# The B7 zero-curve row + the curve id its payload bootstraps, probed separately
+# in test_cache_engaged_zero_curve so the transparency assertion above cannot
+# pass trivially with the zero curve unkeyable/uncached.
+ZERO_CURVE_CASE = next(c for c in CASES if c.id == "fixed_rate_bond_zerorate")
+ZERO_CURVE_ID = "usd_zero_curve"
 
 
 def _canonical(response: dict) -> str:
@@ -190,3 +203,42 @@ def test_cache_engaged(cache_client, data_dir, cache_log_path):
         f"the cache-ON gRPC server?"
     )
     print(f"[cache] cache engaged — CurveCache hit logged: {_last_hit_line(cache_log_path)}")
+
+
+def _count_zero_curve_hits(log_path: Path) -> int:
+    if not log_path.exists():
+        return 0
+    return sum(
+        1
+        for line in log_path.read_text(errors="replace").splitlines()
+        if "event=L1_HIT" in line and f"curve={ZERO_CURVE_ID} " in line
+    )
+
+
+def test_cache_engaged_zero_curve(cache_client, data_dir, cache_log_path):
+    """B7 companion to the fixed_rate_bond_zerorate transparency row: prove the
+    ZeroRatePoint (InterpolatedZeroCurve) curve itself actually hits the cache —
+    an L1_HIT line naming its curve id must be logged. Guards against the
+    transparency assertions passing trivially because the zero curve became
+    unkeyable/uncached (e.g. KEY_BUILD_FAILED_UNCACHED)."""
+    request = load_json(data_dir / ZERO_CURVE_CASE.filename)
+
+    before = _count_zero_curve_hits(cache_log_path)
+    cache_client.price(ZERO_CURVE_CASE.product, request)   # warm (may miss)
+    cache_client.price(ZERO_CURVE_CASE.product, request)   # hit
+
+    after = before
+    for _ in range(20):
+        after = _count_zero_curve_hits(cache_log_path)
+        if after > before:
+            break
+        time.sleep(0.1)
+
+    assert after > before, (
+        f"No CurveCache L1 hit for curve={ZERO_CURVE_ID} logged in "
+        f"{cache_log_path} (hits before={before}, after={after}); the "
+        f"ZeroRatePoint curve did not engage the cache, so the B7 "
+        f"transparency case proves nothing."
+    )
+    print(f"[cache] zero curve engaged — L1 hits for {ZERO_CURVE_ID}: "
+          f"{before} -> {after}")


### PR DESCRIPTION
The yield-curve result cache could return slightly wrong prices for some curve types, and it was never actually switched on in the shipped image. This fixes the first and enables the cache.

- **Correctness:** the cache "freeze" step only reproduces `PiecewiseYieldCurve` pillars exactly. For other curves (e.g. a zero-rate `InterpolatedZeroCurve`) it fell back to weekly resampling, so a cache hit could differ from a fresh computation. The freeze/store path is now gated on a new `canSerializeExactly()` check; curves it cannot reproduce exactly cache the live curve instead (value-identical).
- **Enablement:** nothing set the cache env vars, so every request re-bootstrapped despite the fix. Both caches are now enabled in the Dockerfile production stage (the test gate is unaffected — it runs in the dev image and starts its own cache-on/off servers).

New cache-transparency test for a zero-rate curve (hit == miss, byte-identical); confirmed failing before the fix, passing after. Full suite green in Docker (322 cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)