### PR TITLE
Improve HTTP error responses and request-id propagation at the gateway

### DIFF
--- a/client/cpp/include/quantra_client.h
+++ b/client/cpp/include/quantra_client.h
@@ -126,26 +126,26 @@ public:
     // JSON API - Easy to use, works with any language via HTTP
     // -------------------------------------------------------------------------
     
-    JsonResponse PriceFixedRateBondJSON(const std::string& json);
-    JsonResponse PriceFloatingRateBondJSON(const std::string& json);
-    JsonResponse PriceVanillaSwapJSON(const std::string& json);
-    JsonResponse PriceZeroCouponInflationSwapJSON(const std::string& json);
-    JsonResponse PriceYearOnYearInflationSwapJSON(const std::string& json);
-    JsonResponse PriceOisSwapJSON(const std::string& json);
-    JsonResponse PriceBasisSwapJSON(const std::string& json);
-    JsonResponse PriceFRAJSON(const std::string& json);
-    JsonResponse PriceCapFloorJSON(const std::string& json);
-    JsonResponse PriceSwaptionJSON(const std::string& json);
-    JsonResponse PriceCDSJSON(const std::string& json);
-    JsonResponse BootstrapCurvesJSON(const std::string& json);
-    JsonResponse BootstrapInflationCurvesJSON(const std::string& json);
-    JsonResponse SampleVolSurfacesJSON(const std::string& json);
-    JsonResponse CalendarBusinessDaysJSON(const std::string& json);
-    JsonResponse CalendarHolidaysJSON(const std::string& json);
-    JsonResponse CalendarAdvanceJSON(const std::string& json);
-    JsonResponse CalibrateSwaptionModelJSON(const std::string& json);
-    JsonResponse CalibrateSwaptionVolJSON(const std::string& json);
-    JsonResponse PriceEquityOptionJSON(const std::string& json);
+    JsonResponse PriceFixedRateBondJSON(const std::string& json, const std::string& request_id = "");
+    JsonResponse PriceFloatingRateBondJSON(const std::string& json, const std::string& request_id = "");
+    JsonResponse PriceVanillaSwapJSON(const std::string& json, const std::string& request_id = "");
+    JsonResponse PriceZeroCouponInflationSwapJSON(const std::string& json, const std::string& request_id = "");
+    JsonResponse PriceYearOnYearInflationSwapJSON(const std::string& json, const std::string& request_id = "");
+    JsonResponse PriceOisSwapJSON(const std::string& json, const std::string& request_id = "");
+    JsonResponse PriceBasisSwapJSON(const std::string& json, const std::string& request_id = "");
+    JsonResponse PriceFRAJSON(const std::string& json, const std::string& request_id = "");
+    JsonResponse PriceCapFloorJSON(const std::string& json, const std::string& request_id = "");
+    JsonResponse PriceSwaptionJSON(const std::string& json, const std::string& request_id = "");
+    JsonResponse PriceCDSJSON(const std::string& json, const std::string& request_id = "");
+    JsonResponse BootstrapCurvesJSON(const std::string& json, const std::string& request_id = "");
+    JsonResponse BootstrapInflationCurvesJSON(const std::string& json, const std::string& request_id = "");
+    JsonResponse SampleVolSurfacesJSON(const std::string& json, const std::string& request_id = "");
+    JsonResponse CalendarBusinessDaysJSON(const std::string& json, const std::string& request_id = "");
+    JsonResponse CalendarHolidaysJSON(const std::string& json, const std::string& request_id = "");
+    JsonResponse CalendarAdvanceJSON(const std::string& json, const std::string& request_id = "");
+    JsonResponse CalibrateSwaptionModelJSON(const std::string& json, const std::string& request_id = "");
+    JsonResponse CalibrateSwaptionVolJSON(const std::string& json, const std::string& request_id = "");
+    JsonResponse PriceEquityOptionJSON(const std::string& json, const std::string& request_id = "");
     
     // -------------------------------------------------------------------------
     // Native FlatBuffers API - Maximum performance

