### PR TITLE
Require an explicit quote on all curve helpers (schema v3, step 1)

### DIFF
--- a/flatbuffers/cpp/term_structure_generated.h
+++ b/flatbuffers/cpp/term_structure_generated.h
@@ -539,7 +539,7 @@ inline ::flatbuffers::Offset<HelperDependencies> CreateHelperDependenciesDirect(
 
 struct DepositHelperT : public ::flatbuffers::NativeTable {
   typedef DepositHelper TableType;
-  double rate = 0.0;
+  ::flatbuffers::Optional<double> rate = ::flatbuffers::nullopt;
   std::unique_ptr<quantra::PeriodT> tenor{};
   int32_t fixing_days = 0;
   quantra::enums::Calendar calendar = quantra::enums::Calendar_Argentina;
@@ -565,8 +565,9 @@ struct DepositHelper FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
     VT_DAY_COUNTER = 14,
     VT_QUOTE_ID = 16
   };
-  double rate() const {
-    return GetField<double>(VT_RATE, 0.0);
+  /// Deposit rate. One of rate or quote_id must be provided.
+  ::flatbuffers::Optional<double> rate() const {
+    return GetOptional<double, double>(VT_RATE);
   }
   const quantra::Period *tenor() const {
     return GetPointer<const quantra::Period *>(VT_TENOR);
@@ -610,7 +611,7 @@ struct DepositHelperBuilder {
   ::flatbuffers::FlatBufferBuilder &fbb_;
   ::flatbuffers::uoffset_t start_;
   void add_rate(double rate) {
-    fbb_.AddElement<double>(DepositHelper::VT_RATE, rate, 0.0);
+    fbb_.AddElement<double>(DepositHelper::VT_RATE, rate);
   }
   void add_tenor(::flatbuffers::Offset<quantra::Period> tenor) {
     fbb_.AddOffset(DepositHelper::VT_TENOR, tenor);
@@ -643,7 +644,7 @@ struct DepositHelperBuilder {
 
 inline ::flatbuffers::Offset<DepositHelper> CreateDepositHelper(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    double rate = 0.0,
+    ::flatbuffers::Optional<double> rate = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::Period> tenor = 0,
     int32_t fixing_days = 0,
     quantra::enums::Calendar calendar = quantra::enums::Calendar_Argentina,
@@ -651,7 +652,7 @@ inline ::flatbuffers::Offset<DepositHelper> CreateDepositHelper(
     quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360,
     ::flatbuffers::Offset<::flatbuffers::String> quote_id = 0) {
   DepositHelperBuilder builder_(_fbb);
-  builder_.add_rate(rate);
+  if(rate) { builder_.add_rate(*rate); }
   builder_.add_quote_id(quote_id);
   builder_.add_fixing_days(fixing_days);
   builder_.add_tenor(tenor);
@@ -663,7 +664,7 @@ inline ::flatbuffers::Offset<DepositHelper> CreateDepositHelper(
 
 inline ::flatbuffers::Offset<DepositHelper> CreateDepositHelperDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    double rate = 0.0,
+    ::flatbuffers::Optional<double> rate = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::Period> tenor = 0,
     int32_t fixing_days = 0,
     quantra::enums::Calendar calendar = quantra::enums::Calendar_Argentina,
@@ -686,7 +687,7 @@ inline ::flatbuffers::Offset<DepositHelper> CreateDepositHelperDirect(
 
 struct FRAHelperT : public ::flatbuffers::NativeTable {
   typedef FRAHelper TableType;
-  double rate = 0.0;
+  ::flatbuffers::Optional<double> rate = ::flatbuffers::nullopt;
   int32_t months_to_start = 0;
   int32_t months_to_end = 0;
   int32_t fixing_days = 0;
@@ -710,8 +711,9 @@ struct FRAHelper FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
     VT_DAY_COUNTER = 16,
     VT_QUOTE_ID = 18
   };
-  double rate() const {
-    return GetField<double>(VT_RATE, 0.0);
+  /// FRA rate. One of rate or quote_id must be provided.
+  ::flatbuffers::Optional<double> rate() const {
+    return GetOptional<double, double>(VT_RATE);
   }
   int32_t months_to_start() const {
     return GetField<int32_t>(VT_MONTHS_TO_START, 0);
@@ -757,7 +759,7 @@ struct FRAHelperBuilder {
   ::flatbuffers::FlatBufferBuilder &fbb_;
   ::flatbuffers::uoffset_t start_;
   void add_rate(double rate) {
-    fbb_.AddElement<double>(FRAHelper::VT_RATE, rate, 0.0);
+    fbb_.AddElement<double>(FRAHelper::VT_RATE, rate);
   }
   void add_months_to_start(int32_t months_to_start) {
     fbb_.AddElement<int32_t>(FRAHelper::VT_MONTHS_TO_START, months_to_start, 0);
@@ -793,7 +795,7 @@ struct FRAHelperBuilder {
 
 inline ::flatbuffers::Offset<FRAHelper> CreateFRAHelper(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    double rate = 0.0,
+    ::flatbuffers::Optional<double> rate = ::flatbuffers::nullopt,
     int32_t months_to_start = 0,
     int32_t months_to_end = 0,
     int32_t fixing_days = 0,
@@ -802,7 +804,7 @@ inline ::flatbuffers::Offset<FRAHelper> CreateFRAHelper(
     quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360,
     ::flatbuffers::Offset<::flatbuffers::String> quote_id = 0) {
   FRAHelperBuilder builder_(_fbb);
-  builder_.add_rate(rate);
+  if(rate) { builder_.add_rate(*rate); }
   builder_.add_quote_id(quote_id);
   builder_.add_fixing_days(fixing_days);
   builder_.add_months_to_end(months_to_end);
@@ -815,7 +817,7 @@ inline ::flatbuffers::Offset<FRAHelper> CreateFRAHelper(
 
 inline ::flatbuffers::Offset<FRAHelper> CreateFRAHelperDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    double rate = 0.0,
+    ::flatbuffers::Optional<double> rate = ::flatbuffers::nullopt,
     int32_t months_to_start = 0,
     int32_t months_to_end = 0,
     int32_t fixing_days = 0,
@@ -1013,7 +1015,7 @@ inline ::flatbuffers::Offset<FutureHelper> CreateFutureHelperDirect(
 
 struct SwapHelperT : public ::flatbuffers::NativeTable {
   typedef SwapHelper TableType;
-  double rate = 0.0;
+  ::flatbuffers::Optional<double> rate = ::flatbuffers::nullopt;
   std::unique_ptr<quantra::PeriodT> tenor{};
   quantra::enums::Calendar calendar = quantra::enums::Calendar_Argentina;
   quantra::enums::Frequency sw_fixed_leg_frequency = quantra::enums::Frequency_Annual;
@@ -1047,8 +1049,9 @@ struct SwapHelper FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
     VT_DEPS = 22,
     VT_QUOTE_ID = 24
   };
-  double rate() const {
-    return GetField<double>(VT_RATE, 0.0);
+  /// Swap rate. One of rate or quote_id must be provided.
+  ::flatbuffers::Optional<double> rate() const {
+    return GetOptional<double, double>(VT_RATE);
   }
   const quantra::Period *tenor() const {
     return GetPointer<const quantra::Period *>(VT_TENOR);
@@ -1111,7 +1114,7 @@ struct SwapHelperBuilder {
   ::flatbuffers::FlatBufferBuilder &fbb_;
   ::flatbuffers::uoffset_t start_;
   void add_rate(double rate) {
-    fbb_.AddElement<double>(SwapHelper::VT_RATE, rate, 0.0);
+    fbb_.AddElement<double>(SwapHelper::VT_RATE, rate);
   }
   void add_tenor(::flatbuffers::Offset<quantra::Period> tenor) {
     fbb_.AddOffset(SwapHelper::VT_TENOR, tenor);
@@ -1157,7 +1160,7 @@ struct SwapHelperBuilder {
 
 inline ::flatbuffers::Offset<SwapHelper> CreateSwapHelper(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    double rate = 0.0,
+    ::flatbuffers::Optional<double> rate = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::Period> tenor = 0,
     quantra::enums::Calendar calendar = quantra::enums::Calendar_Argentina,
     quantra::enums::Frequency sw_fixed_leg_frequency = quantra::enums::Frequency_Annual,
@@ -1170,7 +1173,7 @@ inline ::flatbuffers::Offset<SwapHelper> CreateSwapHelper(
     ::flatbuffers::Offset<::flatbuffers::String> quote_id = 0) {
   SwapHelperBuilder builder_(_fbb);
   builder_.add_spread(spread);
-  builder_.add_rate(rate);
+  if(rate) { builder_.add_rate(*rate); }
   builder_.add_quote_id(quote_id);
   builder_.add_deps(deps);
   builder_.add_fwd_start_days(fwd_start_days);
@@ -1185,7 +1188,7 @@ inline ::flatbuffers::Offset<SwapHelper> CreateSwapHelper(
 
 inline ::flatbuffers::Offset<SwapHelper> CreateSwapHelperDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    double rate = 0.0,
+    ::flatbuffers::Optional<double> rate = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::Period> tenor = 0,
     quantra::enums::Calendar calendar = quantra::enums::Calendar_Argentina,
     quantra::enums::Frequency sw_fixed_leg_frequency = quantra::enums::Frequency_Annual,
@@ -1419,7 +1422,7 @@ inline ::flatbuffers::Offset<BondHelper> CreateBondHelperDirect(
 
 struct OISHelperT : public ::flatbuffers::NativeTable {
   typedef OISHelper TableType;
-  double rate = 0.0;
+  ::flatbuffers::Optional<double> rate = ::flatbuffers::nullopt;
   std::unique_ptr<quantra::PeriodT> tenor{};
   std::unique_ptr<quantra::IndexRefT> overnight_index{};
   int32_t settlement_days = 2;
@@ -1451,8 +1454,9 @@ struct OISHelper FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
     VT_DEPS = 20,
     VT_QUOTE_ID = 22
   };
-  double rate() const {
-    return GetField<double>(VT_RATE, 0.0);
+  /// OIS rate. One of rate or quote_id must be provided.
+  ::flatbuffers::Optional<double> rate() const {
+    return GetOptional<double, double>(VT_RATE);
   }
   const quantra::Period *tenor() const {
     return GetPointer<const quantra::Period *>(VT_TENOR);
@@ -1511,7 +1515,7 @@ struct OISHelperBuilder {
   ::flatbuffers::FlatBufferBuilder &fbb_;
   ::flatbuffers::uoffset_t start_;
   void add_rate(double rate) {
-    fbb_.AddElement<double>(OISHelper::VT_RATE, rate, 0.0);
+    fbb_.AddElement<double>(OISHelper::VT_RATE, rate);
   }
   void add_tenor(::flatbuffers::Offset<quantra::Period> tenor) {
     fbb_.AddOffset(OISHelper::VT_TENOR, tenor);
@@ -1554,7 +1558,7 @@ struct OISHelperBuilder {
 
 inline ::flatbuffers::Offset<OISHelper> CreateOISHelper(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    double rate = 0.0,
+    ::flatbuffers::Optional<double> rate = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::Period> tenor = 0,
     ::flatbuffers::Offset<quantra::IndexRef> overnight_index = 0,
     int32_t settlement_days = 2,
@@ -1565,7 +1569,7 @@ inline ::flatbuffers::Offset<OISHelper> CreateOISHelper(
     ::flatbuffers::Offset<quantra::HelperDependencies> deps = 0,
     ::flatbuffers::Offset<::flatbuffers::String> quote_id = 0) {
   OISHelperBuilder builder_(_fbb);
-  builder_.add_rate(rate);
+  if(rate) { builder_.add_rate(*rate); }
   builder_.add_quote_id(quote_id);
   builder_.add_deps(deps);
   builder_.add_settlement_days(settlement_days);
@@ -1580,7 +1584,7 @@ inline ::flatbuffers::Offset<OISHelper> CreateOISHelper(
 
 inline ::flatbuffers::Offset<OISHelper> CreateOISHelperDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    double rate = 0.0,
+    ::flatbuffers::Optional<double> rate = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::Period> tenor = 0,
     ::flatbuffers::Offset<quantra::IndexRef> overnight_index = 0,
     int32_t settlement_days = 2,
@@ -1609,7 +1613,7 @@ inline ::flatbuffers::Offset<OISHelper> CreateOISHelperDirect(
 
 struct DatedOISHelperT : public ::flatbuffers::NativeTable {
   typedef DatedOISHelper TableType;
-  double rate = 0.0;
+  ::flatbuffers::Optional<double> rate = ::flatbuffers::nullopt;
   std::string start_date{};
   std::string end_date{};
   std::unique_ptr<quantra::IndexRefT> overnight_index{};
@@ -1641,8 +1645,9 @@ struct DatedOISHelper FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
     VT_DEPS = 20,
     VT_QUOTE_ID = 22
   };
-  double rate() const {
-    return GetField<double>(VT_RATE, 0.0);
+  /// OIS rate. One of rate or quote_id must be provided.
+  ::flatbuffers::Optional<double> rate() const {
+    return GetOptional<double, double>(VT_RATE);
   }
   const ::flatbuffers::String *start_date() const {
     return GetPointer<const ::flatbuffers::String *>(VT_START_DATE);
@@ -1702,7 +1707,7 @@ struct DatedOISHelperBuilder {
   ::flatbuffers::FlatBufferBuilder &fbb_;
   ::flatbuffers::uoffset_t start_;
   void add_rate(double rate) {
-    fbb_.AddElement<double>(DatedOISHelper::VT_RATE, rate, 0.0);
+    fbb_.AddElement<double>(DatedOISHelper::VT_RATE, rate);
   }
   void add_start_date(::flatbuffers::Offset<::flatbuffers::String> start_date) {
     fbb_.AddOffset(DatedOISHelper::VT_START_DATE, start_date);
@@ -1747,7 +1752,7 @@ struct DatedOISHelperBuilder {
 
 inline ::flatbuffers::Offset<DatedOISHelper> CreateDatedOISHelper(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    double rate = 0.0,
+    ::flatbuffers::Optional<double> rate = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<::flatbuffers::String> start_date = 0,
     ::flatbuffers::Offset<::flatbuffers::String> end_date = 0,
     ::flatbuffers::Offset<quantra::IndexRef> overnight_index = 0,
@@ -1758,7 +1763,7 @@ inline ::flatbuffers::Offset<DatedOISHelper> CreateDatedOISHelper(
     ::flatbuffers::Offset<quantra::HelperDependencies> deps = 0,
     ::flatbuffers::Offset<::flatbuffers::String> quote_id = 0) {
   DatedOISHelperBuilder builder_(_fbb);
-  builder_.add_rate(rate);
+  if(rate) { builder_.add_rate(*rate); }
   builder_.add_quote_id(quote_id);
   builder_.add_deps(deps);
   builder_.add_settlement_days(settlement_days);
@@ -1773,7 +1778,7 @@ inline ::flatbuffers::Offset<DatedOISHelper> CreateDatedOISHelper(
 
 inline ::flatbuffers::Offset<DatedOISHelper> CreateDatedOISHelperDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    double rate = 0.0,
+    ::flatbuffers::Optional<double> rate = ::flatbuffers::nullopt,
     const char *start_date = nullptr,
     const char *end_date = nullptr,
     ::flatbuffers::Offset<quantra::IndexRef> overnight_index = 0,
@@ -1808,7 +1813,7 @@ struct ZeroRatePointT : public ::flatbuffers::NativeTable {
   std::unique_ptr<quantra::PeriodT> tenor{};
   quantra::enums::Calendar calendar = quantra::enums::Calendar_TARGET;
   quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_ModifiedFollowing;
-  double zero_rate = 0.0;
+  ::flatbuffers::Optional<double> zero_rate = ::flatbuffers::nullopt;
   quantra::enums::Compounding compounding = quantra::enums::Compounding_Continuous;
   quantra::enums::Frequency frequency = quantra::enums::Frequency_Annual;
   ZeroRatePointT() = default;
@@ -1844,9 +1849,9 @@ struct ZeroRatePoint FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   quantra::enums::BusinessDayConvention business_day_convention() const {
     return static_cast<quantra::enums::BusinessDayConvention>(GetField<int8_t>(VT_BUSINESS_DAY_CONVENTION, 2));
   }
-  /// Zero rate for this maturity.
-  double zero_rate() const {
-    return GetField<double>(VT_ZERO_RATE, 0.0);
+  /// Zero rate for this maturity. Required.
+  ::flatbuffers::Optional<double> zero_rate() const {
+    return GetOptional<double, double>(VT_ZERO_RATE);
   }
   /// Compounding convention for the zero rate.
   quantra::enums::Compounding compounding() const {
@@ -1891,7 +1896,7 @@ struct ZeroRatePointBuilder {
     fbb_.AddElement<int8_t>(ZeroRatePoint::VT_BUSINESS_DAY_CONVENTION, static_cast<int8_t>(business_day_convention), 2);
   }
   void add_zero_rate(double zero_rate) {
-    fbb_.AddElement<double>(ZeroRatePoint::VT_ZERO_RATE, zero_rate, 0.0);
+    fbb_.AddElement<double>(ZeroRatePoint::VT_ZERO_RATE, zero_rate);
   }
   void add_compounding(quantra::enums::Compounding compounding) {
     fbb_.AddElement<int8_t>(ZeroRatePoint::VT_COMPOUNDING, static_cast<int8_t>(compounding), 1);
@@ -1916,11 +1921,11 @@ inline ::flatbuffers::Offset<ZeroRatePoint> CreateZeroRatePoint(
     ::flatbuffers::Offset<quantra::Period> tenor = 0,
     quantra::enums::Calendar calendar = quantra::enums::Calendar_TARGET,
     quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_ModifiedFollowing,
-    double zero_rate = 0.0,
+    ::flatbuffers::Optional<double> zero_rate = ::flatbuffers::nullopt,
     quantra::enums::Compounding compounding = quantra::enums::Compounding_Continuous,
     quantra::enums::Frequency frequency = quantra::enums::Frequency_Annual) {
   ZeroRatePointBuilder builder_(_fbb);
-  builder_.add_zero_rate(zero_rate);
+  if(zero_rate) { builder_.add_zero_rate(*zero_rate); }
   builder_.add_tenor(tenor);
   builder_.add_date(date);
   builder_.add_frequency(frequency);
@@ -1936,7 +1941,7 @@ inline ::flatbuffers::Offset<ZeroRatePoint> CreateZeroRatePointDirect(
     ::flatbuffers::Offset<quantra::Period> tenor = 0,
     quantra::enums::Calendar calendar = quantra::enums::Calendar_TARGET,
     quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_ModifiedFollowing,
-    double zero_rate = 0.0,
+    ::flatbuffers::Optional<double> zero_rate = ::flatbuffers::nullopt,
     quantra::enums::Compounding compounding = quantra::enums::Compounding_Continuous,
     quantra::enums::Frequency frequency = quantra::enums::Frequency_Annual) {
   auto date__ = date ? _fbb.CreateString(date) : 0;
@@ -1955,7 +1960,7 @@ inline ::flatbuffers::Offset<ZeroRatePoint> CreateZeroRatePointDirect(
 
 struct TenorBasisSwapHelperT : public ::flatbuffers::NativeTable {
   typedef TenorBasisSwapHelper TableType;
-  double spread = 0.0;
+  ::flatbuffers::Optional<double> spread = ::flatbuffers::nullopt;
   std::unique_ptr<quantra::PeriodT> tenor{};
   std::unique_ptr<quantra::IndexRefT> index_short{};
   std::unique_ptr<quantra::IndexRefT> index_long{};
@@ -1981,8 +1986,9 @@ struct TenorBasisSwapHelper FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Tab
     VT_DEPS = 14,
     VT_QUOTE_ID = 16
   };
-  double spread() const {
-    return GetField<double>(VT_SPREAD, 0.0);
+  /// Basis spread. One of spread or quote_id must be provided.
+  ::flatbuffers::Optional<double> spread() const {
+    return GetOptional<double, double>(VT_SPREAD);
   }
   const quantra::Period *tenor() const {
     return GetPointer<const quantra::Period *>(VT_TENOR);
@@ -2030,7 +2036,7 @@ struct TenorBasisSwapHelperBuilder {
   ::flatbuffers::FlatBufferBuilder &fbb_;
   ::flatbuffers::uoffset_t start_;
   void add_spread(double spread) {
-    fbb_.AddElement<double>(TenorBasisSwapHelper::VT_SPREAD, spread, 0.0);
+    fbb_.AddElement<double>(TenorBasisSwapHelper::VT_SPREAD, spread);
   }
   void add_tenor(::flatbuffers::Offset<quantra::Period> tenor) {
     fbb_.AddOffset(TenorBasisSwapHelper::VT_TENOR, tenor);
@@ -2065,7 +2071,7 @@ struct TenorBasisSwapHelperBuilder {
 
 inline ::flatbuffers::Offset<TenorBasisSwapHelper> CreateTenorBasisSwapHelper(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    double spread = 0.0,
+    ::flatbuffers::Optional<double> spread = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::Period> tenor = 0,
     ::flatbuffers::Offset<quantra::IndexRef> index_short = 0,
     ::flatbuffers::Offset<quantra::IndexRef> index_long = 0,
@@ -2073,7 +2079,7 @@ inline ::flatbuffers::Offset<TenorBasisSwapHelper> CreateTenorBasisSwapHelper(
     ::flatbuffers::Offset<quantra::HelperDependencies> deps = 0,
     ::flatbuffers::Offset<::flatbuffers::String> quote_id = 0) {
   TenorBasisSwapHelperBuilder builder_(_fbb);
-  builder_.add_spread(spread);
+  if(spread) { builder_.add_spread(*spread); }
   builder_.add_quote_id(quote_id);
   builder_.add_deps(deps);
   builder_.add_index_long(index_long);
@@ -2085,7 +2091,7 @@ inline ::flatbuffers::Offset<TenorBasisSwapHelper> CreateTenorBasisSwapHelper(
 
 inline ::flatbuffers::Offset<TenorBasisSwapHelper> CreateTenorBasisSwapHelperDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    double spread = 0.0,
+    ::flatbuffers::Optional<double> spread = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::Period> tenor = 0,
     ::flatbuffers::Offset<quantra::IndexRef> index_short = 0,
     ::flatbuffers::Offset<quantra::IndexRef> index_long = 0,
@@ -2108,7 +2114,7 @@ inline ::flatbuffers::Offset<TenorBasisSwapHelper> CreateTenorBasisSwapHelperDir
 
 struct FxSwapHelperT : public ::flatbuffers::NativeTable {
   typedef FxSwapHelper TableType;
-  double fx_points = 0.0;
+  ::flatbuffers::Optional<double> fx_points = ::flatbuffers::nullopt;
   std::unique_ptr<quantra::PeriodT> tenor{};
   int32_t spot_days = 2;
   quantra::enums::Calendar calendar_domestic = quantra::enums::Calendar_TARGET;
@@ -2134,8 +2140,9 @@ struct FxSwapHelper FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
     VT_DEPS = 14,
     VT_QUOTE_ID = 16
   };
-  double fx_points() const {
-    return GetField<double>(VT_FX_POINTS, 0.0);
+  /// FX forward points. One of fx_points or quote_id must be provided.
+  ::flatbuffers::Optional<double> fx_points() const {
+    return GetOptional<double, double>(VT_FX_POINTS);
   }
   const quantra::Period *tenor() const {
     return GetPointer<const quantra::Period *>(VT_TENOR);
@@ -2179,7 +2186,7 @@ struct FxSwapHelperBuilder {
   ::flatbuffers::FlatBufferBuilder &fbb_;
   ::flatbuffers::uoffset_t start_;
   void add_fx_points(double fx_points) {
-    fbb_.AddElement<double>(FxSwapHelper::VT_FX_POINTS, fx_points, 0.0);
+    fbb_.AddElement<double>(FxSwapHelper::VT_FX_POINTS, fx_points);
   }
   void add_tenor(::flatbuffers::Offset<quantra::Period> tenor) {
     fbb_.AddOffset(FxSwapHelper::VT_TENOR, tenor);
@@ -2212,7 +2219,7 @@ struct FxSwapHelperBuilder {
 
 inline ::flatbuffers::Offset<FxSwapHelper> CreateFxSwapHelper(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    double fx_points = 0.0,
+    ::flatbuffers::Optional<double> fx_points = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::Period> tenor = 0,
     int32_t spot_days = 2,
     quantra::enums::Calendar calendar_domestic = quantra::enums::Calendar_TARGET,
@@ -2220,7 +2227,7 @@ inline ::flatbuffers::Offset<FxSwapHelper> CreateFxSwapHelper(
     ::flatbuffers::Offset<quantra::HelperDependencies> deps = 0,
     ::flatbuffers::Offset<::flatbuffers::String> quote_id = 0) {
   FxSwapHelperBuilder builder_(_fbb);
-  builder_.add_fx_points(fx_points);
+  if(fx_points) { builder_.add_fx_points(*fx_points); }
   builder_.add_quote_id(quote_id);
   builder_.add_deps(deps);
   builder_.add_spot_days(spot_days);
@@ -2232,7 +2239,7 @@ inline ::flatbuffers::Offset<FxSwapHelper> CreateFxSwapHelper(
 
 inline ::flatbuffers::Offset<FxSwapHelper> CreateFxSwapHelperDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    double fx_points = 0.0,
+    ::flatbuffers::Optional<double> fx_points = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::Period> tenor = 0,
     int32_t spot_days = 2,
     quantra::enums::Calendar calendar_domestic = quantra::enums::Calendar_TARGET,
@@ -2255,7 +2262,7 @@ inline ::flatbuffers::Offset<FxSwapHelper> CreateFxSwapHelperDirect(
 
 struct CrossCcyBasisHelperT : public ::flatbuffers::NativeTable {
   typedef CrossCcyBasisHelper TableType;
-  double spread = 0.0;
+  ::flatbuffers::Optional<double> spread = ::flatbuffers::nullopt;
   std::unique_ptr<quantra::PeriodT> tenor{};
   std::unique_ptr<quantra::IndexRefT> index_domestic{};
   std::unique_ptr<quantra::IndexRefT> index_foreign{};
@@ -2279,8 +2286,9 @@ struct CrossCcyBasisHelper FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Tabl
     VT_DEPS = 12,
     VT_QUOTE_ID = 14
   };
-  double spread() const {
-    return GetField<double>(VT_SPREAD, 0.0);
+  /// Cross-currency basis spread. One of spread or quote_id must be provided.
+  ::flatbuffers::Optional<double> spread() const {
+    return GetOptional<double, double>(VT_SPREAD);
   }
   const quantra::Period *tenor() const {
     return GetPointer<const quantra::Period *>(VT_TENOR);
@@ -2324,7 +2332,7 @@ struct CrossCcyBasisHelperBuilder {
   ::flatbuffers::FlatBufferBuilder &fbb_;
   ::flatbuffers::uoffset_t start_;
   void add_spread(double spread) {
-    fbb_.AddElement<double>(CrossCcyBasisHelper::VT_SPREAD, spread, 0.0);
+    fbb_.AddElement<double>(CrossCcyBasisHelper::VT_SPREAD, spread);
   }
   void add_tenor(::flatbuffers::Offset<quantra::Period> tenor) {
     fbb_.AddOffset(CrossCcyBasisHelper::VT_TENOR, tenor);
@@ -2356,14 +2364,14 @@ struct CrossCcyBasisHelperBuilder {
 
 inline ::flatbuffers::Offset<CrossCcyBasisHelper> CreateCrossCcyBasisHelper(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    double spread = 0.0,
+    ::flatbuffers::Optional<double> spread = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::Period> tenor = 0,
     ::flatbuffers::Offset<quantra::IndexRef> index_domestic = 0,
     ::flatbuffers::Offset<quantra::IndexRef> index_foreign = 0,
     ::flatbuffers::Offset<quantra::HelperDependencies> deps = 0,
     ::flatbuffers::Offset<::flatbuffers::String> quote_id = 0) {
   CrossCcyBasisHelperBuilder builder_(_fbb);
-  builder_.add_spread(spread);
+  if(spread) { builder_.add_spread(*spread); }
   builder_.add_quote_id(quote_id);
   builder_.add_deps(deps);
   builder_.add_index_foreign(index_foreign);
@@ -2374,7 +2382,7 @@ inline ::flatbuffers::Offset<CrossCcyBasisHelper> CreateCrossCcyBasisHelper(
 
 inline ::flatbuffers::Offset<CrossCcyBasisHelper> CreateCrossCcyBasisHelperDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    double spread = 0.0,
+    ::flatbuffers::Optional<double> spread = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::Period> tenor = 0,
     ::flatbuffers::Offset<quantra::IndexRef> index_domestic = 0,
     ::flatbuffers::Offset<quantra::IndexRef> index_foreign = 0,

--- a/flatbuffers/fbs/term_structure.fbs
+++ b/flatbuffers/fbs/term_structure.fbs
@@ -24,7 +24,8 @@ table HelperDependencies {
 
 /// Money market deposit helper.
 table DepositHelper {
-    rate:double;
+    /// Deposit rate. One of rate or quote_id must be provided.
+    rate:double = null;
     tenor:Period;
     fixing_days:int;
     calendar:enums.Calendar;
@@ -36,7 +37,8 @@ table DepositHelper {
 
 /// FRA helper for curve bootstrap.
 table FRAHelper {
-    rate:double;
+    /// FRA rate. One of rate or quote_id must be provided.
+    rate:double = null;
     months_to_start:int;
     months_to_end:int;
     fixing_days:int;
@@ -65,7 +67,8 @@ table FutureHelper {
 
 /// Vanilla IBOR swap helper. Uses IndexRef to reference an IndexDef.
 table SwapHelper {
-    rate:double;
+    /// Swap rate. One of rate or quote_id must be provided.
+    rate:double = null;
     tenor:Period;
     calendar:enums.Calendar;
     sw_fixed_leg_frequency:enums.Frequency;
@@ -100,7 +103,8 @@ table BondHelper {
 
 /// OIS helper. Uses IndexRef to reference an overnight IndexDef.
 table OISHelper {
-    rate:double;
+    /// OIS rate. One of rate or quote_id must be provided.
+    rate:double = null;
     tenor:Period;
     /// Reference to an overnight IndexDef by id (e.g., "USD_SOFR").
     overnight_index:IndexRef (required);
@@ -116,7 +120,8 @@ table OISHelper {
 
 /// Dated OIS helper with explicit start/end dates.
 table DatedOISHelper {
-    rate:double;
+    /// OIS rate. One of rate or quote_id must be provided.
+    rate:double = null;
     start_date:string (required);
     end_date:string (required);
     /// Reference to an overnight IndexDef by id.
@@ -138,8 +143,8 @@ table ZeroRatePoint {
     tenor:Period;
     calendar:enums.Calendar = TARGET;
     business_day_convention:enums.BusinessDayConvention = ModifiedFollowing;
-    /// Zero rate for this maturity.
-    zero_rate:double;
+    /// Zero rate for this maturity. Required.
+    zero_rate:double = null;
     /// Compounding convention for the zero rate.
     compounding:enums.Compounding = Continuous;
     /// Frequency (used when compounding != Continuous).
@@ -148,7 +153,8 @@ table ZeroRatePoint {
 
 /// Tenor basis swap helper.
 table TenorBasisSwapHelper {
-    spread:double;
+    /// Basis spread. One of spread or quote_id must be provided.
+    spread:double = null;
     tenor:Period;
     /// Short tenor index (e.g., "EUR_3M").
     index_short:IndexRef (required);
@@ -161,7 +167,8 @@ table TenorBasisSwapHelper {
 
 /// FX swap helper.
 table FxSwapHelper {
-    fx_points:double;
+    /// FX forward points. One of fx_points or quote_id must be provided.
+    fx_points:double = null;
     tenor:Period;
     spot_days:int = 2;
     calendar_domestic:enums.Calendar = TARGET;
@@ -172,7 +179,8 @@ table FxSwapHelper {
 
 /// Cross-currency basis swap helper.
 table CrossCcyBasisHelper {
-    spread:double;
+    /// Cross-currency basis spread. One of spread or quote_id must be provided.
+    spread:double = null;
     tenor:Period;
     /// Domestic leg index.
     index_domestic:IndexRef (required);

--- a/flatbuffers/json/bootstrap_curves_request.schema.json
+++ b/flatbuffers/json/bootstrap_curves_request.schema.json
@@ -493,7 +493,8 @@
       "description" : "Money market deposit helper.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Deposit rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -522,7 +523,8 @@
       "description" : "FRA helper for curve bootstrap.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "FRA rate. One of rate or quote_id must be provided."
               },
         "months_to_start" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -590,7 +592,8 @@
       "description" : "Vanilla IBOR swap helper. Uses IndexRef to reference an IndexDef.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Swap rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -675,7 +678,8 @@
       "description" : "OIS helper. Uses IndexRef to reference an overnight IndexDef.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "OIS rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -715,7 +719,8 @@
       "description" : "Dated OIS helper with explicit start/end dates.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "OIS rate. One of rate or quote_id must be provided."
               },
         "start_date" : {
                 "type" : "string"
@@ -770,7 +775,7 @@
               },
         "zero_rate" : {
                 "type" : "number",
-                "description" : "Zero rate for this maturity."
+                "description" : "Zero rate for this maturity. Required."
               },
         "compounding" : {
                 "$ref" : "#/definitions/quantra_enums_Compounding",
@@ -788,7 +793,8 @@
       "description" : "Tenor basis swap helper.",
       "properties" : {
         "spread" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Basis spread. One of spread or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -819,7 +825,8 @@
       "description" : "FX swap helper.",
       "properties" : {
         "fx_points" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "FX forward points. One of fx_points or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -847,7 +854,8 @@
       "description" : "Cross-currency basis swap helper.",
       "properties" : {
         "spread" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Cross-currency basis spread. One of spread or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"

--- a/flatbuffers/json/bootstrap_inflation_curves_request.schema.json
+++ b/flatbuffers/json/bootstrap_inflation_curves_request.schema.json
@@ -485,7 +485,8 @@
       "description" : "Money market deposit helper.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Deposit rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -514,7 +515,8 @@
       "description" : "FRA helper for curve bootstrap.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "FRA rate. One of rate or quote_id must be provided."
               },
         "months_to_start" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -582,7 +584,8 @@
       "description" : "Vanilla IBOR swap helper. Uses IndexRef to reference an IndexDef.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Swap rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -667,7 +670,8 @@
       "description" : "OIS helper. Uses IndexRef to reference an overnight IndexDef.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "OIS rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -707,7 +711,8 @@
       "description" : "Dated OIS helper with explicit start/end dates.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "OIS rate. One of rate or quote_id must be provided."
               },
         "start_date" : {
                 "type" : "string"
@@ -762,7 +767,7 @@
               },
         "zero_rate" : {
                 "type" : "number",
-                "description" : "Zero rate for this maturity."
+                "description" : "Zero rate for this maturity. Required."
               },
         "compounding" : {
                 "$ref" : "#/definitions/quantra_enums_Compounding",
@@ -780,7 +785,8 @@
       "description" : "Tenor basis swap helper.",
       "properties" : {
         "spread" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Basis spread. One of spread or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -811,7 +817,8 @@
       "description" : "FX swap helper.",
       "properties" : {
         "fx_points" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "FX forward points. One of fx_points or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -839,7 +846,8 @@
       "description" : "Cross-currency basis swap helper.",
       "properties" : {
         "spread" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Cross-currency basis spread. One of spread or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"

--- a/flatbuffers/json/calibrate_swaption_model_request.schema.json
+++ b/flatbuffers/json/calibrate_swaption_model_request.schema.json
@@ -481,7 +481,8 @@
       "description" : "Money market deposit helper.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Deposit rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -510,7 +511,8 @@
       "description" : "FRA helper for curve bootstrap.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "FRA rate. One of rate or quote_id must be provided."
               },
         "months_to_start" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -578,7 +580,8 @@
       "description" : "Vanilla IBOR swap helper. Uses IndexRef to reference an IndexDef.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Swap rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -663,7 +666,8 @@
       "description" : "OIS helper. Uses IndexRef to reference an overnight IndexDef.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "OIS rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -703,7 +707,8 @@
       "description" : "Dated OIS helper with explicit start/end dates.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "OIS rate. One of rate or quote_id must be provided."
               },
         "start_date" : {
                 "type" : "string"
@@ -758,7 +763,7 @@
               },
         "zero_rate" : {
                 "type" : "number",
-                "description" : "Zero rate for this maturity."
+                "description" : "Zero rate for this maturity. Required."
               },
         "compounding" : {
                 "$ref" : "#/definitions/quantra_enums_Compounding",
@@ -776,7 +781,8 @@
       "description" : "Tenor basis swap helper.",
       "properties" : {
         "spread" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Basis spread. One of spread or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -807,7 +813,8 @@
       "description" : "FX swap helper.",
       "properties" : {
         "fx_points" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "FX forward points. One of fx_points or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -835,7 +842,8 @@
       "description" : "Cross-currency basis swap helper.",
       "properties" : {
         "spread" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Cross-currency basis spread. One of spread or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"

--- a/flatbuffers/json/calibrate_swaption_vol_request.schema.json
+++ b/flatbuffers/json/calibrate_swaption_vol_request.schema.json
@@ -481,7 +481,8 @@
       "description" : "Money market deposit helper.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Deposit rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -510,7 +511,8 @@
       "description" : "FRA helper for curve bootstrap.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "FRA rate. One of rate or quote_id must be provided."
               },
         "months_to_start" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -578,7 +580,8 @@
       "description" : "Vanilla IBOR swap helper. Uses IndexRef to reference an IndexDef.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Swap rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -663,7 +666,8 @@
       "description" : "OIS helper. Uses IndexRef to reference an overnight IndexDef.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "OIS rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -703,7 +707,8 @@
       "description" : "Dated OIS helper with explicit start/end dates.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "OIS rate. One of rate or quote_id must be provided."
               },
         "start_date" : {
                 "type" : "string"
@@ -758,7 +763,7 @@
               },
         "zero_rate" : {
                 "type" : "number",
-                "description" : "Zero rate for this maturity."
+                "description" : "Zero rate for this maturity. Required."
               },
         "compounding" : {
                 "$ref" : "#/definitions/quantra_enums_Compounding",
@@ -776,7 +781,8 @@
       "description" : "Tenor basis swap helper.",
       "properties" : {
         "spread" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Basis spread. One of spread or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -807,7 +813,8 @@
       "description" : "FX swap helper.",
       "properties" : {
         "fx_points" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "FX forward points. One of fx_points or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -835,7 +842,8 @@
       "description" : "Cross-currency basis swap helper.",
       "properties" : {
         "spread" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Cross-currency basis spread. One of spread or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"

--- a/flatbuffers/json/price_basis_swap_request.schema.json
+++ b/flatbuffers/json/price_basis_swap_request.schema.json
@@ -481,7 +481,8 @@
       "description" : "Money market deposit helper.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Deposit rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -510,7 +511,8 @@
       "description" : "FRA helper for curve bootstrap.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "FRA rate. One of rate or quote_id must be provided."
               },
         "months_to_start" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -578,7 +580,8 @@
       "description" : "Vanilla IBOR swap helper. Uses IndexRef to reference an IndexDef.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Swap rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -663,7 +666,8 @@
       "description" : "OIS helper. Uses IndexRef to reference an overnight IndexDef.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "OIS rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -703,7 +707,8 @@
       "description" : "Dated OIS helper with explicit start/end dates.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "OIS rate. One of rate or quote_id must be provided."
               },
         "start_date" : {
                 "type" : "string"
@@ -758,7 +763,7 @@
               },
         "zero_rate" : {
                 "type" : "number",
-                "description" : "Zero rate for this maturity."
+                "description" : "Zero rate for this maturity. Required."
               },
         "compounding" : {
                 "$ref" : "#/definitions/quantra_enums_Compounding",
@@ -776,7 +781,8 @@
       "description" : "Tenor basis swap helper.",
       "properties" : {
         "spread" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Basis spread. One of spread or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -807,7 +813,8 @@
       "description" : "FX swap helper.",
       "properties" : {
         "fx_points" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "FX forward points. One of fx_points or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -835,7 +842,8 @@
       "description" : "Cross-currency basis swap helper.",
       "properties" : {
         "spread" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Cross-currency basis spread. One of spread or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"

--- a/flatbuffers/json/price_cap_floor_request.schema.json
+++ b/flatbuffers/json/price_cap_floor_request.schema.json
@@ -481,7 +481,8 @@
       "description" : "Money market deposit helper.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Deposit rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -510,7 +511,8 @@
       "description" : "FRA helper for curve bootstrap.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "FRA rate. One of rate or quote_id must be provided."
               },
         "months_to_start" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -578,7 +580,8 @@
       "description" : "Vanilla IBOR swap helper. Uses IndexRef to reference an IndexDef.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Swap rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -663,7 +666,8 @@
       "description" : "OIS helper. Uses IndexRef to reference an overnight IndexDef.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "OIS rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -703,7 +707,8 @@
       "description" : "Dated OIS helper with explicit start/end dates.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "OIS rate. One of rate or quote_id must be provided."
               },
         "start_date" : {
                 "type" : "string"
@@ -758,7 +763,7 @@
               },
         "zero_rate" : {
                 "type" : "number",
-                "description" : "Zero rate for this maturity."
+                "description" : "Zero rate for this maturity. Required."
               },
         "compounding" : {
                 "$ref" : "#/definitions/quantra_enums_Compounding",
@@ -776,7 +781,8 @@
       "description" : "Tenor basis swap helper.",
       "properties" : {
         "spread" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Basis spread. One of spread or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -807,7 +813,8 @@
       "description" : "FX swap helper.",
       "properties" : {
         "fx_points" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "FX forward points. One of fx_points or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -835,7 +842,8 @@
       "description" : "Cross-currency basis swap helper.",
       "properties" : {
         "spread" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Cross-currency basis spread. One of spread or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"

--- a/flatbuffers/json/price_cds_request.schema.json
+++ b/flatbuffers/json/price_cds_request.schema.json
@@ -481,7 +481,8 @@
       "description" : "Money market deposit helper.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Deposit rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -510,7 +511,8 @@
       "description" : "FRA helper for curve bootstrap.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "FRA rate. One of rate or quote_id must be provided."
               },
         "months_to_start" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -578,7 +580,8 @@
       "description" : "Vanilla IBOR swap helper. Uses IndexRef to reference an IndexDef.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Swap rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -663,7 +666,8 @@
       "description" : "OIS helper. Uses IndexRef to reference an overnight IndexDef.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "OIS rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -703,7 +707,8 @@
       "description" : "Dated OIS helper with explicit start/end dates.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "OIS rate. One of rate or quote_id must be provided."
               },
         "start_date" : {
                 "type" : "string"
@@ -758,7 +763,7 @@
               },
         "zero_rate" : {
                 "type" : "number",
-                "description" : "Zero rate for this maturity."
+                "description" : "Zero rate for this maturity. Required."
               },
         "compounding" : {
                 "$ref" : "#/definitions/quantra_enums_Compounding",
@@ -776,7 +781,8 @@
       "description" : "Tenor basis swap helper.",
       "properties" : {
         "spread" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Basis spread. One of spread or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -807,7 +813,8 @@
       "description" : "FX swap helper.",
       "properties" : {
         "fx_points" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "FX forward points. One of fx_points or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -835,7 +842,8 @@
       "description" : "Cross-currency basis swap helper.",
       "properties" : {
         "spread" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Cross-currency basis spread. One of spread or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"

--- a/flatbuffers/json/price_equity_option_request.schema.json
+++ b/flatbuffers/json/price_equity_option_request.schema.json
@@ -481,7 +481,8 @@
       "description" : "Money market deposit helper.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Deposit rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -510,7 +511,8 @@
       "description" : "FRA helper for curve bootstrap.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "FRA rate. One of rate or quote_id must be provided."
               },
         "months_to_start" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -578,7 +580,8 @@
       "description" : "Vanilla IBOR swap helper. Uses IndexRef to reference an IndexDef.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Swap rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -663,7 +666,8 @@
       "description" : "OIS helper. Uses IndexRef to reference an overnight IndexDef.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "OIS rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -703,7 +707,8 @@
       "description" : "Dated OIS helper with explicit start/end dates.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "OIS rate. One of rate or quote_id must be provided."
               },
         "start_date" : {
                 "type" : "string"
@@ -758,7 +763,7 @@
               },
         "zero_rate" : {
                 "type" : "number",
-                "description" : "Zero rate for this maturity."
+                "description" : "Zero rate for this maturity. Required."
               },
         "compounding" : {
                 "$ref" : "#/definitions/quantra_enums_Compounding",
@@ -776,7 +781,8 @@
       "description" : "Tenor basis swap helper.",
       "properties" : {
         "spread" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Basis spread. One of spread or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -807,7 +813,8 @@
       "description" : "FX swap helper.",
       "properties" : {
         "fx_points" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "FX forward points. One of fx_points or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -835,7 +842,8 @@
       "description" : "Cross-currency basis swap helper.",
       "properties" : {
         "spread" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Cross-currency basis spread. One of spread or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"

--- a/flatbuffers/json/price_fixed_rate_bond_request.schema.json
+++ b/flatbuffers/json/price_fixed_rate_bond_request.schema.json
@@ -481,7 +481,8 @@
       "description" : "Money market deposit helper.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Deposit rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -510,7 +511,8 @@
       "description" : "FRA helper for curve bootstrap.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "FRA rate. One of rate or quote_id must be provided."
               },
         "months_to_start" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -578,7 +580,8 @@
       "description" : "Vanilla IBOR swap helper. Uses IndexRef to reference an IndexDef.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Swap rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -663,7 +666,8 @@
       "description" : "OIS helper. Uses IndexRef to reference an overnight IndexDef.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "OIS rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -703,7 +707,8 @@
       "description" : "Dated OIS helper with explicit start/end dates.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "OIS rate. One of rate or quote_id must be provided."
               },
         "start_date" : {
                 "type" : "string"
@@ -758,7 +763,7 @@
               },
         "zero_rate" : {
                 "type" : "number",
-                "description" : "Zero rate for this maturity."
+                "description" : "Zero rate for this maturity. Required."
               },
         "compounding" : {
                 "$ref" : "#/definitions/quantra_enums_Compounding",
@@ -776,7 +781,8 @@
       "description" : "Tenor basis swap helper.",
       "properties" : {
         "spread" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Basis spread. One of spread or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -807,7 +813,8 @@
       "description" : "FX swap helper.",
       "properties" : {
         "fx_points" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "FX forward points. One of fx_points or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -835,7 +842,8 @@
       "description" : "Cross-currency basis swap helper.",
       "properties" : {
         "spread" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Cross-currency basis spread. One of spread or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"

--- a/flatbuffers/json/price_floating_rate_bond_request.schema.json
+++ b/flatbuffers/json/price_floating_rate_bond_request.schema.json
@@ -481,7 +481,8 @@
       "description" : "Money market deposit helper.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Deposit rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -510,7 +511,8 @@
       "description" : "FRA helper for curve bootstrap.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "FRA rate. One of rate or quote_id must be provided."
               },
         "months_to_start" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -578,7 +580,8 @@
       "description" : "Vanilla IBOR swap helper. Uses IndexRef to reference an IndexDef.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Swap rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -663,7 +666,8 @@
       "description" : "OIS helper. Uses IndexRef to reference an overnight IndexDef.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "OIS rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -703,7 +707,8 @@
       "description" : "Dated OIS helper with explicit start/end dates.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "OIS rate. One of rate or quote_id must be provided."
               },
         "start_date" : {
                 "type" : "string"
@@ -758,7 +763,7 @@
               },
         "zero_rate" : {
                 "type" : "number",
-                "description" : "Zero rate for this maturity."
+                "description" : "Zero rate for this maturity. Required."
               },
         "compounding" : {
                 "$ref" : "#/definitions/quantra_enums_Compounding",
@@ -776,7 +781,8 @@
       "description" : "Tenor basis swap helper.",
       "properties" : {
         "spread" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Basis spread. One of spread or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -807,7 +813,8 @@
       "description" : "FX swap helper.",
       "properties" : {
         "fx_points" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "FX forward points. One of fx_points or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -835,7 +842,8 @@
       "description" : "Cross-currency basis swap helper.",
       "properties" : {
         "spread" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Cross-currency basis spread. One of spread or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"

--- a/flatbuffers/json/price_fra_request.schema.json
+++ b/flatbuffers/json/price_fra_request.schema.json
@@ -481,7 +481,8 @@
       "description" : "Money market deposit helper.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Deposit rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -510,7 +511,8 @@
       "description" : "FRA helper for curve bootstrap.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "FRA rate. One of rate or quote_id must be provided."
               },
         "months_to_start" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -578,7 +580,8 @@
       "description" : "Vanilla IBOR swap helper. Uses IndexRef to reference an IndexDef.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Swap rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -663,7 +666,8 @@
       "description" : "OIS helper. Uses IndexRef to reference an overnight IndexDef.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "OIS rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -703,7 +707,8 @@
       "description" : "Dated OIS helper with explicit start/end dates.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "OIS rate. One of rate or quote_id must be provided."
               },
         "start_date" : {
                 "type" : "string"
@@ -758,7 +763,7 @@
               },
         "zero_rate" : {
                 "type" : "number",
-                "description" : "Zero rate for this maturity."
+                "description" : "Zero rate for this maturity. Required."
               },
         "compounding" : {
                 "$ref" : "#/definitions/quantra_enums_Compounding",
@@ -776,7 +781,8 @@
       "description" : "Tenor basis swap helper.",
       "properties" : {
         "spread" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Basis spread. One of spread or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -807,7 +813,8 @@
       "description" : "FX swap helper.",
       "properties" : {
         "fx_points" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "FX forward points. One of fx_points or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -835,7 +842,8 @@
       "description" : "Cross-currency basis swap helper.",
       "properties" : {
         "spread" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Cross-currency basis spread. One of spread or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"

--- a/flatbuffers/json/price_ois_swap_request.schema.json
+++ b/flatbuffers/json/price_ois_swap_request.schema.json
@@ -481,7 +481,8 @@
       "description" : "Money market deposit helper.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Deposit rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -510,7 +511,8 @@
       "description" : "FRA helper for curve bootstrap.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "FRA rate. One of rate or quote_id must be provided."
               },
         "months_to_start" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -578,7 +580,8 @@
       "description" : "Vanilla IBOR swap helper. Uses IndexRef to reference an IndexDef.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Swap rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -663,7 +666,8 @@
       "description" : "OIS helper. Uses IndexRef to reference an overnight IndexDef.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "OIS rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -703,7 +707,8 @@
       "description" : "Dated OIS helper with explicit start/end dates.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "OIS rate. One of rate or quote_id must be provided."
               },
         "start_date" : {
                 "type" : "string"
@@ -758,7 +763,7 @@
               },
         "zero_rate" : {
                 "type" : "number",
-                "description" : "Zero rate for this maturity."
+                "description" : "Zero rate for this maturity. Required."
               },
         "compounding" : {
                 "$ref" : "#/definitions/quantra_enums_Compounding",
@@ -776,7 +781,8 @@
       "description" : "Tenor basis swap helper.",
       "properties" : {
         "spread" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Basis spread. One of spread or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -807,7 +813,8 @@
       "description" : "FX swap helper.",
       "properties" : {
         "fx_points" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "FX forward points. One of fx_points or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -835,7 +842,8 @@
       "description" : "Cross-currency basis swap helper.",
       "properties" : {
         "spread" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Cross-currency basis spread. One of spread or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"

--- a/flatbuffers/json/price_swaption_request.schema.json
+++ b/flatbuffers/json/price_swaption_request.schema.json
@@ -485,7 +485,8 @@
       "description" : "Money market deposit helper.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Deposit rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -514,7 +515,8 @@
       "description" : "FRA helper for curve bootstrap.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "FRA rate. One of rate or quote_id must be provided."
               },
         "months_to_start" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -582,7 +584,8 @@
       "description" : "Vanilla IBOR swap helper. Uses IndexRef to reference an IndexDef.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Swap rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -667,7 +670,8 @@
       "description" : "OIS helper. Uses IndexRef to reference an overnight IndexDef.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "OIS rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -707,7 +711,8 @@
       "description" : "Dated OIS helper with explicit start/end dates.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "OIS rate. One of rate or quote_id must be provided."
               },
         "start_date" : {
                 "type" : "string"
@@ -762,7 +767,7 @@
               },
         "zero_rate" : {
                 "type" : "number",
-                "description" : "Zero rate for this maturity."
+                "description" : "Zero rate for this maturity. Required."
               },
         "compounding" : {
                 "$ref" : "#/definitions/quantra_enums_Compounding",
@@ -780,7 +785,8 @@
       "description" : "Tenor basis swap helper.",
       "properties" : {
         "spread" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Basis spread. One of spread or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -811,7 +817,8 @@
       "description" : "FX swap helper.",
       "properties" : {
         "fx_points" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "FX forward points. One of fx_points or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -839,7 +846,8 @@
       "description" : "Cross-currency basis swap helper.",
       "properties" : {
         "spread" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Cross-currency basis spread. One of spread or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"

--- a/flatbuffers/json/price_vanilla_swap_request.schema.json
+++ b/flatbuffers/json/price_vanilla_swap_request.schema.json
@@ -481,7 +481,8 @@
       "description" : "Money market deposit helper.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Deposit rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -510,7 +511,8 @@
       "description" : "FRA helper for curve bootstrap.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "FRA rate. One of rate or quote_id must be provided."
               },
         "months_to_start" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -578,7 +580,8 @@
       "description" : "Vanilla IBOR swap helper. Uses IndexRef to reference an IndexDef.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Swap rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -663,7 +666,8 @@
       "description" : "OIS helper. Uses IndexRef to reference an overnight IndexDef.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "OIS rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -703,7 +707,8 @@
       "description" : "Dated OIS helper with explicit start/end dates.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "OIS rate. One of rate or quote_id must be provided."
               },
         "start_date" : {
                 "type" : "string"
@@ -758,7 +763,7 @@
               },
         "zero_rate" : {
                 "type" : "number",
-                "description" : "Zero rate for this maturity."
+                "description" : "Zero rate for this maturity. Required."
               },
         "compounding" : {
                 "$ref" : "#/definitions/quantra_enums_Compounding",
@@ -776,7 +781,8 @@
       "description" : "Tenor basis swap helper.",
       "properties" : {
         "spread" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Basis spread. One of spread or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -807,7 +813,8 @@
       "description" : "FX swap helper.",
       "properties" : {
         "fx_points" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "FX forward points. One of fx_points or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -835,7 +842,8 @@
       "description" : "Cross-currency basis swap helper.",
       "properties" : {
         "spread" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Cross-currency basis spread. One of spread or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"

--- a/flatbuffers/json/price_year_on_year_inflation_swap_request.schema.json
+++ b/flatbuffers/json/price_year_on_year_inflation_swap_request.schema.json
@@ -481,7 +481,8 @@
       "description" : "Money market deposit helper.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Deposit rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -510,7 +511,8 @@
       "description" : "FRA helper for curve bootstrap.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "FRA rate. One of rate or quote_id must be provided."
               },
         "months_to_start" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -578,7 +580,8 @@
       "description" : "Vanilla IBOR swap helper. Uses IndexRef to reference an IndexDef.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Swap rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -663,7 +666,8 @@
       "description" : "OIS helper. Uses IndexRef to reference an overnight IndexDef.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "OIS rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -703,7 +707,8 @@
       "description" : "Dated OIS helper with explicit start/end dates.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "OIS rate. One of rate or quote_id must be provided."
               },
         "start_date" : {
                 "type" : "string"
@@ -758,7 +763,7 @@
               },
         "zero_rate" : {
                 "type" : "number",
-                "description" : "Zero rate for this maturity."
+                "description" : "Zero rate for this maturity. Required."
               },
         "compounding" : {
                 "$ref" : "#/definitions/quantra_enums_Compounding",
@@ -776,7 +781,8 @@
       "description" : "Tenor basis swap helper.",
       "properties" : {
         "spread" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Basis spread. One of spread or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -807,7 +813,8 @@
       "description" : "FX swap helper.",
       "properties" : {
         "fx_points" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "FX forward points. One of fx_points or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -835,7 +842,8 @@
       "description" : "Cross-currency basis swap helper.",
       "properties" : {
         "spread" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Cross-currency basis spread. One of spread or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"

--- a/flatbuffers/json/price_zero_coupon_inflation_swap_request.schema.json
+++ b/flatbuffers/json/price_zero_coupon_inflation_swap_request.schema.json
@@ -481,7 +481,8 @@
       "description" : "Money market deposit helper.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Deposit rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -510,7 +511,8 @@
       "description" : "FRA helper for curve bootstrap.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "FRA rate. One of rate or quote_id must be provided."
               },
         "months_to_start" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -578,7 +580,8 @@
       "description" : "Vanilla IBOR swap helper. Uses IndexRef to reference an IndexDef.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Swap rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -663,7 +666,8 @@
       "description" : "OIS helper. Uses IndexRef to reference an overnight IndexDef.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "OIS rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -703,7 +707,8 @@
       "description" : "Dated OIS helper with explicit start/end dates.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "OIS rate. One of rate or quote_id must be provided."
               },
         "start_date" : {
                 "type" : "string"
@@ -758,7 +763,7 @@
               },
         "zero_rate" : {
                 "type" : "number",
-                "description" : "Zero rate for this maturity."
+                "description" : "Zero rate for this maturity. Required."
               },
         "compounding" : {
                 "$ref" : "#/definitions/quantra_enums_Compounding",
@@ -776,7 +781,8 @@
       "description" : "Tenor basis swap helper.",
       "properties" : {
         "spread" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Basis spread. One of spread or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -807,7 +813,8 @@
       "description" : "FX swap helper.",
       "properties" : {
         "fx_points" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "FX forward points. One of fx_points or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -835,7 +842,8 @@
       "description" : "Cross-currency basis swap helper.",
       "properties" : {
         "spread" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Cross-currency basis spread. One of spread or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"

--- a/flatbuffers/json/sample_vol_surfaces_request.schema.json
+++ b/flatbuffers/json/sample_vol_surfaces_request.schema.json
@@ -501,7 +501,8 @@
       "description" : "Money market deposit helper.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Deposit rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -530,7 +531,8 @@
       "description" : "FRA helper for curve bootstrap.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "FRA rate. One of rate or quote_id must be provided."
               },
         "months_to_start" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -598,7 +600,8 @@
       "description" : "Vanilla IBOR swap helper. Uses IndexRef to reference an IndexDef.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Swap rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -683,7 +686,8 @@
       "description" : "OIS helper. Uses IndexRef to reference an overnight IndexDef.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "OIS rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -723,7 +727,8 @@
       "description" : "Dated OIS helper with explicit start/end dates.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "OIS rate. One of rate or quote_id must be provided."
               },
         "start_date" : {
                 "type" : "string"
@@ -778,7 +783,7 @@
               },
         "zero_rate" : {
                 "type" : "number",
-                "description" : "Zero rate for this maturity."
+                "description" : "Zero rate for this maturity. Required."
               },
         "compounding" : {
                 "$ref" : "#/definitions/quantra_enums_Compounding",
@@ -796,7 +801,8 @@
       "description" : "Tenor basis swap helper.",
       "properties" : {
         "spread" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Basis spread. One of spread or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -827,7 +833,8 @@
       "description" : "FX swap helper.",
       "properties" : {
         "fx_points" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "FX forward points. One of fx_points or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -855,7 +862,8 @@
       "description" : "Cross-currency basis swap helper.",
       "properties" : {
         "spread" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Cross-currency basis spread. One of spread or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"

--- a/flatbuffers/json/term_structure.schema.json
+++ b/flatbuffers/json/term_structure.schema.json
@@ -445,7 +445,8 @@
       "description" : "Money market deposit helper.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Deposit rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -474,7 +475,8 @@
       "description" : "FRA helper for curve bootstrap.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "FRA rate. One of rate or quote_id must be provided."
               },
         "months_to_start" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -542,7 +544,8 @@
       "description" : "Vanilla IBOR swap helper. Uses IndexRef to reference an IndexDef.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Swap rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -627,7 +630,8 @@
       "description" : "OIS helper. Uses IndexRef to reference an overnight IndexDef.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "OIS rate. One of rate or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -667,7 +671,8 @@
       "description" : "Dated OIS helper with explicit start/end dates.",
       "properties" : {
         "rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "OIS rate. One of rate or quote_id must be provided."
               },
         "start_date" : {
                 "type" : "string"
@@ -722,7 +727,7 @@
               },
         "zero_rate" : {
                 "type" : "number",
-                "description" : "Zero rate for this maturity."
+                "description" : "Zero rate for this maturity. Required."
               },
         "compounding" : {
                 "$ref" : "#/definitions/quantra_enums_Compounding",
@@ -740,7 +745,8 @@
       "description" : "Tenor basis swap helper.",
       "properties" : {
         "spread" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Basis spread. One of spread or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -771,7 +777,8 @@
       "description" : "FX swap helper.",
       "properties" : {
         "fx_points" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "FX forward points. One of fx_points or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -799,7 +806,8 @@
       "description" : "Cross-currency basis swap helper.",
       "properties" : {
         "spread" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Cross-currency basis spread. One of spread or quote_id must be provided."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period"

--- a/flatbuffers/python/quantra/CrossCcyBasisHelper.py
+++ b/flatbuffers/python/quantra/CrossCcyBasisHelper.py
@@ -25,12 +25,13 @@ class CrossCcyBasisHelper(object):
     def Init(self, buf, pos):
         self._tab = flatbuffers.table.Table(buf, pos)
 
+    # Cross-currency basis spread. One of spread or quote_id must be provided.
     # CrossCcyBasisHelper
     def Spread(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return 0.0
+        return None
 
     # CrossCcyBasisHelper
     def Tenor(self):
@@ -91,7 +92,7 @@ def Start(builder):
     CrossCcyBasisHelperStart(builder)
 
 def CrossCcyBasisHelperAddSpread(builder, spread):
-    builder.PrependFloat64Slot(0, spread, 0.0)
+    builder.PrependFloat64Slot(0, spread, None)
 
 def AddSpread(builder, spread):
     CrossCcyBasisHelperAddSpread(builder, spread)
@@ -141,7 +142,7 @@ class CrossCcyBasisHelperT(object):
 
     # CrossCcyBasisHelperT
     def __init__(self):
-        self.spread = 0.0  # type: float
+        self.spread = None  # type: Optional[float]
         self.tenor = None  # type: Optional[PeriodT]
         self.indexDomestic = None  # type: Optional[IndexRefT]
         self.indexForeign = None  # type: Optional[IndexRefT]

--- a/flatbuffers/python/quantra/DatedOISHelper.py
+++ b/flatbuffers/python/quantra/DatedOISHelper.py
@@ -25,12 +25,13 @@ class DatedOISHelper(object):
     def Init(self, buf, pos):
         self._tab = flatbuffers.table.Table(buf, pos)
 
+    # OIS rate. One of rate or quote_id must be provided.
     # DatedOISHelper
     def Rate(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return 0.0
+        return None
 
     # DatedOISHelper
     def StartDate(self):
@@ -112,7 +113,7 @@ def Start(builder):
     DatedOISHelperStart(builder)
 
 def DatedOISHelperAddRate(builder, rate):
-    builder.PrependFloat64Slot(0, rate, 0.0)
+    builder.PrependFloat64Slot(0, rate, None)
 
 def AddRate(builder, rate):
     DatedOISHelperAddRate(builder, rate)
@@ -186,7 +187,7 @@ class DatedOISHelperT(object):
 
     # DatedOISHelperT
     def __init__(self):
-        self.rate = 0.0  # type: float
+        self.rate = None  # type: Optional[float]
         self.startDate = None  # type: str
         self.endDate = None  # type: str
         self.overnightIndex = None  # type: Optional[IndexRefT]

--- a/flatbuffers/python/quantra/DepositHelper.py
+++ b/flatbuffers/python/quantra/DepositHelper.py
@@ -25,12 +25,13 @@ class DepositHelper(object):
     def Init(self, buf, pos):
         self._tab = flatbuffers.table.Table(buf, pos)
 
+    # Deposit rate. One of rate or quote_id must be provided.
     # DepositHelper
     def Rate(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return 0.0
+        return None
 
     # DepositHelper
     def Tenor(self):
@@ -86,7 +87,7 @@ def Start(builder):
     DepositHelperStart(builder)
 
 def DepositHelperAddRate(builder, rate):
-    builder.PrependFloat64Slot(0, rate, 0.0)
+    builder.PrependFloat64Slot(0, rate, None)
 
 def AddRate(builder, rate):
     DepositHelperAddRate(builder, rate)
@@ -142,7 +143,7 @@ class DepositHelperT(object):
 
     # DepositHelperT
     def __init__(self):
-        self.rate = 0.0  # type: float
+        self.rate = None  # type: Optional[float]
         self.tenor = None  # type: Optional[PeriodT]
         self.fixingDays = 0  # type: int
         self.calendar = 0  # type: int

--- a/flatbuffers/python/quantra/FRAHelper.py
+++ b/flatbuffers/python/quantra/FRAHelper.py
@@ -25,12 +25,13 @@ class FRAHelper(object):
     def Init(self, buf, pos):
         self._tab = flatbuffers.table.Table(buf, pos)
 
+    # FRA rate. One of rate or quote_id must be provided.
     # FRAHelper
     def Rate(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return 0.0
+        return None
 
     # FRAHelper
     def MonthsToStart(self):
@@ -88,7 +89,7 @@ def Start(builder):
     FRAHelperStart(builder)
 
 def FRAHelperAddRate(builder, rate):
-    builder.PrependFloat64Slot(0, rate, 0.0)
+    builder.PrependFloat64Slot(0, rate, None)
 
 def AddRate(builder, rate):
     FRAHelperAddRate(builder, rate)
@@ -146,7 +147,7 @@ class FRAHelperT(object):
 
     # FRAHelperT
     def __init__(self):
-        self.rate = 0.0  # type: float
+        self.rate = None  # type: Optional[float]
         self.monthsToStart = 0  # type: int
         self.monthsToEnd = 0  # type: int
         self.fixingDays = 0  # type: int

--- a/flatbuffers/python/quantra/FxSwapHelper.py
+++ b/flatbuffers/python/quantra/FxSwapHelper.py
@@ -25,12 +25,13 @@ class FxSwapHelper(object):
     def Init(self, buf, pos):
         self._tab = flatbuffers.table.Table(buf, pos)
 
+    # FX forward points. One of fx_points or quote_id must be provided.
     # FxSwapHelper
     def FxPoints(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return 0.0
+        return None
 
     # FxSwapHelper
     def Tenor(self):
@@ -89,7 +90,7 @@ def Start(builder):
     FxSwapHelperStart(builder)
 
 def FxSwapHelperAddFxPoints(builder, fxPoints):
-    builder.PrependFloat64Slot(0, fxPoints, 0.0)
+    builder.PrependFloat64Slot(0, fxPoints, None)
 
 def AddFxPoints(builder, fxPoints):
     FxSwapHelperAddFxPoints(builder, fxPoints)
@@ -145,7 +146,7 @@ class FxSwapHelperT(object):
 
     # FxSwapHelperT
     def __init__(self):
-        self.fxPoints = 0.0  # type: float
+        self.fxPoints = None  # type: Optional[float]
         self.tenor = None  # type: Optional[PeriodT]
         self.spotDays = 2  # type: int
         self.calendarDomestic = 32  # type: int

--- a/flatbuffers/python/quantra/OISHelper.py
+++ b/flatbuffers/python/quantra/OISHelper.py
@@ -25,12 +25,13 @@ class OISHelper(object):
     def Init(self, buf, pos):
         self._tab = flatbuffers.table.Table(buf, pos)
 
+    # OIS rate. One of rate or quote_id must be provided.
     # OISHelper
     def Rate(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return 0.0
+        return None
 
     # OISHelper
     def Tenor(self):
@@ -116,7 +117,7 @@ def Start(builder):
     OISHelperStart(builder)
 
 def OISHelperAddRate(builder, rate):
-    builder.PrependFloat64Slot(0, rate, 0.0)
+    builder.PrependFloat64Slot(0, rate, None)
 
 def AddRate(builder, rate):
     OISHelperAddRate(builder, rate)
@@ -190,7 +191,7 @@ class OISHelperT(object):
 
     # OISHelperT
     def __init__(self):
-        self.rate = 0.0  # type: float
+        self.rate = None  # type: Optional[float]
         self.tenor = None  # type: Optional[PeriodT]
         self.overnightIndex = None  # type: Optional[IndexRefT]
         self.settlementDays = 2  # type: int

--- a/flatbuffers/python/quantra/SwapHelper.py
+++ b/flatbuffers/python/quantra/SwapHelper.py
@@ -25,12 +25,13 @@ class SwapHelper(object):
     def Init(self, buf, pos):
         self._tab = flatbuffers.table.Table(buf, pos)
 
+    # Swap rate. One of rate or quote_id must be provided.
     # SwapHelper
     def Rate(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return 0.0
+        return None
 
     # SwapHelper
     def Tenor(self):
@@ -123,7 +124,7 @@ def Start(builder):
     SwapHelperStart(builder)
 
 def SwapHelperAddRate(builder, rate):
-    builder.PrependFloat64Slot(0, rate, 0.0)
+    builder.PrependFloat64Slot(0, rate, None)
 
 def AddRate(builder, rate):
     SwapHelperAddRate(builder, rate)
@@ -203,7 +204,7 @@ class SwapHelperT(object):
 
     # SwapHelperT
     def __init__(self):
-        self.rate = 0.0  # type: float
+        self.rate = None  # type: Optional[float]
         self.tenor = None  # type: Optional[PeriodT]
         self.calendar = 0  # type: int
         self.swFixedLegFrequency = 0  # type: int

--- a/flatbuffers/python/quantra/TenorBasisSwapHelper.py
+++ b/flatbuffers/python/quantra/TenorBasisSwapHelper.py
@@ -25,12 +25,13 @@ class TenorBasisSwapHelper(object):
     def Init(self, buf, pos):
         self._tab = flatbuffers.table.Table(buf, pos)
 
+    # Basis spread. One of spread or quote_id must be provided.
     # TenorBasisSwapHelper
     def Spread(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return 0.0
+        return None
 
     # TenorBasisSwapHelper
     def Tenor(self):
@@ -98,7 +99,7 @@ def Start(builder):
     TenorBasisSwapHelperStart(builder)
 
 def TenorBasisSwapHelperAddSpread(builder, spread):
-    builder.PrependFloat64Slot(0, spread, 0.0)
+    builder.PrependFloat64Slot(0, spread, None)
 
 def AddSpread(builder, spread):
     TenorBasisSwapHelperAddSpread(builder, spread)
@@ -154,7 +155,7 @@ class TenorBasisSwapHelperT(object):
 
     # TenorBasisSwapHelperT
     def __init__(self):
-        self.spread = 0.0  # type: float
+        self.spread = None  # type: Optional[float]
         self.tenor = None  # type: Optional[PeriodT]
         self.indexShort = None  # type: Optional[IndexRefT]
         self.indexLong = None  # type: Optional[IndexRefT]

--- a/flatbuffers/python/quantra/ZeroRatePoint.py
+++ b/flatbuffers/python/quantra/ZeroRatePoint.py
@@ -59,13 +59,13 @@ class ZeroRatePoint(object):
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
         return 2
 
-    # Zero rate for this maturity.
+    # Zero rate for this maturity. Required.
     # ZeroRatePoint
     def ZeroRate(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(12))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return 0.0
+        return None
 
     # Compounding convention for the zero rate.
     # ZeroRatePoint
@@ -114,7 +114,7 @@ def AddBusinessDayConvention(builder, businessDayConvention):
     ZeroRatePointAddBusinessDayConvention(builder, businessDayConvention)
 
 def ZeroRatePointAddZeroRate(builder, zeroRate):
-    builder.PrependFloat64Slot(4, zeroRate, 0.0)
+    builder.PrependFloat64Slot(4, zeroRate, None)
 
 def AddZeroRate(builder, zeroRate):
     ZeroRatePointAddZeroRate(builder, zeroRate)
@@ -150,7 +150,7 @@ class ZeroRatePointT(object):
         self.tenor = None  # type: Optional[PeriodT]
         self.calendar = 32  # type: int
         self.businessDayConvention = 2  # type: int
-        self.zeroRate = 0.0  # type: float
+        self.zeroRate = None  # type: Optional[float]
         self.compounding = 1  # type: int
         self.frequency = 0  # type: int
 

--- a/jsonserver/openapi/openapi3.json
+++ b/jsonserver/openapi/openapi3.json
@@ -2608,7 +2608,8 @@
         "description": "Money market deposit helper.",
         "properties": {
           "rate": {
-            "type": "number"
+            "type": "number",
+            "description": "Deposit rate. One of rate or quote_id must be provided."
           },
           "tenor": {
             "$ref": "#/components/schemas/quantra_Period"
@@ -2639,7 +2640,8 @@
         "description": "FRA helper for curve bootstrap.",
         "properties": {
           "rate": {
-            "type": "number"
+            "type": "number",
+            "description": "FRA rate. One of rate or quote_id must be provided."
           },
           "months_to_start": {
             "type": "integer",
@@ -2715,7 +2717,8 @@
         "description": "Vanilla IBOR swap helper. Uses IndexRef to reference an IndexDef.",
         "properties": {
           "rate": {
-            "type": "number"
+            "type": "number",
+            "description": "Swap rate. One of rate or quote_id must be provided."
           },
           "tenor": {
             "$ref": "#/components/schemas/quantra_Period"
@@ -2804,7 +2807,8 @@
         "description": "OIS helper. Uses IndexRef to reference an overnight IndexDef.",
         "properties": {
           "rate": {
-            "type": "number"
+            "type": "number",
+            "description": "OIS rate. One of rate or quote_id must be provided."
           },
           "tenor": {
             "$ref": "#/components/schemas/quantra_Period"
@@ -2846,7 +2850,8 @@
         "description": "Dated OIS helper with explicit start/end dates.",
         "properties": {
           "rate": {
-            "type": "number"
+            "type": "number",
+            "description": "OIS rate. One of rate or quote_id must be provided."
           },
           "start_date": {
             "type": "string"
@@ -2904,7 +2909,7 @@
           },
           "zero_rate": {
             "type": "number",
-            "description": "Zero rate for this maturity."
+            "description": "Zero rate for this maturity. Required."
           },
           "compounding": {
             "$ref": "#/components/schemas/quantra_enums_Compounding"
@@ -2920,7 +2925,8 @@
         "description": "Tenor basis swap helper.",
         "properties": {
           "spread": {
-            "type": "number"
+            "type": "number",
+            "description": "Basis spread. One of spread or quote_id must be provided."
           },
           "tenor": {
             "$ref": "#/components/schemas/quantra_Period"
@@ -2952,7 +2958,8 @@
         "description": "FX swap helper.",
         "properties": {
           "fx_points": {
-            "type": "number"
+            "type": "number",
+            "description": "FX forward points. One of fx_points or quote_id must be provided."
           },
           "tenor": {
             "$ref": "#/components/schemas/quantra_Period"
@@ -2982,7 +2989,8 @@
         "description": "Cross-currency basis swap helper.",
         "properties": {
           "spread": {
-            "type": "number"
+            "type": "number",
+            "description": "Cross-currency basis spread. One of spread or quote_id must be provided."
           },
           "tenor": {
             "$ref": "#/components/schemas/quantra_Period"

--- a/jsonserver/openapi/openapi3.yaml
+++ b/jsonserver/openapi/openapi3.yaml
@@ -1826,6 +1826,7 @@ components:
       properties:
         rate:
           type: number
+          description: Deposit rate. One of rate or quote_id must be provided.
         tenor:
           $ref: '#/components/schemas/quantra_Period'
         fixing_days:
@@ -1849,6 +1850,7 @@ components:
       properties:
         rate:
           type: number
+          description: FRA rate. One of rate or quote_id must be provided.
         months_to_start:
           type: integer
           minimum: -2147483648
@@ -1906,6 +1908,7 @@ components:
       properties:
         rate:
           type: number
+          description: Swap rate. One of rate or quote_id must be provided.
         tenor:
           $ref: '#/components/schemas/quantra_Period'
         calendar:
@@ -1971,6 +1974,7 @@ components:
       properties:
         rate:
           type: number
+          description: OIS rate. One of rate or quote_id must be provided.
         tenor:
           $ref: '#/components/schemas/quantra_Period'
         overnight_index:
@@ -2000,6 +2004,7 @@ components:
       properties:
         rate:
           type: number
+          description: OIS rate. One of rate or quote_id must be provided.
         start_date:
           type: string
         end_date:
@@ -2040,7 +2045,7 @@ components:
           $ref: '#/components/schemas/quantra_enums_BusinessDayConvention'
         zero_rate:
           type: number
-          description: Zero rate for this maturity.
+          description: Zero rate for this maturity. Required.
         compounding:
           $ref: '#/components/schemas/quantra_enums_Compounding'
         frequency:
@@ -2052,6 +2057,7 @@ components:
       properties:
         spread:
           type: number
+          description: Basis spread. One of spread or quote_id must be provided.
         tenor:
           $ref: '#/components/schemas/quantra_Period'
         index_short:
@@ -2074,6 +2080,7 @@ components:
       properties:
         fx_points:
           type: number
+          description: FX forward points. One of fx_points or quote_id must be provided.
         tenor:
           $ref: '#/components/schemas/quantra_Period'
         spot_days:
@@ -2095,6 +2102,8 @@ components:
       properties:
         spread:
           type: number
+          description: Cross-currency basis spread. One of spread or quote_id must
+            be provided.
         tenor:
           $ref: '#/components/schemas/quantra_Period'
         index_domestic:

--- a/src/market/curve_cache_key.cpp
+++ b/src/market/curve_cache_key.cpp
@@ -144,7 +144,8 @@ std::vector<uint8_t> CurveKeyBuilder::serializePoint(
 
     case quantra::Point_DepositHelper: {
         auto p = pw->point_as_DepositHelper();
-        buf.writeDouble(resolveQuoteValue(p->rate(), p->quote_id(), ctx));
+        buf.writeDouble(resolveQuoteValue(p->rate().value_or(0.0), p->quote_id(), ctx));
+        buf.writeU8(p->rate().has_value() ? 1 : 0);
         buf.writeI32(p->tenor() ? p->tenor()->n() : 0);
         buf.writeU8(static_cast<uint8_t>(p->tenor() ? p->tenor()->unit() : quantra::enums::TimeUnit_Days));
         buf.writeI32(p->fixing_days());
@@ -156,7 +157,8 @@ std::vector<uint8_t> CurveKeyBuilder::serializePoint(
 
     case quantra::Point_FRAHelper: {
         auto p = pw->point_as_FRAHelper();
-        buf.writeDouble(resolveQuoteValue(p->rate(), p->quote_id(), ctx));
+        buf.writeDouble(resolveQuoteValue(p->rate().value_or(0.0), p->quote_id(), ctx));
+        buf.writeU8(p->rate().has_value() ? 1 : 0);
         buf.writeI32(p->months_to_start());
         buf.writeI32(p->months_to_end());
         buf.writeI32(p->fixing_days());
@@ -192,7 +194,8 @@ std::vector<uint8_t> CurveKeyBuilder::serializePoint(
 
     case quantra::Point_SwapHelper: {
         auto p = pw->point_as_SwapHelper();
-        buf.writeDouble(resolveQuoteValue(p->rate(), p->quote_id(), ctx));
+        buf.writeDouble(resolveQuoteValue(p->rate().value_or(0.0), p->quote_id(), ctx));
+        buf.writeU8(p->rate().has_value() ? 1 : 0);
         buf.writeI32(p->tenor() ? p->tenor()->n() : 0);
         buf.writeU8(static_cast<uint8_t>(p->tenor() ? p->tenor()->unit() : quantra::enums::TimeUnit_Days));
         buf.writeU8(static_cast<uint8_t>(p->calendar()));
@@ -233,7 +236,8 @@ std::vector<uint8_t> CurveKeyBuilder::serializePoint(
 
     case quantra::Point_OISHelper: {
         auto p = pw->point_as_OISHelper();
-        buf.writeDouble(resolveQuoteValue(p->rate(), p->quote_id(), ctx));
+        buf.writeDouble(resolveQuoteValue(p->rate().value_or(0.0), p->quote_id(), ctx));
+        buf.writeU8(p->rate().has_value() ? 1 : 0);
         buf.writeI32(p->tenor() ? p->tenor()->n() : 0);
         buf.writeU8(static_cast<uint8_t>(p->tenor() ? p->tenor()->unit() : quantra::enums::TimeUnit_Days));
         writeIndexRef(buf, p->overnight_index());
@@ -248,7 +252,8 @@ std::vector<uint8_t> CurveKeyBuilder::serializePoint(
 
     case quantra::Point_DatedOISHelper: {
         auto p = pw->point_as_DatedOISHelper();
-        buf.writeDouble(resolveQuoteValue(p->rate(), p->quote_id(), ctx));
+        buf.writeDouble(resolveQuoteValue(p->rate().value_or(0.0), p->quote_id(), ctx));
+        buf.writeU8(p->rate().has_value() ? 1 : 0);
         buf.writeFbString(p->start_date());
         buf.writeFbString(p->end_date());
         writeIndexRef(buf, p->overnight_index());
@@ -263,7 +268,8 @@ std::vector<uint8_t> CurveKeyBuilder::serializePoint(
     case quantra::Point_ZeroRatePoint: {
         auto p = pw->point_as_ZeroRatePoint();
         buf.writeFbString(p->date());
-        buf.writeDouble(p->zero_rate());
+        buf.writeDouble(p->zero_rate().value_or(0.0));
+        buf.writeU8(p->zero_rate().has_value() ? 1 : 0);
         buf.writeI32(p->tenor() ? p->tenor()->n() : 0);
         buf.writeU8(static_cast<uint8_t>(p->tenor() ? p->tenor()->unit() : quantra::enums::TimeUnit_Days));
         buf.writeU8(static_cast<uint8_t>(p->calendar()));
@@ -275,7 +281,8 @@ std::vector<uint8_t> CurveKeyBuilder::serializePoint(
 
     case quantra::Point_TenorBasisSwapHelper: {
         auto p = pw->point_as_TenorBasisSwapHelper();
-        buf.writeDouble(resolveQuoteValue(p->spread(), p->quote_id(), ctx));
+        buf.writeDouble(resolveQuoteValue(p->spread().value_or(0.0), p->quote_id(), ctx));
+        buf.writeU8(p->spread().has_value() ? 1 : 0);
         buf.writeI32(p->tenor() ? p->tenor()->n() : 0);
         buf.writeU8(static_cast<uint8_t>(p->tenor() ? p->tenor()->unit() : quantra::enums::TimeUnit_Days));
         writeIndexRef(buf, p->index_short());
@@ -287,7 +294,8 @@ std::vector<uint8_t> CurveKeyBuilder::serializePoint(
 
     case quantra::Point_FxSwapHelper: {
         auto p = pw->point_as_FxSwapHelper();
-        buf.writeDouble(resolveQuoteValue(p->fx_points(), p->quote_id(), ctx));
+        buf.writeDouble(resolveQuoteValue(p->fx_points().value_or(0.0), p->quote_id(), ctx));
+        buf.writeU8(p->fx_points().has_value() ? 1 : 0);
         buf.writeI32(p->tenor() ? p->tenor()->n() : 0);
         buf.writeU8(static_cast<uint8_t>(p->tenor() ? p->tenor()->unit() : quantra::enums::TimeUnit_Days));
         buf.writeI32(p->spot_days());
@@ -299,7 +307,8 @@ std::vector<uint8_t> CurveKeyBuilder::serializePoint(
 
     case quantra::Point_CrossCcyBasisHelper: {
         auto p = pw->point_as_CrossCcyBasisHelper();
-        buf.writeDouble(resolveQuoteValue(p->spread(), p->quote_id(), ctx));
+        buf.writeDouble(resolveQuoteValue(p->spread().value_or(0.0), p->quote_id(), ctx));
+        buf.writeU8(p->spread().has_value() ? 1 : 0);
         buf.writeI32(p->tenor() ? p->tenor()->n() : 0);
         buf.writeU8(static_cast<uint8_t>(p->tenor() ? p->tenor()->unit() : quantra::enums::TimeUnit_Days));
         writeIndexRef(buf, p->index_domestic());
@@ -441,7 +450,7 @@ void CurveKeyBuilder::writeCurveHeader(
     const std::string& asOfDate,
     const quantra::TermStructure* ts)
 {
-    buf.writeTag("yc-key-v2");
+    buf.writeTag("yc-key-v3");
     buf.writeString(asOfDate);
     buf.writeU8(static_cast<uint8_t>(ts->day_counter()));
     buf.writeU8(static_cast<uint8_t>(ts->interpolator()));
@@ -498,7 +507,7 @@ std::string CurveKeyBuilder::compute(
     }
 
     // 5. Hash
-    return "yc:v2:" + sha256hex(buf.data());
+    return "yc:v3:" + sha256hex(buf.data());
 }
 
 } // namespace quantra

--- a/src/market/curve_cache_key.h
+++ b/src/market/curve_cache_key.h
@@ -131,7 +131,7 @@ struct KeyContext {
 /**
  * CurveKeyBuilder - Builds deterministic cache keys for yield curve specs.
  *
- * Produces: "yc:v2:<sha256hex>"
+ * Produces: "yc:v3:<sha256hex>"
  *
  * The key captures everything that affects bootstrapping output:
  * - as_of_date
@@ -155,7 +155,7 @@ public:
      * @param ts            The curve spec
      * @param ctx           Pre-built quote/index lookup maps
      * @param depKeys       Keys of dependency curves (sorted by depId)
-     * @return              Key string "yc:v2:<sha256hex>"
+     * @return              Key string "yc:v3:<sha256hex>"
      */
     static std::string compute(
         const std::string& asOfDate,

--- a/src/market/pricing_registry.h
+++ b/src/market/pricing_registry.h
@@ -52,7 +52,7 @@ struct InflationCurveEntry {
 
 struct RatesRegistry {
     std::map<std::string, std::shared_ptr<QuantLib::RelinkableHandle<QuantLib::YieldTermStructure>>> curves;
-    /// Per-curve canonical cache keys ("yc:v2:<hex>"), populated when the curve
+    /// Per-curve canonical cache keys ("yc:v3:<hex>"), populated when the curve
     /// cache is enabled. Used by downstream consumers (e.g. SABR calibrate
     /// cube cache) to derive their own content-keyed identities. Missing
     /// entries indicate that the curve was bootstrapped with caching disabled

--- a/src/parsers/term_structure_parser.cpp
+++ b/src/parsers/term_structure_parser.cpp
@@ -87,7 +87,10 @@ std::shared_ptr<YieldTermStructure> TermStructureParser::parse(
                 d = cal.advance(ref, tenorN * TimeUnitToQL(tenorUnit), bdc);
             }
             dates.push_back(d);
-            zeroRates.push_back(p->zero_rate() + bump);
+            if (!p->zero_rate().has_value()) {
+                QUANTRA_INVALID_ARGUMENT("ZeroRatePoint.zero_rate is required");
+            }
+            zeroRates.push_back(p->zero_rate().value() + bump);
 
             if (!compSet) {
                 comp = CompoundingToQL(p->compounding());

--- a/src/parsers/term_structure_point_parser.cpp
+++ b/src/parsers/term_structure_point_parser.cpp
@@ -73,7 +73,16 @@ std::shared_ptr<RateHelper> TermStructurePointParser::parse(
         if (!point->tenor()) {
             QUANTRA_INVALID_ARGUMENT("DepositHelper.tenor is required");
         }
-        auto q = resolveQuote(point->rate(), point->quote_id(), quotes, quantra::QuoteType_Curve, bump);
+        const bool has_quote = point->quote_id() && !point->quote_id()->str().empty();
+        double rateValue;
+        if (point->rate().has_value()) {
+            rateValue = point->rate().value();
+        } else if (has_quote) {
+            rateValue = 0.0; // unused: quote_id supplies the rate below
+        } else {
+            QUANTRA_INVALID_ARGUMENT("DepositHelper requires one of rate or quote_id");
+        }
+        auto q = resolveQuote(rateValue, point->quote_id(), quotes, quantra::QuoteType_Curve, bump);
 
         return std::make_shared<DepositRateHelper>(
             q,
@@ -90,7 +99,16 @@ std::shared_ptr<RateHelper> TermStructurePointParser::parse(
     // ------------------------------------------------------------------
     else if (point_type == quantra::Point_FRAHelper) {
         auto point = static_cast<const quantra::FRAHelper*>(data);
-        auto q = resolveQuote(point->rate(), point->quote_id(), quotes, quantra::QuoteType_Curve, bump);
+        const bool has_quote = point->quote_id() && !point->quote_id()->str().empty();
+        double rateValue;
+        if (point->rate().has_value()) {
+            rateValue = point->rate().value();
+        } else if (has_quote) {
+            rateValue = 0.0; // unused: quote_id supplies the rate below
+        } else {
+            QUANTRA_INVALID_ARGUMENT("FRAHelper requires one of rate or quote_id");
+        }
+        auto q = resolveQuote(rateValue, point->quote_id(), quotes, quantra::QuoteType_Curve, bump);
 
         return std::make_shared<FraRateHelper>(
             q,
@@ -174,7 +192,16 @@ std::shared_ptr<RateHelper> TermStructurePointParser::parse(
         if (!point->tenor()) {
             QUANTRA_INVALID_ARGUMENT("SwapHelper.tenor is required");
         }
-        auto q = resolveQuote(point->rate(), point->quote_id(), quotes, quantra::QuoteType_Curve, bump);
+        const bool has_quote = point->quote_id() && !point->quote_id()->str().empty();
+        double rateValue;
+        if (point->rate().has_value()) {
+            rateValue = point->rate().value();
+        } else if (has_quote) {
+            rateValue = 0.0; // unused: quote_id supplies the rate below
+        } else {
+            QUANTRA_INVALID_ARGUMENT("SwapHelper requires one of rate or quote_id");
+        }
+        auto q = resolveQuote(rateValue, point->quote_id(), quotes, quantra::QuoteType_Curve, bump);
 
         if (!indices) {
             QUANTRA_ERROR("IndexRegistry is required for SwapHelper");
@@ -277,7 +304,16 @@ std::shared_ptr<RateHelper> TermStructurePointParser::parse(
         if (!point->tenor()) {
             QUANTRA_INVALID_ARGUMENT("OISHelper.tenor is required");
         }
-        auto q = resolveQuote(point->rate(), point->quote_id(), quotes, quantra::QuoteType_Curve, bump);
+        const bool has_quote = point->quote_id() && !point->quote_id()->str().empty();
+        double rateValue;
+        if (point->rate().has_value()) {
+            rateValue = point->rate().value();
+        } else if (has_quote) {
+            rateValue = 0.0; // unused: quote_id supplies the rate below
+        } else {
+            QUANTRA_INVALID_ARGUMENT("OISHelper requires one of rate or quote_id");
+        }
+        auto q = resolveQuote(rateValue, point->quote_id(), quotes, quantra::QuoteType_Curve, bump);
 
         if (!indices) {
             QUANTRA_ERROR("IndexRegistry is required for OISHelper");
@@ -322,7 +358,16 @@ std::shared_ptr<RateHelper> TermStructurePointParser::parse(
     // ------------------------------------------------------------------
     else if (point_type == quantra::Point_DatedOISHelper) {
         auto point = static_cast<const quantra::DatedOISHelper*>(data);
-        auto q = resolveQuote(point->rate(), point->quote_id(), quotes, quantra::QuoteType_Curve, bump);
+        const bool has_quote = point->quote_id() && !point->quote_id()->str().empty();
+        double rateValue;
+        if (point->rate().has_value()) {
+            rateValue = point->rate().value();
+        } else if (has_quote) {
+            rateValue = 0.0; // unused: quote_id supplies the rate below
+        } else {
+            QUANTRA_INVALID_ARGUMENT("DatedOISHelper requires one of rate or quote_id");
+        }
+        auto q = resolveQuote(rateValue, point->quote_id(), quotes, quantra::QuoteType_Curve, bump);
 
         if (!indices) {
             QUANTRA_ERROR("IndexRegistry is required for DatedOISHelper");

--- a/tests/parity/curve_cache_key_unknown_point_test.cpp
+++ b/tests/parity/curve_cache_key_unknown_point_test.cpp
@@ -83,7 +83,7 @@ TEST(CurveCacheKeyUnknownPoint, NonePointTypeStillKeyable) {
 
     KeyContext ctx;
     std::string key = CurveKeyBuilder::compute("2026-06-11", root, ctx, {});
-    EXPECT_EQ(key.rfind("yc:v2:", 0), 0u);
+    EXPECT_EQ(key.rfind("yc:v3:", 0), 0u);
 }
 
 } // namespace

--- a/tests/parity/curve_cache_key_unresolvable_ref_test.cpp
+++ b/tests/parity/curve_cache_key_unresolvable_ref_test.cpp
@@ -104,8 +104,8 @@ TEST(CurveCacheKeyUnresolvableRef, ResolvedQuoteIdStillKeyable) {
 
     std::string k1 = CurveKeyBuilder::compute("2026-06-11", ts1, lo, {});
     std::string k2 = CurveKeyBuilder::compute("2026-06-11", ts2, hi, {});
-    EXPECT_EQ(k1.rfind("yc:v2:", 0), 0u);
-    EXPECT_EQ(k2.rfind("yc:v2:", 0), 0u);
+    EXPECT_EQ(k1.rfind("yc:v3:", 0), 0u);
+    EXPECT_EQ(k2.rfind("yc:v3:", 0), 0u);
     EXPECT_NE(k1, k2);
 }
 
@@ -116,7 +116,7 @@ TEST(CurveCacheKeyUnresolvableRef, InlineValueWithoutQuoteIdStillKeyable) {
 
     KeyContext ctx;
     std::string key = CurveKeyBuilder::compute("2026-06-11", ts, ctx, {});
-    EXPECT_EQ(key.rfind("yc:v2:", 0), 0u);
+    EXPECT_EQ(key.rfind("yc:v3:", 0), 0u);
 }
 
 // A referenced index with no definition must throw (fail closed -> curve
@@ -144,7 +144,7 @@ TEST(CurveCacheKeyUnresolvableRef, DefinedIndexStillKeyable) {
     ctx.indexDefs["euribor-6m"] = defRoot;
 
     std::string key = CurveKeyBuilder::compute("2026-06-11", ts, ctx, {});
-    EXPECT_EQ(key.rfind("yc:v2:", 0), 0u);
+    EXPECT_EQ(key.rfind("yc:v3:", 0), 0u);
 }
 
 } // namespace

--- a/tests/parity/helper_presence_test.cpp
+++ b/tests/parity/helper_presence_test.cpp
@@ -61,6 +61,54 @@ const quantra::BondHelper* makeBondHelper(
     return flatbuffers::GetRoot<quantra::BondHelper>(fbb.GetBufferPointer());
 }
 
+enum class RateQuoteSlot { Rate, QuoteId, None };
+
+const quantra::DepositHelper* makeDepositHelper(
+    flatbuffers::FlatBufferBuilder& fbb, RateQuoteSlot slot, double rate)
+{
+    flatbuffers::Offset<flatbuffers::String> quoteId;
+    if (slot == RateQuoteSlot::QuoteId) quoteId = fbb.CreateString("dep-quote");
+    auto tenorN = 3;
+    quantra::PeriodBuilder pb(fbb);
+    pb.add_n(tenorN);
+    pb.add_unit(quantra::enums::TimeUnit_Months);
+    auto tenor = pb.Finish();
+    quantra::DepositHelperBuilder db(fbb);
+    if (slot == RateQuoteSlot::Rate) db.add_rate(rate);
+    if (slot == RateQuoteSlot::QuoteId) db.add_quote_id(quoteId);
+    db.add_tenor(tenor);
+    db.add_fixing_days(2);
+    db.add_calendar(quantra::enums::Calendar_TARGET);
+    db.add_business_day_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
+    db.add_day_counter(quantra::enums::DayCounter_Actual360);
+    fbb.Finish(db.Finish());
+    return flatbuffers::GetRoot<quantra::DepositHelper>(fbb.GetBufferPointer());
+}
+
+const quantra::SwapHelper* makeSwapHelper(
+    flatbuffers::FlatBufferBuilder& fbb, RateQuoteSlot slot, double rate)
+{
+    auto idxId = fbb.CreateString("EUR_6M");
+    auto idxRef = quantra::CreateIndexRef(fbb, idxId);
+    flatbuffers::Offset<flatbuffers::String> quoteId;
+    if (slot == RateQuoteSlot::QuoteId) quoteId = fbb.CreateString("swap-quote");
+    quantra::PeriodBuilder pb(fbb);
+    pb.add_n(5);
+    pb.add_unit(quantra::enums::TimeUnit_Years);
+    auto tenor = pb.Finish();
+    quantra::SwapHelperBuilder sb(fbb);
+    if (slot == RateQuoteSlot::Rate) sb.add_rate(rate);
+    if (slot == RateQuoteSlot::QuoteId) sb.add_quote_id(quoteId);
+    sb.add_tenor(tenor);
+    sb.add_calendar(quantra::enums::Calendar_TARGET);
+    sb.add_sw_fixed_leg_frequency(quantra::enums::Frequency_Annual);
+    sb.add_sw_fixed_leg_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
+    sb.add_sw_fixed_leg_day_counter(quantra::enums::DayCounter_Thirty360);
+    sb.add_float_index(idxRef);
+    fbb.Finish(sb.Finish());
+    return flatbuffers::GetRoot<quantra::SwapHelper>(fbb.GetBufferPointer());
+}
+
 enum class FutureQuoteSlot { FuturesPrice, Rate, Both, None };
 
 const quantra::FutureHelper* makeFutureHelper(
@@ -163,6 +211,51 @@ TEST(FutureHelperPresence, AbsentBothIsClearError) {
         FAIL() << "expected QuantraError for FutureHelper without futures_price/rate/quote_id";
     } catch (const QuantraError& e) {
         EXPECT_NE(std::string(e.what()).find("futures_price, rate or quote_id"),
+                  std::string::npos)
+            << "actual message: " << e.what();
+    }
+}
+
+// A DepositHelper carrying its rate inline hands QuantLib that exact quote.
+TEST(DepositHelperPresence, RateSlotPricesFromRate) {
+    const double rate = 0.0123;
+    TermStructurePointParser parser;
+    flatbuffers::FlatBufferBuilder fbb;
+    auto h = parser.parse(
+        quantra::Point_DepositHelper, makeDepositHelper(fbb, RateQuoteSlot::Rate, rate));
+    ASSERT_NE(h, nullptr);
+    EXPECT_DOUBLE_EQ(h->quote()->value(), rate);
+}
+
+// Neither rate nor quote_id: a clear request error, not a silent zero-rate
+// helper bootstrapping from a magic default of 0.
+TEST(DepositHelperPresence, AbsentBothIsClearError) {
+    TermStructurePointParser parser;
+    flatbuffers::FlatBufferBuilder fbb;
+    const auto* helper = makeDepositHelper(fbb, RateQuoteSlot::None, 0.0);
+
+    try {
+        parser.parse(quantra::Point_DepositHelper, helper);
+        FAIL() << "expected QuantraError for DepositHelper without rate/quote_id";
+    } catch (const QuantraError& e) {
+        EXPECT_NE(std::string(e.what()).find("rate or quote_id"),
+                  std::string::npos)
+            << "actual message: " << e.what();
+    }
+}
+
+// Same contract for SwapHelper: omitting both rate and quote_id is a clear
+// request error instead of silently bootstrapping a swap quoted at zero.
+TEST(SwapHelperPresence, AbsentBothIsClearError) {
+    TermStructurePointParser parser;
+    flatbuffers::FlatBufferBuilder fbb;
+    const auto* helper = makeSwapHelper(fbb, RateQuoteSlot::None, 0.0);
+
+    try {
+        parser.parse(quantra::Point_SwapHelper, helper);
+        FAIL() << "expected QuantraError for SwapHelper without rate/quote_id";
+    } catch (const QuantraError& e) {
+        EXPECT_NE(std::string(e.what()).find("rate or quote_id"),
                   std::string::npos)
             << "actual message: " << e.what();
     }


### PR DESCRIPTION
**Schema v3, step 1 (wire-breaking).** Extends v2’s optional-with-presence pattern (already on bond/future helpers) to the remaining curve-helper quote fields, so an **omitted quote errors instead of silently becoming a 0% rate**.

- `term_structure.fbs`: `DepositHelper.rate`, `FRAHelper.rate`, `SwapHelper.rate`, `OISHelper.rate`, `DatedOISHelper.rate`, `TenorBasisSwapHelper.spread`, `CrossCcyBasisHelper.spread`, `FxSwapHelper.fx_points`, `ZeroRatePoint.zero_rate` → optional (`= null`).
- Parsers select on presence: value when present, else `quote_id`, else `INVALID_ARGUMENT` naming the helper (mirrors bond/future; ZeroRatePoint has no `quote_id`, so absent → error).
- Cache key serializes each field’s presence, and the curve cache-key version bumps `yc:v2:` → `yc:v3:`.

Public `VERSION` / `docs/versioning.md` are bumped in the **final v3 release step**, not here. **No example/catalog payload needed editing** — every existing curve request already supplies an explicit rate/spread or `quote_id`; +3 presence tests prove the enforced-absence contract. Regenerated FlatBuffers/OpenAPI artifacts included.

Full suite green in Docker (484 cases). First of the v3 sequence (helpers → CDS → convention enums → required fields → dates → 3.0.0 release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
