### PR TITLE
Fail closed in the cache-key builder on unresolvable references

### DIFF
--- a/src/market/curve_cache_key.cpp
+++ b/src/market/curve_cache_key.cpp
@@ -41,6 +41,18 @@ double CurveKeyBuilder::resolveQuoteValue(
             if (it != ctx.quoteValues.end()) {
                 return it->second;
             }
+            // A quote_id was given but does not resolve to a curve quote
+            // (missing from the request, or present with a non-curve quote
+            // type). The parser rejects exactly this situation, so falling
+            // back to the inline value here would key the curve as if the
+            // reference were valid: a request the parser errors on could hash
+            // to the same key as a valid inline-value request and be served a
+            // cached price instead of the error. Fail closed — the
+            // bootstrapper catches this and skips caching for the curve
+            // (bootstrap live; the parser then reports the real error).
+            QUANTRA_ERROR(
+                "curve cache key: quote id '" + id +
+                "' does not resolve to a curve quote — curve must not be cached");
         }
     }
     return inlineValue;
@@ -371,7 +383,17 @@ void CurveKeyBuilder::writeReferencedIndices(
     for (const auto& refId : referencedIds) {
         // O(1) lookup via context map
         auto it = ctx.indexDefs.find(refId);
-        if (it == ctx.indexDefs.end()) continue; // index not found
+        if (it == ctx.indexDefs.end()) {
+            // A helper references an index id with no definition in the
+            // request. Silently skipping it would leave the definition out of
+            // the key entirely (under-keyed): two curves differing only in
+            // that index's conventions or fixings would collide. Fail closed
+            // — the bootstrapper catches this and skips caching for the curve
+            // (bootstrap live; the parser then reports the missing index).
+            QUANTRA_ERROR(
+                "curve cache key: referenced index id '" + refId +
+                "' has no definition — curve must not be cached");
+        }
 
         const auto* def = it->second;
         buf.writeFbString(def->id());

--- a/tests/caching/cache_correctness_test.py
+++ b/tests/caching/cache_correctness_test.py
@@ -17,6 +17,7 @@ bumped curves (curveBump != 0) cacheable, a bumped variant drops in as a
 one-line CASES addition — no other change needed.
 """
 
+import copy
 import json
 import time
 from collections import namedtuple
@@ -158,6 +159,49 @@ def test_cache_transparency_beyond_pillar_error(nocache_client, cache_client,
     )
     print(f"[cache] beyond_pillar_error: off==warm==hit = "
           f"HTTP {off[0]}, body {off[1]!r}")
+
+
+def test_bogus_quote_id_not_masked_by_warm_cache(nocache_client, cache_client,
+                                                 data_dir):
+    """Reference-error transparency: a helper `quote_id` that resolves to
+    nothing must return the parser's NOT_FOUND error even when the cache is
+    warm with the equivalent inline-value request.
+
+    The cache key stores resolved quote VALUES, never quote ids, and it is
+    built before the request is parsed. A key builder that silently falls
+    back to the helper's inline value when a quote_id does not resolve hashes
+    the bogus request to the same key as the valid inline-value request — so
+    a warm cache would serve a cached price where the no-cache path serves
+    404. The key builder must instead refuse to key the curve (leaving it
+    uncached), letting the parser report the unknown id.
+    """
+    valid = load_json(data_dir / "fixed_rate_bond_request.json")
+
+    # Warm the cache-ON server with the valid inline-value request so that a
+    # key collision with the bogus request below would actually serve a hit.
+    cache_client.price("fixed_rate_bond", valid)
+
+    bogus = copy.deepcopy(valid)
+    point = bogus["pricing"]["rates"]["curves"][0]["points"][0]["point"]
+    point["quote_id"] = "quote-id-that-does-not-exist"
+
+    off = _post_raw(nocache_client, "fixed_rate_bond", bogus)   # reference
+    first = _post_raw(cache_client, "fixed_rate_bond", bogus)   # warm cache
+    second = _post_raw(cache_client, "fixed_rate_bond", bogus)  # again: no
+    # entry may have been created by the first attempt either.
+
+    assert off[0] == 404 and "Unknown quote id" in off[1], (
+        f"cache-OFF reference did not reject the bogus quote_id as NOT_FOUND "
+        f"(got HTTP {off[0]}, body {off[1]!r})"
+    )
+    for label, resp in (("first", first), ("second", second)):
+        assert resp[0] == 404 and "Unknown quote id" in resp[1], (
+            f"bogus_quote_id: {label} POST to the warm cache-ON server did "
+            f"not return the parser's NOT_FOUND — a cached price masked the "
+            f"validation error (got HTTP {resp[0]}, body {resp[1]!r})"
+        )
+    print(f"[cache] bogus_quote_id: off/warm-first/warm-second all "
+          f"HTTP 404, body {off[1]!r}")
 
 
 def _count_cache_hits(log_path: Path) -> int:

--- a/tests/parity/curve_cache_key_unresolvable_ref_test.cpp
+++ b/tests/parity/curve_cache_key_unresolvable_ref_test.cpp
@@ -1,0 +1,152 @@
+// Curve cache key: unresolvable references must fail CLOSED.
+//
+// The cache key is built BEFORE the request is parsed, so it must be at least
+// as strict as the parser about references. Two resolutions used to fall back
+// silently instead:
+//
+//  - a helper `quote_id` that did not resolve fell back to the helper's
+//    inline value. The key stores only the resolved double (never the id), so
+//    a request the parser rejects (unknown quote id -> NOT_FOUND) hashed to
+//    the SAME key as a valid inline-value request — a warm cache would serve
+//    a price where the no-cache path serves the error;
+//
+//  - a referenced index id with no definition was skipped entirely, leaving
+//    the definition out of the key (under-keyed): two curves differing only
+//    in that index's conventions or fixings would collide.
+//
+// Both must throw instead, matching the unknown-point-type default in
+// serializePoint. CurveBootstrapper::bootstrapAll catches the throw and
+// degrades by skipping the cache for that curve (no L1/L2 get or put,
+// bootstrap live, request still proceeds) — the parser then reports the real
+// error to the client.
+#include <gtest/gtest.h>
+
+#include "curve_cache_key.h"
+#include "error.h"
+
+namespace quantra {
+namespace testing {
+namespace {
+
+// Curve with a single DepositHelper carrying the given inline rate and an
+// optional quote_id reference.
+const quantra::TermStructure* buildDepositCurve(
+    flatbuffers::FlatBufferBuilder& fbb, double rate, const char* quoteId)
+{
+    auto helper = quantra::CreateDepositHelperDirect(
+        fbb, rate, /*tenor=*/0, /*fixing_days=*/2,
+        quantra::enums::Calendar_TARGET,
+        quantra::enums::BusinessDayConvention_ModifiedFollowing,
+        quantra::enums::DayCounter_Actual360, quoteId);
+    auto pw = quantra::CreatePointsWrapper(
+        fbb, quantra::Point_DepositHelper, helper.Union());
+    std::vector<flatbuffers::Offset<quantra::PointsWrapper>> pts{pw};
+    auto ts = quantra::CreateTermStructureDirect(
+        fbb, "curve-quote-ref",
+        quantra::enums::DayCounter_Actual360,
+        quantra::enums::Interpolator_LogLinear,
+        quantra::enums::BootstrapTrait_Discount,
+        &pts, "2026-06-11");
+    fbb.Finish(ts);
+    return flatbuffers::GetRoot<quantra::TermStructure>(fbb.GetBufferPointer());
+}
+
+// Curve with a single SwapHelper whose float leg references the given index
+// id.
+const quantra::TermStructure* buildSwapCurve(
+    flatbuffers::FlatBufferBuilder& fbb, const char* indexId)
+{
+    auto idx = quantra::CreateIndexRefDirect(fbb, indexId);
+    auto helper = quantra::CreateSwapHelperDirect(
+        fbb, /*rate=*/0.02, /*tenor=*/0,
+        quantra::enums::Calendar_TARGET,
+        quantra::enums::Frequency_Annual,
+        quantra::enums::BusinessDayConvention_ModifiedFollowing,
+        quantra::enums::DayCounter_Actual360,
+        idx);
+    auto pw = quantra::CreatePointsWrapper(
+        fbb, quantra::Point_SwapHelper, helper.Union());
+    std::vector<flatbuffers::Offset<quantra::PointsWrapper>> pts{pw};
+    auto ts = quantra::CreateTermStructureDirect(
+        fbb, "curve-index-ref",
+        quantra::enums::DayCounter_Actual360,
+        quantra::enums::Interpolator_LogLinear,
+        quantra::enums::BootstrapTrait_Discount,
+        &pts, "2026-06-11");
+    fbb.Finish(ts);
+    return flatbuffers::GetRoot<quantra::TermStructure>(fbb.GetBufferPointer());
+}
+
+// A quote_id the request does not define must throw (fail closed -> curve
+// left uncached), never fall back to the inline value: pre-fix, both curves
+// below produced the SAME key as an inline-only curve with that rate, so a
+// warm cache could answer a request the parser rejects.
+TEST(CurveCacheKeyUnresolvableRef, UnknownQuoteIdFailsClosed) {
+    flatbuffers::FlatBufferBuilder fbb;
+    const auto* ts = buildDepositCurve(fbb, 0.0096, "no-such-quote");
+
+    KeyContext ctx;  // empty: the id resolves to nothing
+    EXPECT_THROW(CurveKeyBuilder::compute("2026-06-11", ts, ctx, {}),
+                 QuantraError);
+}
+
+// Same shape, but the quote resolves — key building must succeed, and the
+// key must track the RESOLVED value (two different quote values, identical
+// inline values, must not collide).
+TEST(CurveCacheKeyUnresolvableRef, ResolvedQuoteIdStillKeyable) {
+    flatbuffers::FlatBufferBuilder f1, f2;
+    const auto* ts1 = buildDepositCurve(f1, 0.0096, "depo-3m");
+    const auto* ts2 = buildDepositCurve(f2, 0.0096, "depo-3m");
+
+    KeyContext lo, hi;
+    lo.quoteValues["depo-3m"] = 0.01;
+    hi.quoteValues["depo-3m"] = 0.05;
+
+    std::string k1 = CurveKeyBuilder::compute("2026-06-11", ts1, lo, {});
+    std::string k2 = CurveKeyBuilder::compute("2026-06-11", ts2, hi, {});
+    EXPECT_EQ(k1.rfind("yc:v2:", 0), 0u);
+    EXPECT_EQ(k2.rfind("yc:v2:", 0), 0u);
+    EXPECT_NE(k1, k2);
+}
+
+// No quote_id at all: the inline value is authoritative, exactly as before.
+TEST(CurveCacheKeyUnresolvableRef, InlineValueWithoutQuoteIdStillKeyable) {
+    flatbuffers::FlatBufferBuilder fbb;
+    const auto* ts = buildDepositCurve(fbb, 0.0096, nullptr);
+
+    KeyContext ctx;
+    std::string key = CurveKeyBuilder::compute("2026-06-11", ts, ctx, {});
+    EXPECT_EQ(key.rfind("yc:v2:", 0), 0u);
+}
+
+// A referenced index with no definition must throw (fail closed -> curve
+// left uncached), never be silently dropped from the key.
+TEST(CurveCacheKeyUnresolvableRef, MissingIndexDefinitionFailsClosed) {
+    flatbuffers::FlatBufferBuilder fbb;
+    const auto* ts = buildSwapCurve(fbb, "no-such-index");
+
+    KeyContext ctx;  // empty: the index id resolves to nothing
+    EXPECT_THROW(CurveKeyBuilder::compute("2026-06-11", ts, ctx, {}),
+                 QuantraError);
+}
+
+// Same shape, but the index definition exists — key building must succeed.
+TEST(CurveCacheKeyUnresolvableRef, DefinedIndexStillKeyable) {
+    flatbuffers::FlatBufferBuilder tsFbb, idxFbb;
+    const auto* ts = buildSwapCurve(tsFbb, "euribor-6m");
+
+    auto def = quantra::CreateIndexDefDirect(idxFbb, "euribor-6m", "Euribor6M");
+    idxFbb.Finish(def);
+    const auto* defRoot =
+        flatbuffers::GetRoot<quantra::IndexDef>(idxFbb.GetBufferPointer());
+
+    KeyContext ctx;
+    ctx.indexDefs["euribor-6m"] = defRoot;
+
+    std::string key = CurveKeyBuilder::compute("2026-06-11", ts, ctx, {});
+    EXPECT_EQ(key.rfind("yc:v2:", 0), 0u);
+}
+
+} // namespace
+} // namespace testing
+} // namespace quantra


### PR DESCRIPTION
Two spots in the yield-curve cache-key builder silently tolerated an unresolvable reference, which could under-key a curve and (with caching on) serve a cached price where a fresh request would error.

- A helper `quote_id` that does not resolve to a curve quote used to fall back to the inline value, so a request the parser rejects could hash to the same key as a valid inline-value request. It now fails closed.
- A referenced index id with no definition used to be dropped from the key entirely (two curves differing only in that index would collide). It now fails closed too.

Both throws are caught by the bootstrapper as *leave this curve uncached* (bootstrap live and continue) — they never fail an otherwise valid request; the parser still reports the real error.

+6 tests, including a cache-on transparency case proving a bogus quote id is not masked by a warm cache. Full suite green in Docker (345 cases). No `.fbs`/wire change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
