### PR TITLE
Make CDS drive on presence, not sentinel zeros (schema v3, step 2)

### DIFF
--- a/examples/data/cds/cds_upfront_zero_running_coupon.json
+++ b/examples/data/cds/cds_upfront_zero_running_coupon.json
@@ -1,0 +1,219 @@
+{
+  "pricing": {
+    "as_of_date": "2025-01-15",
+    "settlement_date": "2025-01-17",
+    "quotes": [
+      {
+        "id": "eur_disc_3m",
+        "kind": "Rate",
+        "value": 0.03,
+        "quote_type": "Curve"
+      },
+      {
+        "id": "eur_disc_6m",
+        "kind": "Rate",
+        "value": 0.03,
+        "quote_type": "Curve"
+      },
+      {
+        "id": "eur_disc_1y",
+        "kind": "Rate",
+        "value": 0.03,
+        "quote_type": "Curve"
+      },
+      {
+        "id": "eur_disc_5y",
+        "kind": "Rate",
+        "value": 0.03,
+        "quote_type": "Curve"
+      },
+      {
+        "id": "eur_disc_10y",
+        "kind": "Rate",
+        "value": 0.03,
+        "quote_type": "Curve"
+      }
+    ],
+    "rates": {
+      "indices": [
+        {
+          "id": "EUR_6M",
+          "name": "Euribor",
+          "index_type": "Ibor",
+          "fixing_days": 2,
+          "calendar": "TARGET",
+          "business_day_convention": "ModifiedFollowing",
+          "day_counter": "Actual360",
+          "end_of_month": false,
+          "currency": "EUR",
+          "tenor": {
+            "n": 6,
+            "unit": "Months"
+          }
+        }
+      ],
+      "curves": [
+        {
+          "id": "discount",
+          "day_counter": "Actual365Fixed",
+          "interpolator": "LogLinear",
+          "reference_date": "2025-01-15",
+          "bootstrap_trait": "Discount",
+          "points": [
+            {
+              "point_type": "DepositHelper",
+              "point": {
+                "quote_id": "eur_disc_3m",
+                "fixing_days": 2,
+                "calendar": "TARGET",
+                "business_day_convention": "ModifiedFollowing",
+                "day_counter": "Actual365Fixed",
+                "tenor": {
+                  "n": 3,
+                  "unit": "Months"
+                }
+              }
+            },
+            {
+              "point_type": "DepositHelper",
+              "point": {
+                "quote_id": "eur_disc_6m",
+                "fixing_days": 2,
+                "calendar": "TARGET",
+                "business_day_convention": "ModifiedFollowing",
+                "day_counter": "Actual365Fixed",
+                "tenor": {
+                  "n": 6,
+                  "unit": "Months"
+                }
+              }
+            },
+            {
+              "point_type": "DepositHelper",
+              "point": {
+                "quote_id": "eur_disc_1y",
+                "fixing_days": 2,
+                "calendar": "TARGET",
+                "business_day_convention": "ModifiedFollowing",
+                "day_counter": "Actual365Fixed",
+                "tenor": {
+                  "n": 1,
+                  "unit": "Years"
+                }
+              }
+            },
+            {
+              "point_type": "SwapHelper",
+              "point": {
+                "quote_id": "eur_disc_5y",
+                "calendar": "TARGET",
+                "sw_fixed_leg_frequency": "Annual",
+                "sw_fixed_leg_convention": "ModifiedFollowing",
+                "sw_fixed_leg_day_counter": "Thirty360",
+                "spread": 0.0,
+                "fwd_start_days": 0,
+                "float_index": {
+                  "id": "EUR_6M"
+                },
+                "tenor": {
+                  "n": 5,
+                  "unit": "Years"
+                }
+              }
+            },
+            {
+              "point_type": "SwapHelper",
+              "point": {
+                "quote_id": "eur_disc_10y",
+                "calendar": "TARGET",
+                "sw_fixed_leg_frequency": "Annual",
+                "sw_fixed_leg_convention": "ModifiedFollowing",
+                "sw_fixed_leg_day_counter": "Thirty360",
+                "spread": 0.0,
+                "fwd_start_days": 0,
+                "float_index": {
+                  "id": "EUR_6M"
+                },
+                "tenor": {
+                  "n": 10,
+                  "unit": "Years"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "credit": {
+      "credit_curves": [
+        {
+          "id": "eur_upfront",
+          "reference_date": "2025-01-15",
+          "calendar": "TARGET",
+          "day_counter": "Actual365Fixed",
+          "recovery_rate": 0.4,
+          "curve_interpolator": "LogLinear",
+          "helper_conventions": {
+            "settlement_days": 0,
+            "frequency": "Quarterly",
+            "business_day_convention": "Following",
+            "date_generation_rule": "TwentiethIMM",
+            "last_period_day_counter": "Actual365Fixed",
+            "settles_accrual": true,
+            "pays_at_default_time": true,
+            "rebates_accrual": true,
+            "helper_model": "MidPoint"
+          },
+          "quotes": [
+            {
+              "quote_type": "Upfront",
+              "quoted_upfront": 0.05,
+              "running_coupon": 0.0,
+              "tenor": {
+                "n": 5,
+                "unit": "Years"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "volatility": {
+      "models": [
+        {
+          "id": "cds_midpoint",
+          "payload_type": "CdsModelSpec",
+          "payload": {
+            "engine_type": "MidPoint"
+          }
+        }
+      ]
+    }
+  },
+  "cds_list": [
+    {
+      "cds": {
+        "side": "Buyer",
+        "notional": 10000000.0,
+        "running_coupon": 0.0,
+        "upfront": 0.03,
+        "schedule": {
+          "calendar": "TARGET",
+          "effective_date": "2025-01-15",
+          "termination_date": "2030-01-15",
+          "frequency": "Quarterly",
+          "convention": "Following",
+          "termination_date_convention": "Unadjusted",
+          "date_generation_rule": "TwentiethIMM"
+        },
+        "day_counter": "Actual360",
+        "business_day_convention": "Following",
+        "protection_start": "2025-01-15",
+        "upfront_date": "2025-01-20"
+      },
+      "discounting_curve": "discount",
+      "credit_curve_id": "eur_upfront",
+      "model": "cds_midpoint"
+    }
+  ]
+}

--- a/flatbuffers/cpp/cds_generated.h
+++ b/flatbuffers/cpp/cds_generated.h
@@ -26,9 +26,9 @@ struct CDST : public ::flatbuffers::NativeTable {
   typedef CDS TableType;
   quantra::enums::ProtectionSide side = quantra::enums::ProtectionSide_Buyer;
   double notional = 0.0;
-  double running_coupon = 0.0;
+  ::flatbuffers::Optional<double> running_coupon = ::flatbuffers::nullopt;
   std::unique_ptr<quantra::ScheduleT> schedule{};
-  double upfront = 0.0;
+  ::flatbuffers::Optional<double> upfront = ::flatbuffers::nullopt;
   quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360;
   quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_Following;
   bool settles_accrual = true;
@@ -72,16 +72,19 @@ struct CDS FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   double notional() const {
     return GetField<double>(VT_NOTIONAL, 0.0);
   }
-  /// Running coupon in decimal (0.01 = 100bps).
-  double running_coupon() const {
-    return GetField<double>(VT_RUNNING_COUPON, 0.0);
+  /// Running coupon in decimal (0.01 = 100bps). Required; presence-driven
+  /// (a genuine 0 is a valid zero-coupon CDS, an absent value is rejected).
+  ::flatbuffers::Optional<double> running_coupon() const {
+    return GetOptional<double, double>(VT_RUNNING_COUPON);
   }
   const quantra::Schedule *schedule() const {
     return GetPointer<const quantra::Schedule *>(VT_SCHEDULE);
   }
-  /// Upfront payment (can be 0).
-  double upfront() const {
-    return GetField<double>(VT_UPFRONT, 0.0);
+  /// Upfront payment. Optional: presence selects the upfront-bearing
+  /// CreditDefaultSwap constructor (a genuine 0 upfront is representable);
+  /// absent selects the plain no-upfront constructor.
+  ::flatbuffers::Optional<double> upfront() const {
+    return GetOptional<double, double>(VT_UPFRONT);
   }
   quantra::enums::DayCounter day_counter() const {
     return static_cast<quantra::enums::DayCounter>(GetField<int8_t>(VT_DAY_COUNTER, 0));
@@ -152,13 +155,13 @@ struct CDSBuilder {
     fbb_.AddElement<double>(CDS::VT_NOTIONAL, notional, 0.0);
   }
   void add_running_coupon(double running_coupon) {
-    fbb_.AddElement<double>(CDS::VT_RUNNING_COUPON, running_coupon, 0.0);
+    fbb_.AddElement<double>(CDS::VT_RUNNING_COUPON, running_coupon);
   }
   void add_schedule(::flatbuffers::Offset<quantra::Schedule> schedule) {
     fbb_.AddOffset(CDS::VT_SCHEDULE, schedule);
   }
   void add_upfront(double upfront) {
-    fbb_.AddElement<double>(CDS::VT_UPFRONT, upfront, 0.0);
+    fbb_.AddElement<double>(CDS::VT_UPFRONT, upfront);
   }
   void add_day_counter(quantra::enums::DayCounter day_counter) {
     fbb_.AddElement<int8_t>(CDS::VT_DAY_COUNTER, static_cast<int8_t>(day_counter), 0);
@@ -205,9 +208,9 @@ inline ::flatbuffers::Offset<CDS> CreateCDS(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     quantra::enums::ProtectionSide side = quantra::enums::ProtectionSide_Buyer,
     double notional = 0.0,
-    double running_coupon = 0.0,
+    ::flatbuffers::Optional<double> running_coupon = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::Schedule> schedule = 0,
-    double upfront = 0.0,
+    ::flatbuffers::Optional<double> upfront = ::flatbuffers::nullopt,
     quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360,
     quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_Following,
     bool settles_accrual = true,
@@ -219,8 +222,8 @@ inline ::flatbuffers::Offset<CDS> CreateCDS(
     ::flatbuffers::Offset<::flatbuffers::String> trade_date = 0,
     int32_t cash_settlement_days = 3) {
   CDSBuilder builder_(_fbb);
-  builder_.add_upfront(upfront);
-  builder_.add_running_coupon(running_coupon);
+  if(upfront) { builder_.add_upfront(*upfront); }
+  if(running_coupon) { builder_.add_running_coupon(*running_coupon); }
   builder_.add_notional(notional);
   builder_.add_cash_settlement_days(cash_settlement_days);
   builder_.add_trade_date(trade_date);
@@ -241,9 +244,9 @@ inline ::flatbuffers::Offset<CDS> CreateCDSDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     quantra::enums::ProtectionSide side = quantra::enums::ProtectionSide_Buyer,
     double notional = 0.0,
-    double running_coupon = 0.0,
+    ::flatbuffers::Optional<double> running_coupon = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::Schedule> schedule = 0,
-    double upfront = 0.0,
+    ::flatbuffers::Optional<double> upfront = ::flatbuffers::nullopt,
     quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360,
     quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_Following,
     bool settles_accrual = true,

--- a/flatbuffers/cpp/cds_response_generated.h
+++ b/flatbuffers/cpp/cds_response_generated.h
@@ -28,7 +28,7 @@ struct PriceCDSResponseT;
 struct CDSValuesT : public ::flatbuffers::NativeTable {
   typedef CDSValues TableType;
   double npv = 0.0;
-  double fair_spread = 0.0;
+  ::flatbuffers::Optional<double> fair_spread = ::flatbuffers::nullopt;
   double fair_upfront = 0.0;
   double default_leg_npv = 0.0;
   double premium_leg_npv = 0.0;
@@ -54,9 +54,10 @@ struct CDSValues FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   double npv() const {
     return GetField<double>(VT_NPV, 0.0);
   }
-  /// Par spread in decimal.
-  double fair_spread() const {
-    return GetField<double>(VT_FAIR_SPREAD, 0.0);
+  /// Par spread in decimal. Absent when QuantLib cannot express a fair
+  /// spread for the trade (e.g. a zero-running-coupon CDS).
+  ::flatbuffers::Optional<double> fair_spread() const {
+    return GetOptional<double, double>(VT_FAIR_SPREAD);
   }
   /// Upfront for par spread.
   double fair_upfront() const {
@@ -97,7 +98,7 @@ struct CDSValuesBuilder {
     fbb_.AddElement<double>(CDSValues::VT_NPV, npv, 0.0);
   }
   void add_fair_spread(double fair_spread) {
-    fbb_.AddElement<double>(CDSValues::VT_FAIR_SPREAD, fair_spread, 0.0);
+    fbb_.AddElement<double>(CDSValues::VT_FAIR_SPREAD, fair_spread);
   }
   void add_fair_upfront(double fair_upfront) {
     fbb_.AddElement<double>(CDSValues::VT_FAIR_UPFRONT, fair_upfront, 0.0);
@@ -125,7 +126,7 @@ struct CDSValuesBuilder {
 inline ::flatbuffers::Offset<CDSValues> CreateCDSValues(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     double npv = 0.0,
-    double fair_spread = 0.0,
+    ::flatbuffers::Optional<double> fair_spread = ::flatbuffers::nullopt,
     double fair_upfront = 0.0,
     double default_leg_npv = 0.0,
     double premium_leg_npv = 0.0,
@@ -134,7 +135,7 @@ inline ::flatbuffers::Offset<CDSValues> CreateCDSValues(
   builder_.add_premium_leg_npv(premium_leg_npv);
   builder_.add_default_leg_npv(default_leg_npv);
   builder_.add_fair_upfront(fair_upfront);
-  builder_.add_fair_spread(fair_spread);
+  if(fair_spread) { builder_.add_fair_spread(*fair_spread); }
   builder_.add_npv(npv);
   builder_.add_error(error);
   return builder_.Finish();

--- a/flatbuffers/cpp/credit_curve_generated.h
+++ b/flatbuffers/cpp/credit_curve_generated.h
@@ -37,7 +37,7 @@ struct CdsQuoteT : public ::flatbuffers::NativeTable {
   std::string quote_id{};
   double quoted_par_spread = 0.0;
   double quoted_upfront = 0.0;
-  double running_coupon = 0.0;
+  ::flatbuffers::Optional<double> running_coupon = ::flatbuffers::nullopt;
   CdsQuoteT() = default;
   CdsQuoteT(const CdsQuoteT &o);
   CdsQuoteT(CdsQuoteT&&) FLATBUFFERS_NOEXCEPT = default;
@@ -74,9 +74,11 @@ struct CdsQuote FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   double quoted_upfront() const {
     return GetField<double>(VT_QUOTED_UPFRONT, 0.0);
   }
-  /// Running coupon for upfront quotes (decimal).
-  double running_coupon() const {
-    return GetField<double>(VT_RUNNING_COUPON, 0.0);
+  /// Running coupon for upfront quotes (decimal). Optional; presence-driven
+  /// (a genuine 0 running coupon is valid for some upfront quotes, an absent
+  /// value on an upfront quote is rejected).
+  ::flatbuffers::Optional<double> running_coupon() const {
+    return GetOptional<double, double>(VT_RUNNING_COUPON);
   }
   bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -115,7 +117,7 @@ struct CdsQuoteBuilder {
     fbb_.AddElement<double>(CdsQuote::VT_QUOTED_UPFRONT, quoted_upfront, 0.0);
   }
   void add_running_coupon(double running_coupon) {
-    fbb_.AddElement<double>(CdsQuote::VT_RUNNING_COUPON, running_coupon, 0.0);
+    fbb_.AddElement<double>(CdsQuote::VT_RUNNING_COUPON, running_coupon);
   }
   explicit CdsQuoteBuilder(::flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
@@ -135,9 +137,9 @@ inline ::flatbuffers::Offset<CdsQuote> CreateCdsQuote(
     ::flatbuffers::Offset<::flatbuffers::String> quote_id = 0,
     double quoted_par_spread = 0.0,
     double quoted_upfront = 0.0,
-    double running_coupon = 0.0) {
+    ::flatbuffers::Optional<double> running_coupon = ::flatbuffers::nullopt) {
   CdsQuoteBuilder builder_(_fbb);
-  builder_.add_running_coupon(running_coupon);
+  if(running_coupon) { builder_.add_running_coupon(*running_coupon); }
   builder_.add_quoted_upfront(quoted_upfront);
   builder_.add_quoted_par_spread(quoted_par_spread);
   builder_.add_quote_id(quote_id);
@@ -153,7 +155,7 @@ inline ::flatbuffers::Offset<CdsQuote> CreateCdsQuoteDirect(
     const char *quote_id = nullptr,
     double quoted_par_spread = 0.0,
     double quoted_upfront = 0.0,
-    double running_coupon = 0.0) {
+    ::flatbuffers::Optional<double> running_coupon = ::flatbuffers::nullopt) {
   auto quote_id__ = quote_id ? _fbb.CreateString(quote_id) : 0;
   return quantra::CreateCdsQuote(
       _fbb,
@@ -318,7 +320,7 @@ struct CreditCurveSpecT : public ::flatbuffers::NativeTable {
   quantra::enums::Interpolator curve_interpolator = quantra::enums::Interpolator_LogLinear;
   std::unique_ptr<quantra::CdsHelperConventionsT> helper_conventions{};
   std::vector<std::unique_ptr<quantra::CdsQuoteT>> quotes{};
-  double flat_hazard_rate = 0.0;
+  ::flatbuffers::Optional<double> flat_hazard_rate = ::flatbuffers::nullopt;
   CreditCurveSpecT() = default;
   CreditCurveSpecT(const CreditCurveSpecT &o);
   CreditCurveSpecT(CreditCurveSpecT&&) FLATBUFFERS_NOEXCEPT = default;
@@ -365,9 +367,11 @@ struct CreditCurveSpec FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   const ::flatbuffers::Vector<::flatbuffers::Offset<quantra::CdsQuote>> *quotes() const {
     return GetPointer<const ::flatbuffers::Vector<::flatbuffers::Offset<quantra::CdsQuote>> *>(VT_QUOTES);
   }
-  /// OR: use flat hazard rate.
-  double flat_hazard_rate() const {
-    return GetField<double>(VT_FLAT_HAZARD_RATE, 0.0);
+  /// OR: use flat hazard rate. Optional; presence-driven. Present -> use it;
+  /// absent with quotes -> bootstrap from quotes; absent with no quotes is an
+  /// error (no invented default hazard rate).
+  ::flatbuffers::Optional<double> flat_hazard_rate() const {
+    return GetOptional<double, double>(VT_FLAT_HAZARD_RATE);
   }
   bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -421,7 +425,7 @@ struct CreditCurveSpecBuilder {
     fbb_.AddOffset(CreditCurveSpec::VT_QUOTES, quotes);
   }
   void add_flat_hazard_rate(double flat_hazard_rate) {
-    fbb_.AddElement<double>(CreditCurveSpec::VT_FLAT_HAZARD_RATE, flat_hazard_rate, 0.0);
+    fbb_.AddElement<double>(CreditCurveSpec::VT_FLAT_HAZARD_RATE, flat_hazard_rate);
   }
   explicit CreditCurveSpecBuilder(::flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
@@ -446,9 +450,9 @@ inline ::flatbuffers::Offset<CreditCurveSpec> CreateCreditCurveSpec(
     quantra::enums::Interpolator curve_interpolator = quantra::enums::Interpolator_LogLinear,
     ::flatbuffers::Offset<quantra::CdsHelperConventions> helper_conventions = 0,
     ::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<quantra::CdsQuote>>> quotes = 0,
-    double flat_hazard_rate = 0.0) {
+    ::flatbuffers::Optional<double> flat_hazard_rate = ::flatbuffers::nullopt) {
   CreditCurveSpecBuilder builder_(_fbb);
-  builder_.add_flat_hazard_rate(flat_hazard_rate);
+  if(flat_hazard_rate) { builder_.add_flat_hazard_rate(*flat_hazard_rate); }
   builder_.add_recovery_rate(recovery_rate);
   builder_.add_quotes(quotes);
   builder_.add_helper_conventions(helper_conventions);
@@ -470,7 +474,7 @@ inline ::flatbuffers::Offset<CreditCurveSpec> CreateCreditCurveSpecDirect(
     quantra::enums::Interpolator curve_interpolator = quantra::enums::Interpolator_LogLinear,
     ::flatbuffers::Offset<quantra::CdsHelperConventions> helper_conventions = 0,
     const std::vector<::flatbuffers::Offset<quantra::CdsQuote>> *quotes = nullptr,
-    double flat_hazard_rate = 0.0) {
+    ::flatbuffers::Optional<double> flat_hazard_rate = ::flatbuffers::nullopt) {
   auto id__ = id ? _fbb.CreateString(id) : 0;
   auto reference_date__ = reference_date ? _fbb.CreateString(reference_date) : 0;
   auto quotes__ = quotes ? _fbb.CreateVector<::flatbuffers::Offset<quantra::CdsQuote>>(*quotes) : 0;

--- a/flatbuffers/fbs/cds.fbs
+++ b/flatbuffers/fbs/cds.fbs
@@ -7,11 +7,14 @@ namespace quantra;
 table CDS {
     side:enums.ProtectionSide;
     notional:double;
-    /// Running coupon in decimal (0.01 = 100bps).
-    running_coupon:double;
+    /// Running coupon in decimal (0.01 = 100bps). Required; presence-driven
+    /// (a genuine 0 is a valid zero-coupon CDS, an absent value is rejected).
+    running_coupon:double = null;
     schedule:Schedule;
-    /// Upfront payment (can be 0).
-    upfront:double = 0.0;
+    /// Upfront payment. Optional: presence selects the upfront-bearing
+    /// CreditDefaultSwap constructor (a genuine 0 upfront is representable);
+    /// absent selects the plain no-upfront constructor.
+    upfront:double = null;
     day_counter:enums.DayCounter;
     business_day_convention:enums.BusinessDayConvention;
     settles_accrual:bool = true;

--- a/flatbuffers/fbs/cds_response.fbs
+++ b/flatbuffers/fbs/cds_response.fbs
@@ -5,8 +5,9 @@ namespace quantra;
 /// CDS pricing results.
 table CDSValues {
     npv:double;
-    /// Par spread in decimal.
-    fair_spread:double;
+    /// Par spread in decimal. Absent when QuantLib cannot express a fair
+    /// spread for the trade (e.g. a zero-running-coupon CDS).
+    fair_spread:double = null;
     /// Upfront for par spread.
     fair_upfront:double;
     /// NPV of protection leg.

--- a/flatbuffers/fbs/credit_curve.fbs
+++ b/flatbuffers/fbs/credit_curve.fbs
@@ -13,8 +13,10 @@ table CdsQuote {
     quoted_par_spread:double;
     /// Used when quote_type=Upfront (decimal, 0.01=1%).
     quoted_upfront:double;
-    /// Running coupon for upfront quotes (decimal).
-    running_coupon:double;
+    /// Running coupon for upfront quotes (decimal). Optional; presence-driven
+    /// (a genuine 0 running coupon is valid for some upfront quotes, an absent
+    /// value on an upfront quote is rejected).
+    running_coupon:double = null;
 }
 
 /// CDS helper conventions for curve building.
@@ -41,6 +43,8 @@ table CreditCurveSpec {
     helper_conventions:CdsHelperConventions;
     /// Build from CDS market quotes.
     quotes:[CdsQuote];
-    /// OR: use flat hazard rate.
-    flat_hazard_rate:double;
+    /// OR: use flat hazard rate. Optional; presence-driven. Present -> use it;
+    /// absent with quotes -> bootstrap from quotes; absent with no quotes is an
+    /// error (no invented default hazard rate).
+    flat_hazard_rate:double = null;
 }

--- a/flatbuffers/json/bootstrap_curves_request.schema.json
+++ b/flatbuffers/json/bootstrap_curves_request.schema.json
@@ -1639,7 +1639,7 @@
               },
         "running_coupon" : {
                 "type" : "number",
-                "description" : "Running coupon for upfront quotes (decimal)."
+                "description" : "Running coupon for upfront quotes (decimal). Optional; presence-driven\n(a genuine 0 running coupon is valid for some upfront quotes, an absent\nvalue on an upfront quote is rejected)."
               }
       },
       "additionalProperties" : false
@@ -1709,7 +1709,7 @@
               },
         "flat_hazard_rate" : {
                 "type" : "number",
-                "description" : "OR: use flat hazard rate."
+                "description" : "OR: use flat hazard rate. Optional; presence-driven. Present -> use it;\nabsent with quotes -> bootstrap from quotes; absent with no quotes is an\nerror (no invented default hazard rate)."
               }
       },
       "required" : ["id", "reference_date"],

--- a/flatbuffers/json/bootstrap_inflation_curves_request.schema.json
+++ b/flatbuffers/json/bootstrap_inflation_curves_request.schema.json
@@ -1631,7 +1631,7 @@
               },
         "running_coupon" : {
                 "type" : "number",
-                "description" : "Running coupon for upfront quotes (decimal)."
+                "description" : "Running coupon for upfront quotes (decimal). Optional; presence-driven\n(a genuine 0 running coupon is valid for some upfront quotes, an absent\nvalue on an upfront quote is rejected)."
               }
       },
       "additionalProperties" : false
@@ -1701,7 +1701,7 @@
               },
         "flat_hazard_rate" : {
                 "type" : "number",
-                "description" : "OR: use flat hazard rate."
+                "description" : "OR: use flat hazard rate. Optional; presence-driven. Present -> use it;\nabsent with quotes -> bootstrap from quotes; absent with no quotes is an\nerror (no invented default hazard rate)."
               }
       },
       "required" : ["id", "reference_date"],

--- a/flatbuffers/json/calibrate_swaption_model_request.schema.json
+++ b/flatbuffers/json/calibrate_swaption_model_request.schema.json
@@ -1627,7 +1627,7 @@
               },
         "running_coupon" : {
                 "type" : "number",
-                "description" : "Running coupon for upfront quotes (decimal)."
+                "description" : "Running coupon for upfront quotes (decimal). Optional; presence-driven\n(a genuine 0 running coupon is valid for some upfront quotes, an absent\nvalue on an upfront quote is rejected)."
               }
       },
       "additionalProperties" : false
@@ -1697,7 +1697,7 @@
               },
         "flat_hazard_rate" : {
                 "type" : "number",
-                "description" : "OR: use flat hazard rate."
+                "description" : "OR: use flat hazard rate. Optional; presence-driven. Present -> use it;\nabsent with quotes -> bootstrap from quotes; absent with no quotes is an\nerror (no invented default hazard rate)."
               }
       },
       "required" : ["id", "reference_date"],

--- a/flatbuffers/json/calibrate_swaption_vol_request.schema.json
+++ b/flatbuffers/json/calibrate_swaption_vol_request.schema.json
@@ -1627,7 +1627,7 @@
               },
         "running_coupon" : {
                 "type" : "number",
-                "description" : "Running coupon for upfront quotes (decimal)."
+                "description" : "Running coupon for upfront quotes (decimal). Optional; presence-driven\n(a genuine 0 running coupon is valid for some upfront quotes, an absent\nvalue on an upfront quote is rejected)."
               }
       },
       "additionalProperties" : false
@@ -1697,7 +1697,7 @@
               },
         "flat_hazard_rate" : {
                 "type" : "number",
-                "description" : "OR: use flat hazard rate."
+                "description" : "OR: use flat hazard rate. Optional; presence-driven. Present -> use it;\nabsent with quotes -> bootstrap from quotes; absent with no quotes is an\nerror (no invented default hazard rate)."
               }
       },
       "required" : ["id", "reference_date"],

--- a/flatbuffers/json/cds.schema.json
+++ b/flatbuffers/json/cds.schema.json
@@ -208,14 +208,14 @@
               },
         "running_coupon" : {
                 "type" : "number",
-                "description" : "Running coupon in decimal (0.01 = 100bps)."
+                "description" : "Running coupon in decimal (0.01 = 100bps). Required; presence-driven\n(a genuine 0 is a valid zero-coupon CDS, an absent value is rejected)."
               },
         "schedule" : {
                 "$ref" : "#/definitions/quantra_Schedule"
               },
         "upfront" : {
                 "type" : "number",
-                "description" : "Upfront payment (can be 0)."
+                "description" : "Upfront payment. Optional: presence selects the upfront-bearing\nCreditDefaultSwap constructor (a genuine 0 upfront is representable);\nabsent selects the plain no-upfront constructor."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter"

--- a/flatbuffers/json/cds_response.schema.json
+++ b/flatbuffers/json/cds_response.schema.json
@@ -299,7 +299,7 @@
               },
         "fair_spread" : {
                 "type" : "number",
-                "description" : "Par spread in decimal."
+                "description" : "Par spread in decimal. Absent when QuantLib cannot express a fair\nspread for the trade (e.g. a zero-running-coupon CDS)."
               },
         "fair_upfront" : {
                 "type" : "number",

--- a/flatbuffers/json/price_basis_swap_request.schema.json
+++ b/flatbuffers/json/price_basis_swap_request.schema.json
@@ -1627,7 +1627,7 @@
               },
         "running_coupon" : {
                 "type" : "number",
-                "description" : "Running coupon for upfront quotes (decimal)."
+                "description" : "Running coupon for upfront quotes (decimal). Optional; presence-driven\n(a genuine 0 running coupon is valid for some upfront quotes, an absent\nvalue on an upfront quote is rejected)."
               }
       },
       "additionalProperties" : false
@@ -1697,7 +1697,7 @@
               },
         "flat_hazard_rate" : {
                 "type" : "number",
-                "description" : "OR: use flat hazard rate."
+                "description" : "OR: use flat hazard rate. Optional; presence-driven. Present -> use it;\nabsent with quotes -> bootstrap from quotes; absent with no quotes is an\nerror (no invented default hazard rate)."
               }
       },
       "required" : ["id", "reference_date"],

--- a/flatbuffers/json/price_cap_floor_request.schema.json
+++ b/flatbuffers/json/price_cap_floor_request.schema.json
@@ -1627,7 +1627,7 @@
               },
         "running_coupon" : {
                 "type" : "number",
-                "description" : "Running coupon for upfront quotes (decimal)."
+                "description" : "Running coupon for upfront quotes (decimal). Optional; presence-driven\n(a genuine 0 running coupon is valid for some upfront quotes, an absent\nvalue on an upfront quote is rejected)."
               }
       },
       "additionalProperties" : false
@@ -1697,7 +1697,7 @@
               },
         "flat_hazard_rate" : {
                 "type" : "number",
-                "description" : "OR: use flat hazard rate."
+                "description" : "OR: use flat hazard rate. Optional; presence-driven. Present -> use it;\nabsent with quotes -> bootstrap from quotes; absent with no quotes is an\nerror (no invented default hazard rate)."
               }
       },
       "required" : ["id", "reference_date"],

--- a/flatbuffers/json/price_cds_request.schema.json
+++ b/flatbuffers/json/price_cds_request.schema.json
@@ -1627,7 +1627,7 @@
               },
         "running_coupon" : {
                 "type" : "number",
-                "description" : "Running coupon for upfront quotes (decimal)."
+                "description" : "Running coupon for upfront quotes (decimal). Optional; presence-driven\n(a genuine 0 running coupon is valid for some upfront quotes, an absent\nvalue on an upfront quote is rejected)."
               }
       },
       "additionalProperties" : false
@@ -1697,7 +1697,7 @@
               },
         "flat_hazard_rate" : {
                 "type" : "number",
-                "description" : "OR: use flat hazard rate."
+                "description" : "OR: use flat hazard rate. Optional; presence-driven. Present -> use it;\nabsent with quotes -> bootstrap from quotes; absent with no quotes is an\nerror (no invented default hazard rate)."
               }
       },
       "required" : ["id", "reference_date"],
@@ -2221,14 +2221,14 @@
               },
         "running_coupon" : {
                 "type" : "number",
-                "description" : "Running coupon in decimal (0.01 = 100bps)."
+                "description" : "Running coupon in decimal (0.01 = 100bps). Required; presence-driven\n(a genuine 0 is a valid zero-coupon CDS, an absent value is rejected)."
               },
         "schedule" : {
                 "$ref" : "#/definitions/quantra_Schedule"
               },
         "upfront" : {
                 "type" : "number",
-                "description" : "Upfront payment (can be 0)."
+                "description" : "Upfront payment. Optional: presence selects the upfront-bearing\nCreditDefaultSwap constructor (a genuine 0 upfront is representable);\nabsent selects the plain no-upfront constructor."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter"

--- a/flatbuffers/json/price_equity_option_request.schema.json
+++ b/flatbuffers/json/price_equity_option_request.schema.json
@@ -1627,7 +1627,7 @@
               },
         "running_coupon" : {
                 "type" : "number",
-                "description" : "Running coupon for upfront quotes (decimal)."
+                "description" : "Running coupon for upfront quotes (decimal). Optional; presence-driven\n(a genuine 0 running coupon is valid for some upfront quotes, an absent\nvalue on an upfront quote is rejected)."
               }
       },
       "additionalProperties" : false
@@ -1697,7 +1697,7 @@
               },
         "flat_hazard_rate" : {
                 "type" : "number",
-                "description" : "OR: use flat hazard rate."
+                "description" : "OR: use flat hazard rate. Optional; presence-driven. Present -> use it;\nabsent with quotes -> bootstrap from quotes; absent with no quotes is an\nerror (no invented default hazard rate)."
               }
       },
       "required" : ["id", "reference_date"],

--- a/flatbuffers/json/price_fixed_rate_bond_request.schema.json
+++ b/flatbuffers/json/price_fixed_rate_bond_request.schema.json
@@ -1627,7 +1627,7 @@
               },
         "running_coupon" : {
                 "type" : "number",
-                "description" : "Running coupon for upfront quotes (decimal)."
+                "description" : "Running coupon for upfront quotes (decimal). Optional; presence-driven\n(a genuine 0 running coupon is valid for some upfront quotes, an absent\nvalue on an upfront quote is rejected)."
               }
       },
       "additionalProperties" : false
@@ -1697,7 +1697,7 @@
               },
         "flat_hazard_rate" : {
                 "type" : "number",
-                "description" : "OR: use flat hazard rate."
+                "description" : "OR: use flat hazard rate. Optional; presence-driven. Present -> use it;\nabsent with quotes -> bootstrap from quotes; absent with no quotes is an\nerror (no invented default hazard rate)."
               }
       },
       "required" : ["id", "reference_date"],

--- a/flatbuffers/json/price_floating_rate_bond_request.schema.json
+++ b/flatbuffers/json/price_floating_rate_bond_request.schema.json
@@ -1627,7 +1627,7 @@
               },
         "running_coupon" : {
                 "type" : "number",
-                "description" : "Running coupon for upfront quotes (decimal)."
+                "description" : "Running coupon for upfront quotes (decimal). Optional; presence-driven\n(a genuine 0 running coupon is valid for some upfront quotes, an absent\nvalue on an upfront quote is rejected)."
               }
       },
       "additionalProperties" : false
@@ -1697,7 +1697,7 @@
               },
         "flat_hazard_rate" : {
                 "type" : "number",
-                "description" : "OR: use flat hazard rate."
+                "description" : "OR: use flat hazard rate. Optional; presence-driven. Present -> use it;\nabsent with quotes -> bootstrap from quotes; absent with no quotes is an\nerror (no invented default hazard rate)."
               }
       },
       "required" : ["id", "reference_date"],

