### PR TITLE
Reject unsupported enum values instead of silently mispricing

### DIFF
--- a/src/common/enum_convert.cpp
+++ b/src/common/enum_convert.cpp
@@ -163,7 +163,9 @@ QuantLib::DayCounter DayCounterToQL(const quantra::enums::DayCounter dayCounter)
     case quantra::enums::DayCounter_Actual365Fixed:
         return QuantLib::Actual365Fixed();
     case quantra::enums::DayCounter_Actual365NoLeap:
-        return QuantLib::Actual365Fixed();
+        // must use the NoLeap convention — plain Actual365Fixed
+        // counts Feb 29 and yields wrong year-fractions across leap days.
+        return QuantLib::Actual365Fixed(QuantLib::Actual365Fixed::NoLeap);
     case quantra::enums::DayCounter_ActualActual:
         return QuantLib::ActualActual(QuantLib::ActualActual::ISDA);
     case quantra::enums::DayCounter_ActualActualISMA:

--- a/src/evaluators/cds_evaluator.cpp
+++ b/src/evaluators/cds_evaluator.cpp
@@ -1,5 +1,6 @@
 #include "cds_evaluator.h"
 
+#include <string>
 #include <variant>
 
 #include <ql/handle.hpp>
@@ -20,6 +21,20 @@
 namespace quantra {
 
 namespace {
+
+/// Human-readable name for a credit-curve interpolator enum value; used in
+/// fail-closed error messages. Out-of-range values (the raw wire
+/// cast in pricing_registry.cpp) fall through to the numeric form.
+std::string creditCurveInterpolatorName(CreditCurveInterpolatorKind kind) {
+    switch (kind) {
+        case CreditCurveInterpolatorKind::BackwardFlat: return "BackwardFlat";
+        case CreditCurveInterpolatorKind::ForwardFlat: return "ForwardFlat";
+        case CreditCurveInterpolatorKind::Linear: return "Linear";
+        case CreditCurveInterpolatorKind::LogCubic: return "LogCubic";
+        case CreditCurveInterpolatorKind::LogLinear: return "LogLinear";
+    }
+    return "enum value " + std::to_string(static_cast<int>(kind));
+}
 
 /**
  * Bootstrap the default-probability term structure from a plain-domain
@@ -138,23 +153,30 @@ std::shared_ptr<QuantLib::DefaultProbabilityTermStructure> buildCreditCurve(
         }
     }
 
+    // Fail closed on the interpolator. QuantLib's default-
+    // probability bootstrap only supports flat-forward interpolation, i.e.
+    // LogLinear on survival probabilities. Every other enum value used to
+    // either masquerade as LogLinear silently (ForwardFlat/LogCubic hit the
+    // old `default:` branch) or die inside the bootstrap with an opaque
+    // QuantLib error (Linear/BackwardFlat). All of them — and any
+    // out-of-range value from the raw wire cast — are now rejected with a
+    // clear INVALID_ARGUMENT.
     switch (curve.curve_interpolator) {
-        case CreditCurveInterpolatorKind::Linear:
-            return std::make_shared<
-                QuantLib::PiecewiseDefaultCurve<QuantLib::SurvivalProbability, QuantLib::Linear>>(
-                curve.reference_date, helpers, curve.day_counter);
-        case CreditCurveInterpolatorKind::BackwardFlat:
-            return std::make_shared<
-                QuantLib::PiecewiseDefaultCurve<QuantLib::SurvivalProbability,
-                                                QuantLib::BackwardFlat>>(
-                curve.reference_date, helpers, curve.day_counter);
         case CreditCurveInterpolatorKind::LogLinear:
-        default:
             return std::make_shared<
                 QuantLib::PiecewiseDefaultCurve<QuantLib::SurvivalProbability,
                                                 QuantLib::LogLinear>>(
                 curve.reference_date, helpers, curve.day_counter);
+        case CreditCurveInterpolatorKind::BackwardFlat:
+        case CreditCurveInterpolatorKind::ForwardFlat:
+        case CreditCurveInterpolatorKind::Linear:
+        case CreditCurveInterpolatorKind::LogCubic:
+            break;
     }
+    throw QuantraInvalidArgument(
+        "Unsupported credit curve interpolator: " +
+        creditCurveInterpolatorName(curve.curve_interpolator) +
+        "; the CDS credit-curve bootstrap supports LogLinear only");
 }
 
 /**
@@ -229,12 +251,16 @@ std::shared_ptr<QuantLib::PricingEngine> buildEngine(
                 fwd);
         }
         case CdsEngineTypeKind::MidPoint:
-        default:
             return std::make_shared<QuantLib::MidPointCdsEngine>(
                 creditHandle,
                 recoveryRate,
                 discountHandle);
     }
+    // Fail closed: an out-of-range engine enum from the raw wire
+    // cast must not silently price with the MidPoint engine.
+    throw QuantraInvalidArgument(
+        "Unsupported CDS engine type: enum value " +
+        std::to_string(static_cast<int>(model.engine_type)));
 }
 
 CdsPerTrade priceTrade(const CdsTrade& trade,

--- a/src/evaluators/swaption_evaluator.cpp
+++ b/src/evaluators/swaption_evaluator.cpp
@@ -165,7 +165,9 @@ std::shared_ptr<QuantLib::Swaption> buildSwaptionInstrument(
             settlementType = QuantLib::Settlement::Cash;
             break;
         default:
-            settlementType = QuantLib::Settlement::Physical;
+            // Fail closed: an unknown settlement type must not
+            // silently price as Physical (mirrors the exercise-type switch).
+            QUANTRA_INVALID_ARGUMENT("Invalid settlement type");
     }
 
     return std::make_shared<QuantLib::Swaption>(

--- a/tests/contract/error_contract_test.py
+++ b/tests/contract/error_contract_test.py
@@ -100,7 +100,7 @@ def _ec_flip_model_type(new_type):
 
 
 def _ec_del_curve_point_field(point_type, field):
-    """Drop `field` from the first curve helper of `point_type` (A5 repro).
+    """Drop `field` from the first curve helper of `point_type`.
 
     Pre-fix these requests SIGSEGV'd the worker (null flatbuffers::String
     deref); post-fix they must return a clean INVALID_ARGUMENT and leave the
@@ -118,7 +118,7 @@ def _ec_del_curve_point_field(point_type, field):
 
 def _ec_future_helper_missing_start_date():
     """Replace the first curve point with a FutureHelper that omits
-    future_start_date (optional in the schema, deref'd by the parser). A5."""
+    future_start_date (optional in the schema, deref'd by the parser)."""
     def f(req):
         req["pricing"]["rates"]["curves"][0]["points"][0] = {
             "point_type": "FutureHelper",
@@ -135,7 +135,7 @@ def _ec_future_helper_missing_start_date():
 
 
 def _ec_abusive_schedule(arr_key, product_key):
-    """Stretch the product schedule to ~300 years Daily (F1 repro: ~108k
+    """Stretch the product schedule to ~300 years Daily (~108k
     implied periods). Must be rejected fast with INVALID_ARGUMENT instead of
     pinning the worker for the full gRPC deadline."""
     def f(req):
@@ -145,6 +145,40 @@ def _ec_abusive_schedule(arr_key, product_key):
         sch["frequency"] = "Daily"
         return req
     return f
+def _ec_set_credit_curve_field(field, value):
+    def f(req):
+        req["pricing"]["credit"]["credit_curves"][0][field] = value
+        return req
+    return f
+
+
+def _ec_set_model_payload_field(field, value):
+    def f(req):
+        for m in req["pricing"].get("volatility", {}).get("models", []):
+            m["payload"][field] = value
+        return req
+    return f
+
+
+def _ec_set_nested_field(arr_key, obj_key, field, value):
+    def f(req):
+        req[arr_key][0][obj_key][field] = value
+        return req
+    return f
+
+
+def _ec_body_contains(substr):
+    """Body validator: the (error) response body must carry substr somewhere.
+
+    Backend errors surface the real exception text in the JSON envelope's
+    `message` field; a plain substring check on the raw body asserts the
+    fail-closed throw was actually reached (not e.g. a parse-layer 400).
+    """
+    def check(body_text):
+        if substr in body_text:
+            return None
+        return f"expected body to contain {substr!r}, got: {body_text[:200]}"
+    return check
 
 
 def _ec_unimplemented_curve_point():
@@ -196,15 +230,40 @@ SCENARIOS = [
      "swaption_request.json", 400, _ec_del_field("swaptions", "model")),
     ("ec:400 fixed_rate_bond missing discounting_curve field", "fixed_rate_bond",
      "fixed_rate_bond_request.json", 400, _ec_del_field("bonds", "discounting_curve")),
-    # ---- 400 INVALID_ARGUMENT: A5 null-deref guards (optional date fields
+    # ---- 400 INVALID_ARGUMENT: null-deref guards (optional date fields
     #      omitted on curve helpers; pre-guard these crashed the worker) ----
     ("ec:400 fixed_rate_bond curve BondHelper missing issue_date", "fixed_rate_bond",
      "fixed_rate_bond_request.json", 400, _ec_del_curve_point_field("BondHelper", "issue_date")),
     ("ec:400 fixed_rate_bond curve FutureHelper missing future_start_date", "fixed_rate_bond",
      "fixed_rate_bond_request.json", 400, _ec_future_helper_missing_start_date()),
-    # ---- 400 INVALID_ARGUMENT: F1 unbounded schedule generation guard ----
+    # ---- 400 INVALID_ARGUMENT: unbounded schedule generation guard ----
     ("ec:400 fixed_rate_bond 300y daily schedule rejected", "fixed_rate_bond",
      "fixed_rate_bond_request.json", 400, _ec_abusive_schedule("bonds", "fixed_rate_bond")),
+    # ---- 400 INVALID_ARGUMENT: fail-closed enum handling ----
+    # The CDS credit-curve bootstrap supports LogLinear only; ForwardFlat
+    # and LogCubic used to be silently priced as LogLinear. The complex request
+    # is used because it carries real par-spread quotes (the simple request
+    # takes the flat-hazard branch and never reaches the interpolator switch).
+    ("ec:400 cds credit interpolator ForwardFlat rejected", "cds",
+     "cds_complex_request.json", 400,
+     _ec_set_credit_curve_field("curve_interpolator", "ForwardFlat"),
+     _ec_body_contains("Unsupported credit curve interpolator")),
+    ("ec:400 cds credit interpolator LogCubic rejected", "cds",
+     "cds_complex_request.json", 400,
+     _ec_set_credit_curve_field("curve_interpolator", "LogCubic"),
+     _ec_body_contains("Unsupported credit curve interpolator")),
+    # An out-of-range CDS engine enum (raw integers are accepted by the
+    # FlatBuffers JSON parser) used to silently price with the MidPoint engine.
+    ("ec:400 cds engine type out of range", "cds",
+     "cds_request.json", 400,
+     _ec_set_model_payload_field("engine_type", 99),
+     _ec_body_contains("Unsupported CDS engine type")),
+    # An out-of-range swaption settlement type used to fail open to
+    # Physical settlement.
+    ("ec:400 swaption settlement type out of range", "swaption",
+     "swaption_request.json", 400,
+     _ec_set_nested_field("swaptions", "swaption", "settlement_type", 99),
+     _ec_body_contains("Invalid settlement type")),
     # ---- 501 UNIMPLEMENTED: valid request, feature not built yet ----
     ("ec:501 swaption curve uses unimplemented helper", "swaption",
      "swaption_request.json", 501, _ec_unimplemented_curve_point()),

--- a/tests/parity/enum_convert_daycounter_test.cpp
+++ b/tests/parity/enum_convert_daycounter_test.cpp
@@ -1,0 +1,48 @@
+// Day-counter enum-conversion regression tests.
+//
+// DayCounter_Actual365NoLeap used to be silently mapped to plain
+// Actual365Fixed, which counts Feb 29 and therefore produces wrong
+// year-fractions for accrual periods spanning a leap day. It must map to
+// QuantLib's Actual365Fixed(NoLeap) convention instead. Built into the single
+// test_quantra_vs_quantlib parity binary (Suite 1).
+#include <gtest/gtest.h>
+
+#include <ql/time/date.hpp>
+#include <ql/time/daycounters/actual365fixed.hpp>
+
+#include "enum_convert.h"
+
+TEST(EnumConvertDayCounter, Actual365NoLeapMapsToNoLeapConvention) {
+    // A period spanning 2024-02-29: 366 actual days, 365 NoLeap days.
+    const QuantLib::Date start(1, QuantLib::January, 2024);
+    const QuantLib::Date end(1, QuantLib::January, 2025);
+
+    const QuantLib::DayCounter mapped =
+        DayCounterToQL(quantra::enums::DayCounter_Actual365NoLeap);
+    const QuantLib::DayCounter noLeap =
+        QuantLib::Actual365Fixed(QuantLib::Actual365Fixed::NoLeap);
+    const QuantLib::DayCounter plain = QuantLib::Actual365Fixed();
+
+    EXPECT_EQ(mapped.name(), noLeap.name());
+    EXPECT_EQ(mapped.dayCount(start, end), noLeap.dayCount(start, end));
+    EXPECT_DOUBLE_EQ(mapped.yearFraction(start, end),
+                     noLeap.yearFraction(start, end));
+
+    // The NoLeap convention drops Feb 29: exactly 365/365 = 1.0, while plain
+    // Actual365Fixed yields 366/365. The old fail-open mapping returned the
+    // plain value.
+    EXPECT_DOUBLE_EQ(mapped.yearFraction(start, end), 1.0);
+    EXPECT_NE(mapped.yearFraction(start, end), plain.yearFraction(start, end));
+}
+
+TEST(EnumConvertDayCounter, Actual365FixedStillPlain) {
+    // Guard the sibling mapping: DayCounter_Actual365Fixed must stay on the
+    // standard convention (366/365 across a leap day).
+    const QuantLib::Date start(1, QuantLib::January, 2024);
+    const QuantLib::Date end(1, QuantLib::January, 2025);
+
+    const QuantLib::DayCounter mapped =
+        DayCounterToQL(quantra::enums::DayCounter_Actual365Fixed);
+    EXPECT_EQ(mapped.name(), QuantLib::Actual365Fixed().name());
+    EXPECT_DOUBLE_EQ(mapped.yearFraction(start, end), 366.0 / 365.0);
+}


### PR DESCRIPTION
Four cases where an unsupported enum value was silently mapped to an arbitrary default and returned a number instead of an error.

- **CDS credit-curve interpolator:** `ForwardFlat`/`LogCubic` were silently priced as `LogLinear`. Only `LogLinear` is supported by the credit bootstrap; every other value now returns `INVALID_ARGUMENT` with a clear message.
- **CDS engine type:** an unknown value silently selected `MidPoint` — now rejected.
- **Swaption settlement type:** an unknown value silently selected `Physical` — now rejected (matching the exercise-type handling beside it).
- **Day counter `Actual365NoLeap`:** was mapped to plain `Actual365Fixed`, giving wrong year-fractions across Feb 29 — now uses the no-leap convention.

+6 tests (day-counter parity and error-contract). Full suite green in Docker (327 cases). No schema/wire change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)