### PR TITLE
Remove internal audit references from source comments

### DIFF
--- a/src/market/curve_bootstrapper.cpp
+++ b/src/market/curve_bootstrapper.cpp
@@ -357,7 +357,7 @@ BootstrappedCurves CurveBootstrapper::bootstrapAll(
             // which is an InterpolatedZeroCurve — serialize() would fall back
             // to weekly resampling, and an L1/L2 hit would serve an
             // approximation of the user's nodes instead of the real curve
-            // (audit B7). Such curves cache the LIVE curve (value-exact, same
+            // Such curves cache the LIVE curve (value-exact, same
             // as the non-Discount-trait branch) and skip the L2 store.
             bool exactPillars = CurveSerializer::canSerializeExactly(curve, ts);
 

--- a/src/market/curve_serializer.h
+++ b/src/market/curve_serializer.h
@@ -44,7 +44,7 @@ public:
      * Curves built any other way — e.g. a ZeroRatePoint curve, which is an
      * InterpolatedZeroCurve — would be WEEKLY-RESAMPLED by serialize()'s
      * fallback, an approximation that must never be served on a cache hit
-     * (audit B7). Callers must check this before caching serialized/frozen
+     * Callers must check this before caching serialized/frozen
      * data; when false, cache the live curve instead.
      */
     static bool canSerializeExactly(
@@ -63,7 +63,7 @@ public:
      * dense weekly sampling if the downcast fails — an APPROXIMATION of the
      * live curve. Callers that cache the result must gate on
      * canSerializeExactly() first so the fallback is never served on a
-     * cache hit (audit B7).
+     * cache hit.
      */
     static CachedCurveData serialize(
         const std::shared_ptr<QuantLib::YieldTermStructure>& curve,


### PR DESCRIPTION
Comment-only cleanup: strip leftover internal bookkeeping tokens from cache-freeze comments. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)