--- a/flatbuffers/json/price_fra_request.schema.json
+++ b/flatbuffers/json/price_fra_request.schema.json
@@ -1627,7 +1627,7 @@
               },
         "running_coupon" : {
                 "type" : "number",
-                "description" : "Running coupon for upfront quotes (decimal)."
+                "description" : "Running coupon for upfront quotes (decimal). Optional; presence-driven\n(a genuine 0 running coupon is valid for some upfront quotes, an absent\nvalue on an upfront quote is rejected)."
               }
       },
       "additionalProperties" : false
@@ -1697,7 +1697,7 @@
               },
         "flat_hazard_rate" : {
                 "type" : "number",
-                "description" : "OR: use flat hazard rate."
+                "description" : "OR: use flat hazard rate. Optional; presence-driven. Present -> use it;\nabsent with quotes -> bootstrap from quotes; absent with no quotes is an\nerror (no invented default hazard rate)."
               }
       },
       "required" : ["id", "reference_date"],

--- a/flatbuffers/json/price_ois_swap_request.schema.json
+++ b/flatbuffers/json/price_ois_swap_request.schema.json
@@ -1627,7 +1627,7 @@
               },
         "running_coupon" : {
                 "type" : "number",
-                "description" : "Running coupon for upfront quotes (decimal)."
+                "description" : "Running coupon for upfront quotes (decimal). Optional; presence-driven\n(a genuine 0 running coupon is valid for some upfront quotes, an absent\nvalue on an upfront quote is rejected)."
               }
       },
       "additionalProperties" : false
