### PR TITLE
Fix swaption diagnostics serializing period units through the wrong enum

### DIFF
--- a/src/common/enum_convert.cpp
+++ b/src/common/enum_convert.cpp
@@ -506,6 +506,10 @@ quantra::enums::EquitySettlementType EquitySettlementTypeToFb(QuantLib::Settleme
 
 quantra::enums::TimeUnit TimeUnitToFb(QuantLib::TimeUnit timeUnit)
 {
+    // The schema's enums::TimeUnit is ALPHABETICAL and does NOT share
+    // QuantLib's enum order, so every unit must be mapped explicitly here
+    // (a raw cast mislabels everything but Days). Fail closed on anything
+    // unexpected, matching the other converters.
     switch (timeUnit)
     {
     case QuantLib::Days:
@@ -516,9 +520,19 @@ quantra::enums::TimeUnit TimeUnitToFb(QuantLib::TimeUnit timeUnit)
         return quantra::enums::TimeUnit_Months;
     case QuantLib::Years:
         return quantra::enums::TimeUnit_Years;
-    default:
-        return quantra::enums::TimeUnit_Days;
+    case QuantLib::Hours:
+        return quantra::enums::TimeUnit_Hours;
+    case QuantLib::Minutes:
+        return quantra::enums::TimeUnit_Minutes;
+    case QuantLib::Seconds:
+        return quantra::enums::TimeUnit_Seconds;
+    case QuantLib::Milliseconds:
+        return quantra::enums::TimeUnit_Milliseconds;
+    case QuantLib::Microseconds:
+        return quantra::enums::TimeUnit_Microseconds;
     }
+
+    QUANTRA_ERROR("Time Unit not found");
 }
 
 quantra::enums::VolatilityType VolatilityTypeToFb(QuantLib::VolatilityType type, double displacement)

--- a/src/market/swaption_vol_diagnostics.cpp
+++ b/src/market/swaption_vol_diagnostics.cpp
@@ -9,6 +9,7 @@
 #include <ql/termstructures/volatility/sabrsmilesection.hpp>
 
 #include "common_generated.h"
+#include "enum_convert.h"
 
 namespace quantra {
 
@@ -53,10 +54,10 @@ std::string endCriteriaName(int endCriteria) {
 
 flatbuffers::Offset<quantra::Period> writePeriod(
     flatbuffers::FlatBufferBuilder& fbb, const QuantLib::Period& p) {
-    // The schema's enums::TimeUnit follows QuantLib's enum order; static_cast
-    // is acceptable here (Days=0..Years=4).
-    return quantra::CreatePeriod(
-        fbb, p.length(), static_cast<quantra::enums::TimeUnit>(p.units()));
+    // The schema's enums::TimeUnit is alphabetical and does NOT match
+    // QuantLib's enum order, so the unit must be mapped explicitly (a raw
+    // cast mislabels everything but Days).
+    return quantra::CreatePeriod(fbb, p.length(), TimeUnitToFb(p.units()));
 }
 
 std::vector<flatbuffers::Offset<quantra::Period>> writePeriods(

--- a/tests/contract/swaption_vol_diagnostics_test.py
+++ b/tests/contract/swaption_vol_diagnostics_test.py
@@ -1,0 +1,33 @@
+"""Swaption vol diagnostics period-unit serialization.
+
+Regression guard: the diagnostics builder used to cast a QuantLib TimeUnit
+straight into the schema's TimeUnit enum. Those two enums do NOT share an
+ordering (the schema enum is alphabetical), so a 1-Year expiry came back
+labelled "Milliseconds". This drives /calibrate-swaption-vol with a known
+1Y/2Y x 5Y/10Y expiry/tenor grid and asserts the returned Period units read
+"Years" (never "Milliseconds").
+"""
+
+from ql_reference import load_json
+
+
+def _units(periods):
+    return [p.get("unit") for p in periods]
+
+
+def test_diagnostics_period_units_are_years(client, data_dir):
+    request = load_json(data_dir / "vol" / "sabrcal_eur_2x2_5strike_roundtrip.json")
+    response = client.price("calibrate_swaption_vol", request)
+
+    diagnostics = response["diagnostics"]
+    expiry_units = _units(diagnostics["expiries"])
+    tenor_units = _units(diagnostics["tenors"])
+
+    # Grid is [1Y, 2Y] expiries x [5Y, 10Y] tenors.
+    assert expiry_units == ["Years", "Years"], (
+        f"expiry units mislabelled: {expiry_units}"
+    )
+    assert tenor_units == ["Years", "Years"], (
+        f"tenor units mislabelled: {tenor_units}"
+    )
+    assert "Milliseconds" not in expiry_units + tenor_units


### PR DESCRIPTION
Fixes a diagnostics serialization bug surfaced by the parity suite: `SwaptionVolDiagnostics.expiries/tenors` reported the wrong time unit — `writePeriod` cast a QuantLib `TimeUnit` straight into the schema’s `enums::TimeUnit`, but the schema enum is **alphabetical** and does not share QuantLib’s order, so a 1-Year expiry came back as `{"n":1,"unit":"Milliseconds"}`. Affects `/calibrate-swaption-vol` and the diagnostics on `/sample-vol-surfaces` and `/price-swaption`.

Completed the existing `TimeUnitToFb` converter (it covered only Days/Weeks/Months/Years and silently defaulted the rest to Days) to map every unit and fail closed, and used it in `writePeriod`. Grep confirmed this was the only raw TimeUnit-to-schema cast.

+1 contract test asserting the period units come back as `"Years"` (never `"Milliseconds"`). Full suite green in Docker (479 cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