--- a/client/cpp/src/json_parser.cpp
+++ b/client/cpp/src/json_parser.cpp
@@ -54,8 +54,20 @@ public:
         ProductType type,
         const std::string& json
     ) {
+        // The body is handed to the flatc parser as a C string below, so an
+        // embedded NUL would silently truncate the request. Reject
+        // it explicitly instead.
+        if (json.find('\0') != std::string::npos) {
+            throw JsonParseException(
+                "request body contains a NUL byte (bodies must be NUL-free JSON text)");
+        }
+
         auto& parser = EnsureThreadParsers().request_parsers.at(type);
 
+        // TODO: flatc's parser error text for malformed JSON can be
+        // misleading ("unknown field ...", spurious "required" complaints,
+        // "input file is empty" for wrong-shape bodies). The wording comes from
+        // the vendored FlatBuffers parser internals — out of scope to fix here.
         if (!parser->Parse(json.c_str(), include_dirs_)) {
             throw JsonParseException("JSON parse error for " +
                 std::string(ProductTypeToString(type)) + ": " + parser->error_);

--- a/client/cpp/src/quantra_client.cpp
+++ b/client/cpp/src/quantra_client.cpp
@@ -6,6 +6,8 @@
 #include "quantra_client.h"
 #include "product_catalog.h"
 
+#include <algorithm>
+#include <cctype>
 #include <stdexcept>
 #include <iostream>
 #include <string_view>
@@ -47,14 +49,37 @@ std::string JsonEscape(std::string_view input) {
     return out;
 }
 
-int GrpcToHttpStatus(grpc::StatusCode code) {
-    switch (code) {
+bool ContainsCaseInsensitive(const std::string& haystack, std::string_view needle) {
+    auto to_lower = [](unsigned char c) { return static_cast<char>(std::tolower(c)); };
+    std::string h(haystack.size(), '\0');
+    std::transform(haystack.begin(), haystack.end(), h.begin(), to_lower);
+    std::string n(needle.size(), '\0');
+    std::transform(needle.begin(), needle.end(), n.begin(), to_lower);
+    return h.find(n) != std::string::npos;
+}
+
+int GrpcToHttpStatus(const grpc::Status& status) {
+    switch (status.error_code()) {
         case grpc::StatusCode::INVALID_ARGUMENT: return 400;
         case grpc::StatusCode::UNAUTHENTICATED: return 401;
         case grpc::StatusCode::PERMISSION_DENIED: return 403;
         case grpc::StatusCode::NOT_FOUND: return 404;
         case grpc::StatusCode::ALREADY_EXISTS: return 409;
-        case grpc::StatusCode::RESOURCE_EXHAUSTED: return 429;
+        case grpc::StatusCode::RESOURCE_EXHAUSTED:
+            // The only known RESOURCE_EXHAUSTED source is gRPC's message-size
+            // cap ("Received message larger than max ..."), which is a
+            // payload-size problem, not a rate-limit -> 413. Anything else
+            // keeps the historical 429.
+            if (ContainsCaseInsensitive(status.error_message(), "larger than max") ||
+                ContainsCaseInsensitive(status.error_message(), "message too large")) {
+                return 413;
+            }
+            return 429;
+        // ABORTED carries QuantLib/engine exceptions raised by well-formed but
+        // unpriceable client inputs (bad dates, degenerate schedules, ...).
+        // Those are client-data faults, not server faults -> 422
+        // Unprocessable Entity instead of the old default 500.
+        case grpc::StatusCode::ABORTED: return 422;
         case grpc::StatusCode::UNIMPLEMENTED: return 501;
         case grpc::StatusCode::UNAVAILABLE: return 503;
         case grpc::StatusCode::DEADLINE_EXCEEDED: return 504;
@@ -110,11 +135,16 @@ JsonResponse JsonResponse::GrpcError(const grpc::Status& status) {
     if (details.empty()) {
         details = status.error_message();
     }
+    // The documented `error` field carries the REAL cause (same text as
+    // `message`), not the old useless constant "gRPC error".
+    // `code`, `code_name` and `message` are kept for backward compatibility.
+    std::string error_text = details.empty() ? "gRPC error" : details;
     std::string code_name = codeName(status.error_code());
-    oss << R"({"error": "gRPC error", "code": )" << status.error_code()
+    oss << R"({"error": ")" << JsonEscape(error_text)
+        << R"(", "code": )" << status.error_code()
         << R"(, "code_name": ")" << JsonEscape(code_name)
         << R"(", "message": ")" << JsonEscape(details) << R"("})";
-    return {false, GrpcToHttpStatus(status.error_code()), oss.str()};
+    return {false, GrpcToHttpStatus(status), oss.str()};
 }
 
 // =============================================================================
@@ -140,7 +170,9 @@ public:
     }
     JsonParser& GetParser() { return *json_parser_; }
 