@@ -1697,7 +1697,7 @@
               },
         "flat_hazard_rate" : {
                 "type" : "number",
-                "description" : "OR: use flat hazard rate."
+                "description" : "OR: use flat hazard rate. Optional; presence-driven. Present -> use it;\nabsent with quotes -> bootstrap from quotes; absent with no quotes is an\nerror (no invented default hazard rate)."
               }
       },
       "required" : ["id", "reference_date"],

--- a/flatbuffers/json/price_swaption_request.schema.json
+++ b/flatbuffers/json/price_swaption_request.schema.json
@@ -1631,7 +1631,7 @@
               },
         "running_coupon" : {
                 "type" : "number",
-                "description" : "Running coupon for upfront quotes (decimal)."
+                "description" : "Running coupon for upfront quotes (decimal). Optional; presence-driven\n(a genuine 0 running coupon is valid for some upfront quotes, an absent\nvalue on an upfront quote is rejected)."
               }
       },
       "additionalProperties" : false
@@ -1701,7 +1701,7 @@
               },
         "flat_hazard_rate" : {
                 "type" : "number",
-                "description" : "OR: use flat hazard rate."
+                "description" : "OR: use flat hazard rate. Optional; presence-driven. Present -> use it;\nabsent with quotes -> bootstrap from quotes; absent with no quotes is an\nerror (no invented default hazard rate)."
               }
       },
       "required" : ["id", "reference_date"],

