### PR TITLE
Cache compiled objects with ccache to speed up rebuilds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ logs/
 
 # Python build/cache artifacts
 *.egg-info/
+
+# ccache (build.sh compiler cache)
+.ccache/

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -23,8 +23,25 @@ echo "=== Cleaning build directory ==="
 rm -rf "$WORKSPACE/build"
 mkdir -p "$WORKSPACE/build"
 
+# Optional ccache. The clean rebuild above throws away build/ every run, but
+# ccache keys on preprocessed source + flags, so it still turns incremental
+# edits into second-scale recompiles. The cache lives inside the (mounted)
+# workspace so it survives `docker run --rm`. Best effort: if ccache is absent
+# and cannot be installed, the build simply proceeds without it.
+CMAKE_CCACHE_ARGS=()
+if ! command -v ccache >/dev/null 2>&1; then
+    apt-get update -qq >/dev/null 2>&1 && apt-get install -y -qq ccache >/dev/null 2>&1 || true
+fi
+if command -v ccache >/dev/null 2>&1; then
+    export CCACHE_DIR="$WORKSPACE/.ccache"
+    export CCACHE_MAXSIZE="${CCACHE_MAXSIZE:-2G}"
+    CMAKE_CCACHE_ARGS=(-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache)
+    echo "=== ccache enabled (CCACHE_DIR=$CCACHE_DIR) ==="
+fi
+
 cd "$WORKSPACE/build"
-cmake -DCMAKE_PREFIX_PATH="$DEPS_PREFIX" -DCMAKE_BUILD_TYPE="$BUILD_TYPE" ..
+cmake ${CMAKE_CCACHE_ARGS[@]+"${CMAKE_CCACHE_ARGS[@]}"} \
+    -DCMAKE_PREFIX_PATH="$DEPS_PREFIX" -DCMAKE_BUILD_TYPE="$BUILD_TYPE" ..
 make -j"$(nproc)"
 
 echo "Build complete!"


### PR DESCRIPTION
Speeds up the dev/gate loop. `build.sh` clears `build/` every run, so each gate did a full from-scratch compile (~9 min) even for a one-line change — the dominant cost when iterating on a PR.

Enables **ccache**: `build.sh` installs it if missing and sets `CCACHE_DIR=$WORKSPACE/.ccache`, which lives inside the mounted workspace so the cache **survives `docker run --rm`** (no gate-command or image changes needed). Passed to CMake via `CMAKE_C/CXX_COMPILER_LAUNCHER`. Self-contained and best-effort: where ccache is absent and can’t be installed (e.g. CI’s fresh runner) the build just proceeds normally.

**Measured in the test image:** cold gate (build + full suite) **611s**; a warm rebuild with no source change **52s** — the build step drops from ~9 min to under a minute. `.ccache/` is gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