-    // Generic JSON call handler
+    // Generic JSON call handler. `request_id` (already sanitized by the HTTP
+    // layer) is forwarded to the backend as `x-request-id` gRPC metadata so
+    // engine log lines correlate with the caller's id.
     template<typename Request, typename Response>
     JsonResponse CallJSON(
         ProductType type,
@@ -149,7 +181,8 @@ public:
             grpc::ClientContext*,
             const flatbuffers::grpc::Message<Request>&,
             flatbuffers::grpc::Message<Response>*
-        )
+        ),
+        const std::string& request_id = ""
     ) {
         try {
             auto builder = json_parser_->ParseRequest(type, json);
@@ -159,6 +192,9 @@ public:
             }
             grpc::ClientContext context;
             SetDefaultDeadline(context);
+            if (!request_id.empty()) {
+                context.AddMetadata("x-request-id", request_id);
+            }
             flatbuffers::grpc::Message<Response> response;
             
             grpc::Status status = (stub_.get()->*rpc)(&context, request, &response);
@@ -258,123 +294,123 @@ bool QuantraClient::WaitForChannelReady(std::chrono::milliseconds timeout) const
 // JSON API Implementation
 // =============================================================================
 
-JsonResponse QuantraClient::PriceFixedRateBondJSON(const std::string& json) {
+JsonResponse QuantraClient::PriceFixedRateBondJSON(const std::string& json, const std::string& request_id) {
     return impl_->CallJSON<PriceFixedRateBondRequest, PriceFixedRateBondResponse>(
-        ProductType::FixedRateBond, json, &QuantraServer::Stub::PriceFixedRateBond
+        ProductType::FixedRateBond, json, &QuantraServer::Stub::PriceFixedRateBond, request_id
     );
 }
 
-JsonResponse QuantraClient::PriceFloatingRateBondJSON(const std::string& json) {
+JsonResponse QuantraClient::PriceFloatingRateBondJSON(const std::string& json, const std::string& request_id) {
     return impl_->CallJSON<PriceFloatingRateBondRequest, PriceFloatingRateBondResponse>(
-        ProductType::FloatingRateBond, json, &QuantraServer::Stub::PriceFloatingRateBond
+        ProductType::FloatingRateBond, json, &QuantraServer::Stub::PriceFloatingRateBond, request_id
     );
 }
 
-JsonResponse QuantraClient::PriceVanillaSwapJSON(const std::string& json) {
+JsonResponse QuantraClient::PriceVanillaSwapJSON(const std::string& json, const std::string& request_id) {
     return impl_->CallJSON<PriceVanillaSwapRequest, PriceVanillaSwapResponse>(
-        ProductType::VanillaSwap, json, &QuantraServer::Stub::PriceVanillaSwap
+        ProductType::VanillaSwap, json, &QuantraServer::Stub::PriceVanillaSwap, request_id
     );
 }
 
-JsonResponse QuantraClient::PriceZeroCouponInflationSwapJSON(const std::string& json) {
+JsonResponse QuantraClient::PriceZeroCouponInflationSwapJSON(const std::string& json, const std::string& request_id) {
     return impl_->CallJSON<PriceZeroCouponInflationSwapRequest, PriceZeroCouponInflationSwapResponse>(
-        ProductType::ZeroCouponInflationSwap, json, &QuantraServer::Stub::PriceZeroCouponInflationSwap
+        ProductType::ZeroCouponInflationSwap, json, &QuantraServer::Stub::PriceZeroCouponInflationSwap, request_id
     );
 }
 
-JsonResponse QuantraClient::PriceYearOnYearInflationSwapJSON(const std::string& json) {
+JsonResponse QuantraClient::PriceYearOnYearInflationSwapJSON(const std::string& json, const std::string& request_id) {
     return impl_->CallJSON<PriceYearOnYearInflationSwapRequest, PriceYearOnYearInflationSwapResponse>(
-        ProductType::YearOnYearInflationSwap, json, &QuantraServer::Stub::PriceYearOnYearInflationSwap
+        ProductType::YearOnYearInflationSwap, json, &QuantraServer::Stub::PriceYearOnYearInflationSwap, request_id
     );
 }
 
-JsonResponse QuantraClient::PriceOisSwapJSON(const std::string& json) {
+JsonResponse QuantraClient::PriceOisSwapJSON(const std::string& json, const std::string& request_id) {
     return impl_->CallJSON<PriceOisSwapRequest, PriceOisSwapResponse>(
-        ProductType::OisSwap, json, &QuantraServer::Stub::PriceOisSwap
+        ProductType::OisSwap, json, &QuantraServer::Stub::PriceOisSwap, request_id
     );
 }
 
-JsonResponse QuantraClient::PriceBasisSwapJSON(const std::string& json) {
+JsonResponse QuantraClient::PriceBasisSwapJSON(const std::string& json, const std::string& request_id) {
     return impl_->CallJSON<PriceBasisSwapRequest, PriceBasisSwapResponse>(
-        ProductType::BasisSwap, json, &QuantraServer::Stub::PriceBasisSwap
+        ProductType::BasisSwap, json, &QuantraServer::Stub::PriceBasisSwap, request_id
     );
 }
 
-JsonResponse QuantraClient::PriceFRAJSON(const std::string& json) {
+JsonResponse QuantraClient::PriceFRAJSON(const std::string& json, const std::string& request_id) {
     return impl_->CallJSON<PriceFRARequest, PriceFRAResponse>(
-        ProductType::FRA, json, &QuantraServer::Stub::PriceFRA
+        ProductType::FRA, json, &QuantraServer::Stub::PriceFRA, request_id
     );
 }
 
-JsonResponse QuantraClient::PriceCapFloorJSON(const std::string& json) {
+JsonResponse QuantraClient::PriceCapFloorJSON(const std::string& json, const std::string& request_id) {
     return impl_->CallJSON<PriceCapFloorRequest, PriceCapFloorResponse>(
-        ProductType::CapFloor, json, &QuantraServer::Stub::PriceCapFloor
+        ProductType::CapFloor, json, &QuantraServer::Stub::PriceCapFloor, request_id
     );
 }
 
-JsonResponse QuantraClient::PriceSwaptionJSON(const std::string& json) {
+JsonResponse QuantraClient::PriceSwaptionJSON(const std::string& json, const std::string& request_id) {
     return impl_->CallJSON<PriceSwaptionRequest, PriceSwaptionResponse>(
-        ProductType::Swaption, json, &QuantraServer::Stub::PriceSwaption
+        ProductType::Swaption, json, &QuantraServer::Stub::PriceSwaption, request_id
     );
 }
 
-JsonResponse QuantraClient::PriceCDSJSON(const std::string& json) {
+JsonResponse QuantraClient::PriceCDSJSON(const std::string& json, const std::string& request_id) {
     return impl_->CallJSON<PriceCDSRequest, PriceCDSResponse>(
-        ProductType::CDS, json, &QuantraServer::Stub::PriceCDS
+        ProductType::CDS, json, &QuantraServer::Stub::PriceCDS, request_id
     );
 }
 
-JsonResponse QuantraClient::BootstrapCurvesJSON(const std::string& json) {
+JsonResponse QuantraClient::BootstrapCurvesJSON(const std::string& json, const std::string& request_id) {
     return impl_->CallJSON<BootstrapCurvesRequest, BootstrapCurvesResponse>(
-        ProductType::BootstrapCurves, json, &QuantraServer::Stub::BootstrapCurves
+        ProductType::BootstrapCurves, json, &QuantraServer::Stub::BootstrapCurves, request_id
     );
 }
 
-JsonResponse QuantraClient::BootstrapInflationCurvesJSON(const std::string& json) {
+JsonResponse QuantraClient::BootstrapInflationCurvesJSON(const std::string& json, const std::string& request_id) {
     return impl_->CallJSON<BootstrapInflationCurvesRequest, BootstrapInflationCurvesResponse>(
-        ProductType::BootstrapInflationCurves, json, &QuantraServer::Stub::BootstrapInflationCurves
+        ProductType::BootstrapInflationCurves, json, &QuantraServer::Stub::BootstrapInflationCurves, request_id
     );
 }
 
-JsonResponse QuantraClient::SampleVolSurfacesJSON(const std::string& json) {
+JsonResponse QuantraClient::SampleVolSurfacesJSON(const std::string& json, const std::string& request_id) {
     return impl_->CallJSON<SampleVolSurfacesRequest, SampleVolSurfacesResponse>(
-        ProductType::SampleVolSurfaces, json, &QuantraServer::Stub::SampleVolSurfaces
+        ProductType::SampleVolSurfaces, json, &QuantraServer::Stub::SampleVolSurfaces, request_id
     );
 }
 
-JsonResponse QuantraClient::CalendarBusinessDaysJSON(const std::string& json) {
+JsonResponse QuantraClient::CalendarBusinessDaysJSON(const std::string& json, const std::string& request_id) {
     return impl_->CallJSON<CalendarBusinessDaysRequest, CalendarBusinessDaysResponse>(
-        ProductType::CalendarBusinessDays, json, &QuantraServer::Stub::CalendarBusinessDays
+        ProductType::CalendarBusinessDays, json, &QuantraServer::Stub::CalendarBusinessDays, request_id
     );
 }
 
-JsonResponse QuantraClient::CalendarHolidaysJSON(const std::string& json) {
+JsonResponse QuantraClient::CalendarHolidaysJSON(const std::string& json, const std::string& request_id) {
     return impl_->CallJSON<CalendarHolidaysRequest, CalendarHolidaysResponse>(
-        ProductType::CalendarHolidays, json, &QuantraServer::Stub::CalendarHolidays
+        ProductType::CalendarHolidays, json, &QuantraServer::Stub::CalendarHolidays, request_id
     );
 }
 
-JsonResponse QuantraClient::CalendarAdvanceJSON(const std::string& json) {
+JsonResponse QuantraClient::CalendarAdvanceJSON(const std::string& json, const std::string& request_id) {
     return impl_->CallJSON<CalendarAdvanceRequest, CalendarAdvanceResponse>(
-        ProductType::CalendarAdvance, json, &QuantraServer::Stub::CalendarAdvance
+        ProductType::CalendarAdvance, json, &QuantraServer::Stub::CalendarAdvance, request_id
     );
 }
 
-JsonResponse QuantraClient::CalibrateSwaptionModelJSON(const std::string& json) {
+JsonResponse QuantraClient::CalibrateSwaptionModelJSON(const std::string& json, const std::string& request_id) {
     return impl_->CallJSON<CalibrateSwaptionModelRequest, CalibrateSwaptionModelResponse>(
-        ProductType::CalibrateSwaptionModel, json, &QuantraServer::Stub::CalibrateSwaptionModel
+        ProductType::CalibrateSwaptionModel, json, &QuantraServer::Stub::CalibrateSwaptionModel, request_id
     );
 }
 
-JsonResponse QuantraClient::CalibrateSwaptionVolJSON(const std::string& json) {
+JsonResponse QuantraClient::CalibrateSwaptionVolJSON(const std::string& json, const std::string& request_id) {
     return impl_->CallJSON<CalibrateSwaptionVolRequest, CalibrateSwaptionVolResponse>(
-        ProductType::CalibrateSwaptionVol, json, &QuantraServer::Stub::CalibrateSwaptionVol
+        ProductType::CalibrateSwaptionVol, json, &QuantraServer::Stub::CalibrateSwaptionVol, request_id
     );
 }
 
-JsonResponse QuantraClient::PriceEquityOptionJSON(const std::string& json) {
+JsonResponse QuantraClient::PriceEquityOptionJSON(const std::string& json, const std::string& request_id) {
     return impl_->CallJSON<PriceEquityOptionRequest, PriceEquityOptionResponse>(
-        ProductType::EquityOption, json, &QuantraServer::Stub::PriceEquityOption
+        ProductType::EquityOption, json, &QuantraServer::Stub::PriceEquityOption, request_id
     );
 }
 

--- a/jsonserver/crow_all.h
+++ b/jsonserver/crow_all.h
@@ -9457,6 +9457,7 @@ namespace crow
               {status::UNSUPPORTED_MEDIA_TYPE, "HTTP/1.1 415 Unsupported Media Type\r\n"},
               {status::RANGE_NOT_SATISFIABLE, "HTTP/1.1 416 Range Not Satisfiable\r\n"},
               {status::EXPECTATION_FAILED, "HTTP/1.1 417 Expectation Failed\r\n"},
+              {422, "HTTP/1.1 422 Unprocessable Entity\r\n"},
               {status::PRECONDITION_REQUIRED, "HTTP/1.1 428 Precondition Required\r\n"},
               {status::TOO_MANY_REQUESTS, "HTTP/1.1 429 Too Many Requests\r\n"},
               {status::UNAVAILABLE_FOR_LEGAL_REASONS, "HTTP/1.1 451 Unavailable For Legal Reasons\r\n"},

--- a/jsonserver/server.cpp
+++ b/jsonserver/server.cpp
@@ -209,7 +209,34 @@ std::optional<crow::response> RejectInvalidJsonRequest(const crow::request& req)
     if (req.body.size() > kMaxJsonRequestBytes) {
         return crow::response(413, R"({"error":"Request body too large"})");
     }
+    // Reject an empty/whitespace-only body up front: forwarded to the flatc
+    // parser it yields the misleading "input file is empty".
+    if (TrimWhitespace(req.body).empty()) {
+        return crow::response(400, R"({"error":"empty request body"})");
+    }
     return std::nullopt;
+}
+
+// Sanitize a caller-supplied X-Request-Id before it is used as gRPC metadata,
+// echoed as a response header, or written to logs: keep only
+// printable non-space ASCII (drops CR/LF and other control characters) and cap
+// the length. Returns "" when nothing usable remains.
+constexpr size_t kMaxRequestIdLen = 128;
+
+std::string SanitizeRequestId(const std::string& raw) {
+    std::string out;
+    out.reserve(std::min(raw.size(), kMaxRequestIdLen));
+    for (char c : raw) {
+        const unsigned char uc = static_cast<unsigned char>(c);
+        if (uc <= 0x20 || uc >= 0x7f) {
+            continue;
+        }
+        out += c;
+        if (out.size() >= kMaxRequestIdLen) {
+            break;
+        }
+    }
+    return out;
 }
 
 std::optional<std::string> HttpGetWithTimeout(
@@ -440,18 +467,31 @@ int main(int argc, char** argv) {
                       << req.body << "\n"
                       << "[jsonserver] JSON END " << route << std::endl;
         };
+        // Shared POST wrapper. The caller's X-Request-Id (sanitized) is echoed
+        // back as a response header and forwarded to the gRPC backend by fn so
+        // engine logs correlate with the HTTP caller.
         auto respond = [&](const char* route, const crow::request& req, auto&& fn) {
+            const std::string request_id =
+                SanitizeRequestId(req.get_header_value("X-Request-Id"));
+            auto with_request_id = [&](crow::response resp) {
+                if (!request_id.empty()) {
+                    resp.set_header("X-Request-Id", request_id);
+                }
+                return resp;
+            };
             if (auto rejected = RejectInvalidJsonRequest(req)) {
-                return std::move(*rejected);
+                return with_request_id(std::move(*rejected));
             }
             log_json_request(route, req);
-            auto r = fn(req.body);
+            auto r = fn(req.body, request_id);
             if (r.status_code >= 400) {
                 std::cerr << "[jsonserver] backend_error " << route
                           << " http_status=" << r.status_code
+                          << (request_id.empty() ? std::string()
+                                                 : " request_id=" + request_id)
                           << " response=" << r.body << std::endl;
             }
-            return crow::response(r.status_code, r.body);
+            return with_request_id(crow::response(r.status_code, r.body));
         };
         
         // Health checks
@@ -521,152 +561,162 @@ int main(int argc, char** argv) {
         // Pricing endpoints
         CROW_ROUTE(app, "/price-fixed-rate-bond").methods("POST"_method)
         ([&](const crow::request& req) {
-            return respond("/price-fixed-rate-bond", req, [&](const std::string& body) {
-                return client.PriceFixedRateBondJSON(body);
+            return respond("/price-fixed-rate-bond", req, [&](const std::string& body, const std::string& request_id) {
+                return client.PriceFixedRateBondJSON(body, request_id);
             });
         });
         
         CROW_ROUTE(app, "/price-floating-rate-bond").methods("POST"_method)
         ([&](const crow::request& req) {
-            return respond("/price-floating-rate-bond", req, [&](const std::string& body) {
-                return client.PriceFloatingRateBondJSON(body);
+            return respond("/price-floating-rate-bond", req, [&](const std::string& body, const std::string& request_id) {
+                return client.PriceFloatingRateBondJSON(body, request_id);
             });
         });
         
         CROW_ROUTE(app, "/price-vanilla-swap").methods("POST"_method)
         ([&](const crow::request& req) {
-            return respond("/price-vanilla-swap", req, [&](const std::string& body) {
-                return client.PriceVanillaSwapJSON(body);
+            return respond("/price-vanilla-swap", req, [&](const std::string& body, const std::string& request_id) {
+                return client.PriceVanillaSwapJSON(body, request_id);
             });
         });
 
         CROW_ROUTE(app, "/price-zero-coupon-inflation-swap").methods("POST"_method)
         ([&](const crow::request& req) {
-            return respond("/price-zero-coupon-inflation-swap", req, [&](const std::string& body) {
-                return client.PriceZeroCouponInflationSwapJSON(body);
+            return respond("/price-zero-coupon-inflation-swap", req, [&](const std::string& body, const std::string& request_id) {
+                return client.PriceZeroCouponInflationSwapJSON(body, request_id);
             });
         });
 
         CROW_ROUTE(app, "/price-year-on-year-inflation-swap").methods("POST"_method)
         ([&](const crow::request& req) {
-            return respond("/price-year-on-year-inflation-swap", req, [&](const std::string& body) {
-                return client.PriceYearOnYearInflationSwapJSON(body);
+            return respond("/price-year-on-year-inflation-swap", req, [&](const std::string& body, const std::string& request_id) {
+                return client.PriceYearOnYearInflationSwapJSON(body, request_id);
             });
         });
 
         CROW_ROUTE(app, "/price-ois-swap").methods("POST"_method)
         ([&](const crow::request& req) {
-            return respond("/price-ois-swap", req, [&](const std::string& body) {
-                return client.PriceOisSwapJSON(body);
+            return respond("/price-ois-swap", req, [&](const std::string& body, const std::string& request_id) {
+                return client.PriceOisSwapJSON(body, request_id);
             });
         });
 
         CROW_ROUTE(app, "/price-basis-swap").methods("POST"_method)
         ([&](const crow::request& req) {
-            return respond("/price-basis-swap", req, [&](const std::string& body) {
-                return client.PriceBasisSwapJSON(body);
+            return respond("/price-basis-swap", req, [&](const std::string& body, const std::string& request_id) {
+                return client.PriceBasisSwapJSON(body, request_id);
             });
         });
         
         CROW_ROUTE(app, "/price-fra").methods("POST"_method)
         ([&](const crow::request& req) {
-            return respond("/price-fra", req, [&](const std::string& body) {
-                return client.PriceFRAJSON(body);
+            return respond("/price-fra", req, [&](const std::string& body, const std::string& request_id) {
+                return client.PriceFRAJSON(body, request_id);
             });
         });
         
         CROW_ROUTE(app, "/price-cap-floor").methods("POST"_method)
         ([&](const crow::request& req) {
-            return respond("/price-cap-floor", req, [&](const std::string& body) {
-                return client.PriceCapFloorJSON(body);
+            return respond("/price-cap-floor", req, [&](const std::string& body, const std::string& request_id) {
+                return client.PriceCapFloorJSON(body, request_id);
             });
         });
         
         CROW_ROUTE(app, "/price-swaption").methods("POST"_method)
         ([&](const crow::request& req) {
-            return respond("/price-swaption", req, [&](const std::string& body) {
-                return client.PriceSwaptionJSON(body);
+            return respond("/price-swaption", req, [&](const std::string& body, const std::string& request_id) {
+                return client.PriceSwaptionJSON(body, request_id);
             });
         });
         
         CROW_ROUTE(app, "/price-cds").methods("POST"_method)
         ([&](const crow::request& req) {
-            return respond("/price-cds", req, [&](const std::string& body) {
-                return client.PriceCDSJSON(body);
+            return respond("/price-cds", req, [&](const std::string& body, const std::string& request_id) {
+                return client.PriceCDSJSON(body, request_id);
             });
         });
         
         CROW_ROUTE(app, "/bootstrap-curves").methods("POST"_method)
         ([&](const crow::request& req) {
-            return respond("/bootstrap-curves", req, [&](const std::string& body) {
-                return client.BootstrapCurvesJSON(body);
+            return respond("/bootstrap-curves", req, [&](const std::string& body, const std::string& request_id) {
+                return client.BootstrapCurvesJSON(body, request_id);
             });
         });
 
         CROW_ROUTE(app, "/bootstrap-inflation-curves").methods("POST"_method)
         ([&](const crow::request& req) {
-            return respond("/bootstrap-inflation-curves", req, [&](const std::string& body) {
-                return client.BootstrapInflationCurvesJSON(body);
+            return respond("/bootstrap-inflation-curves", req, [&](const std::string& body, const std::string& request_id) {
+                return client.BootstrapInflationCurvesJSON(body, request_id);
             });
         });
 
         CROW_ROUTE(app, "/sample-vol-surfaces").methods("POST"_method)
         ([&](const crow::request& req) {
+            const std::string request_id =
+                SanitizeRequestId(req.get_header_value("X-Request-Id"));
+            auto with_request_id = [&](crow::response resp) {
+                if (!request_id.empty()) {
+                    resp.set_header("X-Request-Id", request_id);
+                }
+                return resp;
+            };
             if (auto rejected = RejectInvalidJsonRequest(req)) {
-                return std::move(*rejected);
+                return with_request_id(std::move(*rejected));
             }
             log_json_request("/sample-vol-surfaces", req);
-            auto r = client.SampleVolSurfacesJSON(req.body);
+            auto r = client.SampleVolSurfacesJSON(req.body, request_id);
             if (r.status_code >= 400) {
                 std::cerr << "[jsonserver] backend_error /sample-vol-surfaces"
                           << " http_status=" << r.status_code
+                          << (request_id.empty() ? std::string()
+                                                 : " request_id=" + request_id)
                           << " response=" << r.body << std::endl;
             } else {
                 std::cout << "[jsonserver] /sample-vol-surfaces success"
                           << " http_status=" << r.status_code << std::endl;
             }
-            return crow::response(r.status_code, r.body);
+            return with_request_id(crow::response(r.status_code, r.body));
         });
 
         CROW_ROUTE(app, "/calendar-business-days").methods("POST"_method)
         ([&](const crow::request& req) {
-            return respond("/calendar-business-days", req, [&](const std::string& body) {
-                return client.CalendarBusinessDaysJSON(body);
+            return respond("/calendar-business-days", req, [&](const std::string& body, const std::string& request_id) {
+                return client.CalendarBusinessDaysJSON(body, request_id);
             });
         });
 
         CROW_ROUTE(app, "/calendar-holidays").methods("POST"_method)
         ([&](const crow::request& req) {
-            return respond("/calendar-holidays", req, [&](const std::string& body) {
-                return client.CalendarHolidaysJSON(body);
+            return respond("/calendar-holidays", req, [&](const std::string& body, const std::string& request_id) {
+                return client.CalendarHolidaysJSON(body, request_id);
             });
         });
 
         CROW_ROUTE(app, "/calendar-advance").methods("POST"_method)
         ([&](const crow::request& req) {
-            return respond("/calendar-advance", req, [&](const std::string& body) {
-                return client.CalendarAdvanceJSON(body);
+            return respond("/calendar-advance", req, [&](const std::string& body, const std::string& request_id) {
+                return client.CalendarAdvanceJSON(body, request_id);
             });
         });
 
         CROW_ROUTE(app, "/calibrate-swaption-model").methods("POST"_method)
         ([&](const crow::request& req) {
-            return respond("/calibrate-swaption-model", req, [&](const std::string& body) {
-                return client.CalibrateSwaptionModelJSON(body);
+            return respond("/calibrate-swaption-model", req, [&](const std::string& body, const std::string& request_id) {
+                return client.CalibrateSwaptionModelJSON(body, request_id);
             });
         });
 
         CROW_ROUTE(app, "/calibrate-swaption-vol").methods("POST"_method)
         ([&](const crow::request& req) {
-            return respond("/calibrate-swaption-vol", req, [&](const std::string& body) {
-                return client.CalibrateSwaptionVolJSON(body);
+            return respond("/calibrate-swaption-vol", req, [&](const std::string& body, const std::string& request_id) {
+                return client.CalibrateSwaptionVolJSON(body, request_id);
             });
         });
 
         CROW_ROUTE(app, "/price-equity-option").methods("POST"_method)
         ([&](const crow::request& req) {
-            return respond("/price-equity-option", req, [&](const std::string& body) {
-                return client.PriceEquityOptionJSON(body);
+            return respond("/price-equity-option", req, [&](const std::string& body, const std::string& request_id) {
+                return client.PriceEquityOptionJSON(body, request_id);
             });
         });
         

--- a/tests/contract/gateway_dx_test.py
+++ b/tests/contract/gateway_dx_test.py
@@ -1,0 +1,160 @@
+"""Gateway DX contract.
+
+Locks the Portal-facing HTTP error/observability behaviour of the JSON
+gateway:
+
+  * X-Request-Id: the caller's id is echoed back as a response header and
+    forwarded to the gRPC engine as `x-request-id` metadata, so the engine
+    log line for the request carries `request_id=<id>`. The id is
+    sanitized (printable ASCII only) and capped at 128 chars.
+  * ABORTED (QuantLib/engine exception from a well-formed but unpriceable
+    request) maps to HTTP 422 -- not the old default 500 -- and the
+    documented `error` field carries the REAL cause text, with `code`,
+    `code_name` and `message` kept for backward compatibility.
+  * An empty/whitespace-only body is rejected up front with a clear
+    400 "empty request body" instead of flatc's "input file is empty",
+    and a body with an embedded NUL byte is rejected instead of being
+    silently truncated at the NUL.
+
+The engine log written by run_all_tests.sh (/tmp/grpc.log) is used for the
+log-correlation assertion when it is reachable; otherwise only the response
+header echo is asserted.
+"""
+
+import json
+import os
+import uuid
+from pathlib import Path
+
+import pytest
+import requests
+
+GRPC_LOG = Path(os.environ.get("QUANTRA_GRPC_LOG", "/tmp/grpc.log"))
+JSON_HEADERS = {"Content-Type": "application/json"}
+
+
+@pytest.fixture(scope="module")
+def bond_url(client):
+    return f"{client.base_url}/{client.ENDPOINTS['fixed_rate_bond']}"
+
+
+@pytest.fixture(scope="module")
+def bond_request(data_dir):
+    with open(data_dir / "fixed_rate_bond_request.json") as fh:
+        return json.load(fh)
+
+
+# ---------------------------------------------------------------------------
+# X-Request-Id forwarding + echo
+# ---------------------------------------------------------------------------
+
+def test_request_id_echoed_on_response(bond_url, bond_request):
+    r = requests.post(
+        bond_url,
+        data=json.dumps(bond_request),
+        headers={**JSON_HEADERS, "X-Request-Id": "probe-123"},
+    )
+    assert r.status_code == 200, f"expected 200, got {r.status_code} :: {r.text[:160]}"
+    assert r.headers.get("X-Request-Id") == "probe-123", (
+        f"X-Request-Id not echoed: headers={dict(r.headers)}"
+    )
+
+
+def test_request_id_reaches_engine_log(bond_url, bond_request):
+    # Force an engine log line (errors always log) with a unique id, then look
+    # for request_id=<id> in the engine's log. The mutation below produces a
+    # deterministic QuantLib error (effective date after termination date).
+    rid = f"probe-{uuid.uuid4().hex[:12]}"
+    bad = json.loads(json.dumps(bond_request))
+    bad["bonds"][0]["fixed_rate_bond"]["schedule"]["effective_date"] = "2018/05/15"
+
+    r = requests.post(
+        bond_url,
+        data=json.dumps(bad),
+        headers={**JSON_HEADERS, "X-Request-Id": rid},
+    )
+    assert r.headers.get("X-Request-Id") == rid, (
+        f"X-Request-Id not echoed on error response: headers={dict(r.headers)}"
+    )
+    if not GRPC_LOG.is_file():
+        pytest.skip(f"engine log {GRPC_LOG} not reachable; header echo asserted above")
+    log_text = GRPC_LOG.read_text(errors="replace")
+    assert f"request_id={rid}" in log_text, (
+        f"engine log has no request_id={rid} line (request-id forwarding broken)"
+    )
+
+
+def test_request_id_sanitized_and_capped(bond_url, bond_request):
+    # 200 printable chars in -> at most 128 echoed back (gateway cap).
+    long_id = "a" * 200
+    r = requests.post(
+        bond_url,
+        data=json.dumps(bond_request),
+        headers={**JSON_HEADERS, "X-Request-Id": long_id},
+    )
+    echoed = r.headers.get("X-Request-Id")
+    assert echoed == "a" * 128, f"expected 128-char capped id, got {echoed!r}"
+
+
+def test_no_request_id_header_when_absent(bond_url, bond_request):
+    r = requests.post(bond_url, data=json.dumps(bond_request), headers=JSON_HEADERS)
+    assert r.status_code == 200
+    assert "X-Request-Id" not in r.headers, (
+        "gateway must not invent a request id when the caller sent none"
+    )
+
+
+# ---------------------------------------------------------------------------
+# ABORTED -> 422 with the real cause in `error`
+# ---------------------------------------------------------------------------
+
+def test_quantlib_error_maps_to_422_with_real_cause(bond_url, bond_request):
+    bad = json.loads(json.dumps(bond_request))
+    # Well-formed but unpriceable: schedule effective date after termination
+    # date makes QuantLib throw -> gRPC ABORTED -> HTTP 422 (was 500).
+    bad["bonds"][0]["fixed_rate_bond"]["schedule"]["effective_date"] = "2018/05/15"
+
+    r = requests.post(bond_url, data=json.dumps(bad), headers=JSON_HEADERS)
+    assert r.status_code == 422, (
+        f"QuantLib input error: expected HTTP 422, got {r.status_code} :: {r.text[:200]}"
+    )
+    body = r.json()
+    # E3: documented `error` field carries the real message, not "gRPC error".
+    assert body.get("error") and body["error"] != "gRPC error", (
+        f"'error' field is not the real cause: {r.text[:200]}"
+    )
+    assert "date" in body["error"].lower(), (
+        f"'error' does not mention the offending dates: {r.text[:200]}"
+    )
+    # Backward compatibility: code/code_name/message are still present.
+    assert body.get("code_name") == "ABORTED", f"unexpected code_name: {r.text[:200]}"
+    assert isinstance(body.get("code"), int)
+    assert body.get("message") == body["error"], (
+        f"'message' kept for compat must match 'error': {r.text[:200]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# empty body + NUL byte handling
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("body", [b"", b"   \n\t  "], ids=["empty", "whitespace-only"])
+def test_empty_body_rejected_400(bond_url, body):
+    r = requests.post(bond_url, data=body, headers=JSON_HEADERS)
+    assert r.status_code == 400, (
+        f"empty body: expected HTTP 400, got {r.status_code} :: {r.text[:160]}"
+    )
+    assert r.json() == {"error": "empty request body"}
+
+
+def test_body_with_embedded_nul_rejected_400(bond_url, bond_request):
+    # A NUL inside the body used to silently truncate the request at the NUL
+    # (the body is handed to flatc as a C string); it must be rejected.
+    body = json.dumps(bond_request).encode() + b"\x00trailing"
+    r = requests.post(bond_url, data=body, headers=JSON_HEADERS)
+    assert r.status_code == 400, (
+        f"NUL body: expected HTTP 400, got {r.status_code} :: {r.text[:160]}"
+    )
+    assert "NUL" in r.json().get("error", ""), (
+        f"expected a clear NUL-byte error, got: {r.text[:160]}"
+    )


### PR DESCRIPTION
Makes the JSON gateway's error responses more accurate and adds request tracing. All changes are backward-compatible.

- **Status codes:** engine exceptions from well-formed but unpriceable inputs (bad dates, degenerate schedules, ...) now return **422** instead of a generic 500 — they are client-data faults, not server errors. An over-limit payload now returns **413** instead of 429.
- **Error body:** the documented `error` field now carries the real failure cause (it previously held the useless constant `"gRPC error"`); `code`, `code_name` and `message` are unchanged, so existing clients keep working.
- **Request tracing:** the caller's `X-Request-Id` header is now forwarded to the engine as gRPC metadata (so engine log lines correlate with the request), sanitized, and echoed back as a response header. It was previously dropped.
- **Body validation:** an empty/whitespace-only body returns a clear 400 `"empty request body"`; a body containing a NUL byte (which used to silently truncate the request) is rejected with 400.
- Adds a 422 entry to the vendored Crow status table so it serializes correctly.

New gateway contract tests (Suite 3 → 54). Full test suite green in Docker (329 cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