--- a/flatbuffers/json/price_vanilla_swap_request.schema.json
+++ b/flatbuffers/json/price_vanilla_swap_request.schema.json
@@ -1627,7 +1627,7 @@
               },
         "running_coupon" : {
                 "type" : "number",
-                "description" : "Running coupon for upfront quotes (decimal)."
+                "description" : "Running coupon for upfront quotes (decimal). Optional; presence-driven\n(a genuine 0 running coupon is valid for some upfront quotes, an absent\nvalue on an upfront quote is rejected)."
               }
       },
       "additionalProperties" : false
@@ -1697,7 +1697,7 @@
               },
         "flat_hazard_rate" : {
                 "type" : "number",
-                "description" : "OR: use flat hazard rate."
+                "description" : "OR: use flat hazard rate. Optional; presence-driven. Present -> use it;\nabsent with quotes -> bootstrap from quotes; absent with no quotes is an\nerror (no invented default hazard rate)."
               }
       },
       "required" : ["id", "reference_date"],

--- a/flatbuffers/json/price_year_on_year_inflation_swap_request.schema.json
+++ b/flatbuffers/json/price_year_on_year_inflation_swap_request.schema.json
@@ -1627,7 +1627,7 @@
               },
         "running_coupon" : {
                 "type" : "number",
-                "description" : "Running coupon for upfront quotes (decimal)."
+                "description" : "Running coupon for upfront quotes (decimal). Optional; presence-driven\n(a genuine 0 running coupon is valid for some upfront quotes, an absent\nvalue on an upfront quote is rejected)."
               }
       },
       "additionalProperties" : false
@@ -1697,7 +1697,7 @@
               },
         "flat_hazard_rate" : {
                 "type" : "number",
-                "description" : "OR: use flat hazard rate."
+                "description" : "OR: use flat hazard rate. Optional; presence-driven. Present -> use it;\nabsent with quotes -> bootstrap from quotes; absent with no quotes is an\nerror (no invented default hazard rate)."
               }
       },
       "required" : ["id", "reference_date"],

--- a/flatbuffers/json/price_zero_coupon_inflation_swap_request.schema.json
+++ b/flatbuffers/json/price_zero_coupon_inflation_swap_request.schema.json
@@ -1627,7 +1627,7 @@
               },
         "running_coupon" : {
                 "type" : "number",
-                "description" : "Running coupon for upfront quotes (decimal)."
+                "description" : "Running coupon for upfront quotes (decimal). Optional; presence-driven\n(a genuine 0 running coupon is valid for some upfront quotes, an absent\nvalue on an upfront quote is rejected)."
               }
       },
       "additionalProperties" : false
@@ -1697,7 +1697,7 @@
               },
         "flat_hazard_rate" : {
                 "type" : "number",
-                "description" : "OR: use flat hazard rate."
+                "description" : "OR: use flat hazard rate. Optional; presence-driven. Present -> use it;\nabsent with quotes -> bootstrap from quotes; absent with no quotes is an\nerror (no invented default hazard rate)."
               }
       },
       "required" : ["id", "reference_date"],

--- a/flatbuffers/json/sample_vol_surfaces_request.schema.json
+++ b/flatbuffers/json/sample_vol_surfaces_request.schema.json
@@ -1647,7 +1647,7 @@
               },
         "running_coupon" : {
                 "type" : "number",
-                "description" : "Running coupon for upfront quotes (decimal)."
+                "description" : "Running coupon for upfront quotes (decimal). Optional; presence-driven\n(a genuine 0 running coupon is valid for some upfront quotes, an absent\nvalue on an upfront quote is rejected)."
               }
       },
       "additionalProperties" : false
@@ -1717,7 +1717,7 @@
               },
         "flat_hazard_rate" : {
                 "type" : "number",
-                "description" : "OR: use flat hazard rate."
+                "description" : "OR: use flat hazard rate. Optional; presence-driven. Present -> use it;\nabsent with quotes -> bootstrap from quotes; absent with no quotes is an\nerror (no invented default hazard rate)."
               }
       },
       "required" : ["id", "reference_date"],

--- a/flatbuffers/python/quantra/CDS.py
+++ b/flatbuffers/python/quantra/CDS.py
@@ -39,13 +39,14 @@ class CDS(object):
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
         return 0.0
 
-    # Running coupon in decimal (0.01 = 100bps).
+    # Running coupon in decimal (0.01 = 100bps). Required; presence-driven
+    # (a genuine 0 is a valid zero-coupon CDS, an absent value is rejected).
     # CDS
     def RunningCoupon(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(8))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return 0.0
+        return None
 
     # CDS
     def Schedule(self):
@@ -58,13 +59,15 @@ class CDS(object):
             return obj
         return None
 
-    # Upfront payment (can be 0).
+    # Upfront payment. Optional: presence selects the upfront-bearing
+    # CreditDefaultSwap constructor (a genuine 0 upfront is representable);
+    # absent selects the plain no-upfront constructor.
     # CDS
     def Upfront(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(12))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return 0.0
+        return None
 
     # CDS
     def DayCounter(self):
@@ -155,7 +158,7 @@ def AddNotional(builder, notional):
     CDSAddNotional(builder, notional)
 
 def CDSAddRunningCoupon(builder, runningCoupon):
-    builder.PrependFloat64Slot(2, runningCoupon, 0.0)
+    builder.PrependFloat64Slot(2, runningCoupon, None)
 
 def AddRunningCoupon(builder, runningCoupon):
     CDSAddRunningCoupon(builder, runningCoupon)
@@ -167,7 +170,7 @@ def AddSchedule(builder, schedule):
     CDSAddSchedule(builder, schedule)
 
 def CDSAddUpfront(builder, upfront):
-    builder.PrependFloat64Slot(4, upfront, 0.0)
+    builder.PrependFloat64Slot(4, upfront, None)
 
 def AddUpfront(builder, upfront):
     CDSAddUpfront(builder, upfront)
@@ -249,9 +252,9 @@ class CDST(object):
     def __init__(self):
         self.side = 0  # type: int
         self.notional = 0.0  # type: float
-        self.runningCoupon = 0.0  # type: float
+        self.runningCoupon = None  # type: Optional[float]
         self.schedule = None  # type: Optional[ScheduleT]
-        self.upfront = 0.0  # type: float
+        self.upfront = None  # type: Optional[float]
         self.dayCounter = 0  # type: int
         self.businessDayConvention = 0  # type: int
         self.settlesAccrual = True  # type: bool

--- a/flatbuffers/python/quantra/CDSValues.py
+++ b/flatbuffers/python/quantra/CDSValues.py
@@ -32,13 +32,14 @@ class CDSValues(object):
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
         return 0.0
 
-    # Par spread in decimal.
+    # Par spread in decimal. Absent when QuantLib cannot express a fair
+    # spread for the trade (e.g. a zero-running-coupon CDS).
     # CDSValues
     def FairSpread(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return 0.0
+        return None
 
     # Upfront for par spread.
     # CDSValues
@@ -88,7 +89,7 @@ def AddNpv(builder, npv):
     CDSValuesAddNpv(builder, npv)
 
 def CDSValuesAddFairSpread(builder, fairSpread):
-    builder.PrependFloat64Slot(1, fairSpread, 0.0)
+    builder.PrependFloat64Slot(1, fairSpread, None)
 
 def AddFairSpread(builder, fairSpread):
     CDSValuesAddFairSpread(builder, fairSpread)
@@ -133,7 +134,7 @@ class CDSValuesT(object):
     # CDSValuesT
     def __init__(self):
         self.npv = 0.0  # type: float
-        self.fairSpread = 0.0  # type: float
+        self.fairSpread = None  # type: Optional[float]
         self.fairUpfront = 0.0  # type: float
         self.defaultLegNpv = 0.0  # type: float
         self.premiumLegNpv = 0.0  # type: float

--- a/flatbuffers/python/quantra/CdsQuote.py
+++ b/flatbuffers/python/quantra/CdsQuote.py
@@ -67,13 +67,15 @@ class CdsQuote(object):
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
         return 0.0
 
-    # Running coupon for upfront quotes (decimal).
+    # Running coupon for upfront quotes (decimal). Optional; presence-driven
+    # (a genuine 0 running coupon is valid for some upfront quotes, an absent
+    # value on an upfront quote is rejected).
     # CdsQuote
     def RunningCoupon(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(14))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return 0.0
+        return None
 
 def CdsQuoteStart(builder):
     builder.StartObject(6)
@@ -112,7 +114,7 @@ def AddQuotedUpfront(builder, quotedUpfront):
     CdsQuoteAddQuotedUpfront(builder, quotedUpfront)
 
 def CdsQuoteAddRunningCoupon(builder, runningCoupon):
-    builder.PrependFloat64Slot(5, runningCoupon, 0.0)
+    builder.PrependFloat64Slot(5, runningCoupon, None)
 
 def AddRunningCoupon(builder, runningCoupon):
     CdsQuoteAddRunningCoupon(builder, runningCoupon)
@@ -137,7 +139,7 @@ class CdsQuoteT(object):
         self.quoteId = None  # type: str
         self.quotedParSpread = 0.0  # type: float
         self.quotedUpfront = 0.0  # type: float
-        self.runningCoupon = 0.0  # type: float
+        self.runningCoupon = None  # type: Optional[float]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):

--- a/flatbuffers/python/quantra/CreditCurveSpec.py
+++ b/flatbuffers/python/quantra/CreditCurveSpec.py
@@ -104,13 +104,15 @@ class CreditCurveSpec(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(18))
         return o == 0
 
-    # OR: use flat hazard rate.
+    # OR: use flat hazard rate. Optional; presence-driven. Present -> use it;
+    # absent with quotes -> bootstrap from quotes; absent with no quotes is an
+    # error (no invented default hazard rate).
     # CreditCurveSpec
     def FlatHazardRate(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(20))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return 0.0
+        return None
 
 def CreditCurveSpecStart(builder):
     builder.StartObject(9)
@@ -173,7 +175,7 @@ def StartQuotesVector(builder, numElems):
     return CreditCurveSpecStartQuotesVector(builder, numElems)
 
 def CreditCurveSpecAddFlatHazardRate(builder, flatHazardRate):
-    builder.PrependFloat64Slot(8, flatHazardRate, 0.0)
+    builder.PrependFloat64Slot(8, flatHazardRate, None)
 
 def AddFlatHazardRate(builder, flatHazardRate):
     CreditCurveSpecAddFlatHazardRate(builder, flatHazardRate)
@@ -201,7 +203,7 @@ class CreditCurveSpecT(object):
         self.curveInterpolator = 4  # type: int
         self.helperConventions = None  # type: Optional[CdsHelperConventionsT]
         self.quotes = None  # type: List[CdsQuoteT]
-        self.flatHazardRate = 0.0  # type: float
+        self.flatHazardRate = None  # type: Optional[float]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):

--- a/jsonserver/openapi/openapi3.json
+++ b/jsonserver/openapi/openapi3.json
@@ -3933,7 +3933,7 @@
           },
           "running_coupon": {
             "type": "number",
-            "description": "Running coupon for upfront quotes (decimal)."
+            "description": "Running coupon for upfront quotes (decimal). Optional; presence-driven\n(a genuine 0 running coupon is valid for some upfront quotes, an absent\nvalue on an upfront quote is rejected)."
           }
         },
         "additionalProperties": false
@@ -4008,7 +4008,7 @@
           },
           "flat_hazard_rate": {
             "type": "number",
-            "description": "OR: use flat hazard rate."
+            "description": "OR: use flat hazard rate. Optional; presence-driven. Present -> use it;\nabsent with quotes -> bootstrap from quotes; absent with no quotes is an\nerror (no invented default hazard rate)."
           }
         },
         "required": [
@@ -5551,14 +5551,14 @@
           },
           "running_coupon": {
             "type": "number",
-            "description": "Running coupon in decimal (0.01 = 100bps)."
+            "description": "Running coupon in decimal (0.01 = 100bps). Required; presence-driven\n(a genuine 0 is a valid zero-coupon CDS, an absent value is rejected)."
           },
           "schedule": {
             "$ref": "#/components/schemas/quantra_Schedule"
           },
           "upfront": {
             "type": "number",
-            "description": "Upfront payment (can be 0)."
+            "description": "Upfront payment. Optional: presence selects the upfront-bearing\nCreditDefaultSwap constructor (a genuine 0 upfront is representable);\nabsent selects the plain no-upfront constructor."
           },
           "day_counter": {
             "$ref": "#/components/schemas/quantra_enums_DayCounter"
@@ -5604,7 +5604,7 @@
           },
           "fair_spread": {
             "type": "number",
-            "description": "Par spread in decimal."
+            "description": "Par spread in decimal. Absent when QuantLib cannot express a fair\nspread for the trade (e.g. a zero-running-coupon CDS)."
           },
           "fair_upfront": {
             "type": "number",

--- a/jsonserver/openapi/openapi3.yaml
+++ b/jsonserver/openapi/openapi3.yaml
@@ -2775,7 +2775,11 @@ components:
           description: Used when quote_type=Upfront (decimal, 0.01=1%).
         running_coupon:
           type: number
-          description: Running coupon for upfront quotes (decimal).
+          description: 'Running coupon for upfront quotes (decimal). Optional; presence-driven
+
+            (a genuine 0 running coupon is valid for some upfront quotes, an absent
+
+            value on an upfront quote is rejected).'
       additionalProperties: false
     quantra_CdsHelperConventions:
       type: object
@@ -2827,7 +2831,13 @@ components:
             $ref: '#/components/schemas/quantra_CdsQuote'
         flat_hazard_rate:
           type: number
-          description: 'OR: use flat hazard rate.'
+          description: 'OR: use flat hazard rate. Optional; presence-driven. Present
+            -> use it;
+
+            absent with quotes -> bootstrap from quotes; absent with no quotes is
+            an
+
+            error (no invented default hazard rate).'
       required:
       - id
       - reference_date
@@ -3978,12 +3988,18 @@ components:
           type: number
         running_coupon:
           type: number
-          description: Running coupon in decimal (0.01 = 100bps).
+          description: 'Running coupon in decimal (0.01 = 100bps). Required; presence-driven
+
+            (a genuine 0 is a valid zero-coupon CDS, an absent value is rejected).'
         schedule:
           $ref: '#/components/schemas/quantra_Schedule'
         upfront:
           type: number
-          description: Upfront payment (can be 0).
+          description: 'Upfront payment. Optional: presence selects the upfront-bearing
+
+            CreditDefaultSwap constructor (a genuine 0 upfront is representable);
+
+            absent selects the plain no-upfront constructor.'
         day_counter:
           $ref: '#/components/schemas/quantra_enums_DayCounter'
         business_day_convention:
@@ -4015,7 +4031,10 @@ components:
           type: number
         fair_spread:
           type: number
-          description: Par spread in decimal.
+          description: 'Par spread in decimal. Absent when QuantLib cannot express
+            a fair
+
+            spread for the trade (e.g. a zero-running-coupon CDS).'
         fair_upfront:
           type: number
           description: Upfront for par spread.

--- a/src/domain/credit_curve_domain.h
+++ b/src/domain/credit_curve_domain.h
@@ -52,7 +52,9 @@ struct CdsQuoteDomain {
     std::string quote_id;
     double quoted_par_spread = 0.0;
     double quoted_upfront = 0.0;
-    double running_coupon = 0.0;
+    /// Present -> use it (including a genuine 0). Absent on an upfront quote is
+    /// an error; the evaluator rejects it rather than defaulting.
+    std::optional<double> running_coupon;
 };
 
 struct CreditCurveDomain {
@@ -65,7 +67,9 @@ struct CreditCurveDomain {
     double recovery_rate = 0.4;
     CreditCurveInterpolatorKind curve_interpolator = CreditCurveInterpolatorKind::LogLinear;
     std::optional<CdsHelperConventionsDomain> helper_conventions;
-    double flat_hazard_rate = 0.0;
+    /// Present -> flat-hazard curve. Absent -> bootstrap from `quotes`; absent
+    /// with no quotes is an error (no invented default hazard rate).
+    std::optional<double> flat_hazard_rate;
     std::vector<CdsQuoteDomain> quotes;
 };
 

--- a/src/evaluators/cds_evaluator.cpp
+++ b/src/evaluators/cds_evaluator.cpp
@@ -38,16 +38,18 @@ std::string creditCurveInterpolatorName(CreditCurveInterpolatorKind kind) {
 
 /**
  * Bootstrap the default-probability term structure from a plain-domain
- * CreditCurveDomain. Mirrors the FB-driven path in cds_parser.cpp verbatim:
- *  - flat hazard rate is used when flat_hazard_rate > 0 OR no quotes were
- *    provided (the same dual-trigger the legacy parser uses; the default
- *    1% hazard rate falls out of the same fallback);
- *  - otherwise we build SpreadCdsHelper / UpfrontCdsHelper instances and
- *    dispatch on curve_interpolator for the PiecewiseDefaultCurve choice.
+ * CreditCurveDomain. Presence-driven, no value sentinels:
+ *  - flat_hazard_rate present -> flat-hazard curve at that rate (a genuine 0 is
+ *    honoured);
+ *  - flat_hazard_rate absent with quotes -> build SpreadCdsHelper /
+ *    UpfrontCdsHelper instances and dispatch on curve_interpolator for the
+ *    PiecewiseDefaultCurve choice;
+ *  - flat_hazard_rate absent with no quotes -> INVALID_ARGUMENT. An empty
+ *    credit curve is an error, never a silently invented default hazard rate.
  *
  * Defaults for the helper conventions block mirror the FB schema defaults
- * the legacy parser applies when `helper_conventions` is absent: Quarterly /
- * Following / TwentiethIMM / Actual365Fixed / settlement_days = 0 / MidPoint.
+ * applied when `helper_conventions` is absent: Quarterly / Following /
+ * TwentiethIMM / Actual365Fixed / settlement_days = 0 / MidPoint.
  */
 std::shared_ptr<QuantLib::DefaultProbabilityTermStructure> buildCreditCurve(
     const CreditCurveDomain& curve,
@@ -58,12 +60,16 @@ std::shared_ptr<QuantLib::DefaultProbabilityTermStructure> buildCreditCurve(
         QUANTRA_INVALID_ARGUMENT("CreditCurveSpec.calendar is required");
     }
 
-    if (curve.flat_hazard_rate > 0.0 || curve.quotes.empty()) {
-        double hazardRate = curve.flat_hazard_rate > 0.0 ? curve.flat_hazard_rate : 0.01;
+    if (curve.flat_hazard_rate.has_value()) {
         return std::make_shared<QuantLib::FlatHazardRate>(
             curve.reference_date,
-            hazardRate,
+            curve.flat_hazard_rate.value(),
             curve.day_counter);
+    }
+    if (curve.quotes.empty()) {
+        QUANTRA_INVALID_ARGUMENT(
+            "CreditCurveSpec has neither flat_hazard_rate nor quotes; provide "
+            "one to build the credit curve");
     }
 
     const auto& hc = curve.helper_conventions;
@@ -95,7 +101,7 @@ std::shared_ptr<QuantLib::DefaultProbabilityTermStructure> buildCreditCurve(
 
         switch (quote.quote_type) {
             case CdsQuoteTypeKind::Upfront: {
-                if (quote.running_coupon == 0.0) {
+                if (!quote.running_coupon.has_value()) {
                     QUANTRA_INVALID_ARGUMENT("CdsQuote.running_coupon is required for upfront quotes");
                 }
                 auto upfrontQuote = quoteHandle;
@@ -105,7 +111,7 @@ std::shared_ptr<QuantLib::DefaultProbabilityTermStructure> buildCreditCurve(
                 }
                 helpers.push_back(std::make_shared<QuantLib::UpfrontCdsHelper>(
                     upfrontQuote,
-                    quote.running_coupon,
+                    quote.running_coupon.value(),
                     quote.tenor,
                     settlementDays,
                     curve.calendar,
@@ -180,16 +186,16 @@ std::shared_ptr<QuantLib::DefaultProbabilityTermStructure> buildCreditCurve(
 }
 
 /**
- * Build the QL CDS instrument from the plain trade fields. Mirrors the
- * legacy CDSParser::parse branching: the upfront-bearing constructor is
- * selected when upfront != 0.0 OR an upfront-date string was supplied.
+ * Build the QL CDS instrument from the plain trade fields. Presence-driven:
+ * the upfront-bearing constructor is selected when an upfront value is present
+ * (a genuine 0 upfront is honoured) OR an upfront-date string was supplied.
  */
 std::shared_ptr<QuantLib::CreditDefaultSwap> buildCds(const CdsTrade& trade) {
-    if (trade.upfront != 0.0 || trade.hasUpfrontDate) {
+    if (trade.upfront.has_value() || trade.hasUpfrontDate) {
         return std::make_shared<QuantLib::CreditDefaultSwap>(
             trade.side,
             trade.notional,
-            trade.upfront,
+            trade.upfront.value_or(0.0),
             trade.runningCoupon,
             trade.schedule,
             trade.businessDayConvention,
@@ -303,7 +309,14 @@ CdsPerTrade priceTrade(const CdsTrade& trade,
 
     CdsPerTrade out;
     out.npv = cds->NPV();
-    out.fairSpread = cds->fairSpread();
+    // QuantLib cannot express a fair spread for every trade (e.g. a
+    // zero-running-coupon CDS, where there is no coupon leg to scale). The
+    // trade still prices; report fair_spread only when it is available.
+    try {
+        out.fairSpread = cds->fairSpread();
+    } catch (const QuantLib::Error&) {
+        // fair spread not available for this trade; leave it unset.
+    }
     out.fairUpfront = cds->fairUpfront();
     out.defaultLegNpv = cds->defaultLegNPV();
     out.premiumLegNpv = cds->couponLegNPV();

--- a/src/evaluators/cds_evaluator.h
+++ b/src/evaluators/cds_evaluator.h
@@ -13,6 +13,7 @@
  */
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -33,7 +34,9 @@ struct CdsTrade {
     QuantLib::Protection::Side side = QuantLib::Protection::Buyer;
     double notional = 0.0;
     double runningCoupon = 0.0;
-    double upfront = 0.0;
+    /// Present -> the upfront-bearing CreditDefaultSwap constructor (a genuine
+    /// 0 upfront is representable); absent -> the plain no-upfront constructor.
+    std::optional<double> upfront;
     QuantLib::Schedule schedule;
     QuantLib::DayCounter dayCounter;
     QuantLib::BusinessDayConvention businessDayConvention = QuantLib::Following;
@@ -45,9 +48,9 @@ struct CdsTrade {
     QuantLib::DayCounter lastPeriodDayCounter;
     QuantLib::Date tradeDate;
     QuantLib::Natural cashSettlementDays = 3;
-    /// True when the request supplied an upfront date string; the legacy
-    /// parser selects the upfront-bearing CreditDefaultSwap constructor when
-    /// either upfront != 0.0 OR an upfront date is present.
+    /// True when the request supplied an upfront date string; the upfront-
+    /// bearing CreditDefaultSwap constructor is selected when either an upfront
+    /// value is present OR an upfront date is present.
     bool hasUpfrontDate = false;
 
     std::string discountingCurveId;
@@ -62,7 +65,7 @@ struct CdsInputs {
 /// Per-trade pricing result. Mirrors the legacy CdsPriceResult fields.
 struct CdsPerTrade {
     double npv = 0.0;
-    double fairSpread = 0.0;
+    std::optional<double> fairSpread; // absent when QuantLib cannot express it (e.g. a zero-running-coupon CDS)
     double fairUpfront = 0.0;
     double defaultLegNpv = 0.0;
     double premiumLegNpv = 0.0;

--- a/src/mappers/cds_mapper.cpp
+++ b/src/mappers/cds_mapper.cpp
@@ -37,8 +37,13 @@ CdsTrade extractTrade(const quantra::PriceCDS* pricing) {
     CdsTrade trade;
     trade.side = ProtectionSideToQL(cds->side());
     trade.notional = cds->notional();
-    trade.runningCoupon = cds->running_coupon();
-    trade.upfront = cds->upfront();
+    if (!cds->running_coupon().has_value()) {
+        QUANTRA_INVALID_ARGUMENT("CDS.running_coupon is required");
+    }
+    trade.runningCoupon = cds->running_coupon().value();
+    if (cds->upfront().has_value()) {
+        trade.upfront = cds->upfront().value();
+    }
     trade.schedule = *schedule;
     trade.dayCounter = DayCounterToQL(cds->day_counter());
     trade.businessDayConvention = ConventionToQL(cds->business_day_convention());
@@ -93,7 +98,9 @@ flatbuffers::Offset<quantra::PriceCDSResponse> CdsMapper::toResponse(
     for (const auto& v : result.values) {
         quantra::CDSValuesBuilder vb(builder);
         vb.add_npv(v.npv);
-        vb.add_fair_spread(v.fairSpread);
+        if (v.fairSpread) {
+            vb.add_fair_spread(*v.fairSpread);
+        }
         vb.add_fair_upfront(v.fairUpfront);
         vb.add_default_leg_npv(v.defaultLegNpv);
         vb.add_premium_leg_npv(v.premiumLegNpv);

--- a/src/market/pricing_registry.cpp
+++ b/src/market/pricing_registry.cpp
@@ -323,7 +323,9 @@ PricingRegistry PricingRegistryBuilder::build(const quantra::Pricing* pricing) c
                 hc.helper_model = static_cast<CdsHelperModelKind>(h->helper_model());
                 d.helper_conventions = hc;
             }
-            d.flat_hazard_rate = spec->flat_hazard_rate();
+            if (spec->flat_hazard_rate().has_value()) {
+                d.flat_hazard_rate = spec->flat_hazard_rate().value();
+            }
             if (const auto* qs = spec->quotes()) {
                 d.quotes.reserve(qs->size());
                 for (auto qit = qs->begin(); qit != qs->end(); ++qit) {
@@ -336,7 +338,9 @@ PricingRegistry PricingRegistryBuilder::build(const quantra::Pricing* pricing) c
                     if (qit->quote_id()) q.quote_id = qit->quote_id()->str();
                     q.quoted_par_spread = qit->quoted_par_spread();
                     q.quoted_upfront = qit->quoted_upfront();
-                    q.running_coupon = qit->running_coupon();
+                    if (qit->running_coupon().has_value()) {
+                        q.running_coupon = qit->running_coupon().value();
+                    }
                     d.quotes.push_back(std::move(q));
                 }
             }

--- a/tests/contract/error_contract_test.py
+++ b/tests/contract/error_contract_test.py
@@ -152,6 +152,17 @@ def _ec_set_credit_curve_field(field, value):
     return f
 
 
+def _ec_del_credit_curve_field(field):
+    def f(req):
+        req["pricing"]["credit"]["credit_curves"][0].pop(field, None)
+        return req
+    return f
+
+
+def _ec_identity(req):
+    return req
+
+
 def _ec_set_model_payload_field(field, value):
     def f(req):
         for m in req["pricing"].get("volatility", {}).get("models", []):
@@ -258,6 +269,21 @@ SCENARIOS = [
      "cds_request.json", 400,
      _ec_set_model_payload_field("engine_type", 99),
      _ec_body_contains("Unsupported CDS engine type")),
+    # A credit curve with no flat_hazard_rate and no quotes used to silently
+    # price off an invented 1% flat hazard. It must now be rejected: an empty
+    # credit curve is an error, never a fabricated default hazard rate. The
+    # simple request carries an empty quotes list plus flat_hazard_rate;
+    # dropping the hazard leaves nothing to build the curve from.
+    ("ec:400 cds empty credit curve rejected", "cds",
+     "cds_request.json", 400,
+     _ec_del_credit_curve_field("flat_hazard_rate"),
+     _ec_body_contains("neither flat_hazard_rate nor quotes")),
+    # A genuine 0 running coupon on an upfront quote (and a 0 running coupon /
+    # present upfront on the trade) is a valid CDS, not an error. It used to be
+    # rejected by a running_coupon == 0.0 value test; presence-driven handling
+    # now prices it. Posted verbatim; a clean 200 proves it is representable.
+    ("ec:200 cds upfront quote with zero running coupon prices", "cds",
+     "cds/cds_upfront_zero_running_coupon.json", 200, _ec_identity),
     # An out-of-range swaption settlement type used to fail open to
     # Physical settlement.
     ("ec:400 swaption settlement type out of range", "swaption",

--- a/tests/integration/test_server_client.cpp
+++ b/tests/integration/test_server_client.cpp
@@ -722,9 +722,9 @@ TEST_F(ServerClientTest, CDS_RoundTrip) {
     
     ASSERT_TRUE(status.ok()) << "gRPC failed: " << status.error_message();
     auto r = response.GetRoot()->cds_list()->Get(0);
-    std::cout << "NPV: " << r->npv() << " | Fair Spread: " << r->fair_spread()*10000 << " bps" << std::endl;
+    std::cout << "NPV: " << r->npv() << " | Fair Spread: " << r->fair_spread().value()*10000 << " bps" << std::endl;
     EXPECT_NEAR(r->npv(), 86698.9, 1.0);
-    EXPECT_NEAR(r->fair_spread(), 0.0118792, 0.0001);
+    EXPECT_NEAR(r->fair_spread().value(), 0.0118792, 0.0001);
 }
 
 TEST_F(ServerClientTest, BootstrapInflationCurves_RoundTrip) {

--- a/tests/parity/cds_test.cpp
+++ b/tests/parity/cds_test.cpp
@@ -111,7 +111,7 @@ TEST_F(QuantraComparisonTest, CDS_NPVMatches) {
     respB->Finish(resp);
     auto r = flatbuffers::GetRoot<quantra::PriceCDSResponse>(respB->GetBufferPointer())->cds_list()->Get(0);
     double qNPV = r->npv();
-    double qFair = r->fair_spread();
+    double qFair = r->fair_spread().value();
 
     std::cout << "QuantLib NPV: " << qlNPV << " | Quantra: " << qNPV << " | Diff: " << std::abs(qlNPV-qNPV) << std::endl;
     std::cout << "QuantLib Fair: " << qlFair*10000 << "bps | Quantra: " << qFair*10000 << "bps" << std::endl;
@@ -242,7 +242,7 @@ TEST_F(QuantraComparisonTest, CDS_Seller_NPVMatches) {
     respB->Finish(resp);
     const auto* r = flatbuffers::GetRoot<quantra::PriceCDSResponse>(respB->GetBufferPointer())->cds_list()->Get(0);
     EXPECT_NEAR(qlNPV, r->npv(), 0.01);
-    EXPECT_NEAR(qlFair, r->fair_spread(), 1e-6);
+    EXPECT_NEAR(qlFair, r->fair_spread().value(), 1e-6);
 }
 
 // Buyer, semiannual premium schedule and a low recovery (0.25) — different
@@ -348,7 +348,7 @@ TEST_F(QuantraComparisonTest, CDS_Semiannual_LowRecovery) {
     respB->Finish(resp);
     const auto* r = flatbuffers::GetRoot<quantra::PriceCDSResponse>(respB->GetBufferPointer())->cds_list()->Get(0);
     EXPECT_NEAR(qlNPV, r->npv(), 0.01);
-    EXPECT_NEAR(qlFair, r->fair_spread(), 1e-6);
+    EXPECT_NEAR(qlFair, r->fair_spread().value(), 1e-6);
 }
 
 }} // namespace quantra::testing


### PR DESCRIPTION
**Schema v3, step 2 (wire-breaking).** Replaces the CDS value-sentinel logic with optional-with-presence.

- `flat_hazard_rate` / `running_coupon` / `upfront` become optional (`= null`).
- **An empty credit curve** (no `flat_hazard_rate` and no quotes) now returns `INVALID_ARGUMENT` instead of **silently pricing off an invented 1% flat hazard**.
- `flat_hazard_rate` present (incl. a genuine 0) → flat-hazard curve; absent + quotes → bootstrap; absent + neither → error.
- A **genuine 0 running coupon** on an upfront quote is now valid and prices, instead of being rejected by a `== 0.0` value test.
- `upfront` presence (not a `!= 0` test) selects the upfront path.
- Presence threaded through the CDS mapper/registry into the plain-domain structs (evaluator stays FlatBuffers-free).

+2 error-contract scenarios (empty curve → 400; zero-running-coupon upfront → 200). Public `VERSION`/docs bump in the release step. Regenerated FlatBuffers/OpenAPI included. Full suite green in Docker.

Step 2 of the v3 sequence (helpers ✓ → CDS → convention enums → required fields → dates → 3.0.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
