### PR TITLE
Require explicit schedule conventions (schema v3, step 3a: Schedule)

### DIFF
--- a/flatbuffers/cpp/schedule_generated.h
+++ b/flatbuffers/cpp/schedule_generated.h
@@ -23,13 +23,13 @@ struct ScheduleT;
 
 struct ScheduleT : public ::flatbuffers::NativeTable {
   typedef Schedule TableType;
-  quantra::enums::Calendar calendar = quantra::enums::Calendar_Argentina;
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt;
   std::string effective_date{};
   std::string termination_date{};
-  quantra::enums::Frequency frequency = quantra::enums::Frequency_Annual;
-  quantra::enums::BusinessDayConvention convention = quantra::enums::BusinessDayConvention_Following;
-  quantra::enums::BusinessDayConvention termination_date_convention = quantra::enums::BusinessDayConvention_Following;
-  quantra::enums::DateGenerationRule date_generation_rule = quantra::enums::DateGenerationRule_Backward;
+  ::flatbuffers::Optional<quantra::enums::Frequency> frequency = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> convention = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> termination_date_convention = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::DateGenerationRule> date_generation_rule = ::flatbuffers::nullopt;
   bool end_of_month = false;
 };
 
@@ -47,8 +47,8 @@ struct Schedule FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
     VT_DATE_GENERATION_RULE = 16,
     VT_END_OF_MONTH = 18
   };
-  quantra::enums::Calendar calendar() const {
-    return static_cast<quantra::enums::Calendar>(GetField<int8_t>(VT_CALENDAR, 0));
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar() const {
+    return GetOptional<int8_t, quantra::enums::Calendar>(VT_CALENDAR);
   }
   const ::flatbuffers::String *effective_date() const {
     return GetPointer<const ::flatbuffers::String *>(VT_EFFECTIVE_DATE);
@@ -56,17 +56,17 @@ struct Schedule FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   const ::flatbuffers::String *termination_date() const {
     return GetPointer<const ::flatbuffers::String *>(VT_TERMINATION_DATE);
   }
-  quantra::enums::Frequency frequency() const {
-    return static_cast<quantra::enums::Frequency>(GetField<int8_t>(VT_FREQUENCY, 0));
+  ::flatbuffers::Optional<quantra::enums::Frequency> frequency() const {
+    return GetOptional<int8_t, quantra::enums::Frequency>(VT_FREQUENCY);
   }
-  quantra::enums::BusinessDayConvention convention() const {
-    return static_cast<quantra::enums::BusinessDayConvention>(GetField<int8_t>(VT_CONVENTION, 0));
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> convention() const {
+    return GetOptional<int8_t, quantra::enums::BusinessDayConvention>(VT_CONVENTION);
   }
-  quantra::enums::BusinessDayConvention termination_date_convention() const {
-    return static_cast<quantra::enums::BusinessDayConvention>(GetField<int8_t>(VT_TERMINATION_DATE_CONVENTION, 0));
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> termination_date_convention() const {
+    return GetOptional<int8_t, quantra::enums::BusinessDayConvention>(VT_TERMINATION_DATE_CONVENTION);
   }
-  quantra::enums::DateGenerationRule date_generation_rule() const {
-    return static_cast<quantra::enums::DateGenerationRule>(GetField<int8_t>(VT_DATE_GENERATION_RULE, 0));
+  ::flatbuffers::Optional<quantra::enums::DateGenerationRule> date_generation_rule() const {
+    return GetOptional<int8_t, quantra::enums::DateGenerationRule>(VT_DATE_GENERATION_RULE);
   }
   bool end_of_month() const {
     return GetField<uint8_t>(VT_END_OF_MONTH, 0) != 0;
@@ -95,7 +95,7 @@ struct ScheduleBuilder {
   ::flatbuffers::FlatBufferBuilder &fbb_;
   ::flatbuffers::uoffset_t start_;
   void add_calendar(quantra::enums::Calendar calendar) {
-    fbb_.AddElement<int8_t>(Schedule::VT_CALENDAR, static_cast<int8_t>(calendar), 0);
+    fbb_.AddElement<int8_t>(Schedule::VT_CALENDAR, static_cast<int8_t>(calendar));
   }
   void add_effective_date(::flatbuffers::Offset<::flatbuffers::String> effective_date) {
     fbb_.AddOffset(Schedule::VT_EFFECTIVE_DATE, effective_date);
@@ -104,16 +104,16 @@ struct ScheduleBuilder {
     fbb_.AddOffset(Schedule::VT_TERMINATION_DATE, termination_date);
   }
   void add_frequency(quantra::enums::Frequency frequency) {
-    fbb_.AddElement<int8_t>(Schedule::VT_FREQUENCY, static_cast<int8_t>(frequency), 0);
+    fbb_.AddElement<int8_t>(Schedule::VT_FREQUENCY, static_cast<int8_t>(frequency));
   }
   void add_convention(quantra::enums::BusinessDayConvention convention) {
-    fbb_.AddElement<int8_t>(Schedule::VT_CONVENTION, static_cast<int8_t>(convention), 0);
+    fbb_.AddElement<int8_t>(Schedule::VT_CONVENTION, static_cast<int8_t>(convention));
   }
   void add_termination_date_convention(quantra::enums::BusinessDayConvention termination_date_convention) {
-    fbb_.AddElement<int8_t>(Schedule::VT_TERMINATION_DATE_CONVENTION, static_cast<int8_t>(termination_date_convention), 0);
+    fbb_.AddElement<int8_t>(Schedule::VT_TERMINATION_DATE_CONVENTION, static_cast<int8_t>(termination_date_convention));
   }
   void add_date_generation_rule(quantra::enums::DateGenerationRule date_generation_rule) {
-    fbb_.AddElement<int8_t>(Schedule::VT_DATE_GENERATION_RULE, static_cast<int8_t>(date_generation_rule), 0);
+    fbb_.AddElement<int8_t>(Schedule::VT_DATE_GENERATION_RULE, static_cast<int8_t>(date_generation_rule));
   }
   void add_end_of_month(bool end_of_month) {
     fbb_.AddElement<uint8_t>(Schedule::VT_END_OF_MONTH, static_cast<uint8_t>(end_of_month), 0);
@@ -131,35 +131,35 @@ struct ScheduleBuilder {
 
 inline ::flatbuffers::Offset<Schedule> CreateSchedule(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    quantra::enums::Calendar calendar = quantra::enums::Calendar_Argentina,
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<::flatbuffers::String> effective_date = 0,
     ::flatbuffers::Offset<::flatbuffers::String> termination_date = 0,
-    quantra::enums::Frequency frequency = quantra::enums::Frequency_Annual,
-    quantra::enums::BusinessDayConvention convention = quantra::enums::BusinessDayConvention_Following,
-    quantra::enums::BusinessDayConvention termination_date_convention = quantra::enums::BusinessDayConvention_Following,
-    quantra::enums::DateGenerationRule date_generation_rule = quantra::enums::DateGenerationRule_Backward,
+    ::flatbuffers::Optional<quantra::enums::Frequency> frequency = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> convention = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> termination_date_convention = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::DateGenerationRule> date_generation_rule = ::flatbuffers::nullopt,
     bool end_of_month = false) {
   ScheduleBuilder builder_(_fbb);
   builder_.add_termination_date(termination_date);
   builder_.add_effective_date(effective_date);
   builder_.add_end_of_month(end_of_month);
-  builder_.add_date_generation_rule(date_generation_rule);
-  builder_.add_termination_date_convention(termination_date_convention);
-  builder_.add_convention(convention);
-  builder_.add_frequency(frequency);
-  builder_.add_calendar(calendar);
+  if(date_generation_rule) { builder_.add_date_generation_rule(*date_generation_rule); }
+  if(termination_date_convention) { builder_.add_termination_date_convention(*termination_date_convention); }
+  if(convention) { builder_.add_convention(*convention); }
+  if(frequency) { builder_.add_frequency(*frequency); }
+  if(calendar) { builder_.add_calendar(*calendar); }
   return builder_.Finish();
 }
 
 inline ::flatbuffers::Offset<Schedule> CreateScheduleDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    quantra::enums::Calendar calendar = quantra::enums::Calendar_Argentina,
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
     const char *effective_date = nullptr,
     const char *termination_date = nullptr,
-    quantra::enums::Frequency frequency = quantra::enums::Frequency_Annual,
-    quantra::enums::BusinessDayConvention convention = quantra::enums::BusinessDayConvention_Following,
-    quantra::enums::BusinessDayConvention termination_date_convention = quantra::enums::BusinessDayConvention_Following,
-    quantra::enums::DateGenerationRule date_generation_rule = quantra::enums::DateGenerationRule_Backward,
+    ::flatbuffers::Optional<quantra::enums::Frequency> frequency = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> convention = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> termination_date_convention = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::DateGenerationRule> date_generation_rule = ::flatbuffers::nullopt,
     bool end_of_month = false) {
   auto effective_date__ = effective_date ? _fbb.CreateString(effective_date) : 0;
   auto termination_date__ = termination_date ? _fbb.CreateString(termination_date) : 0;

--- a/flatbuffers/fbs/schedule.fbs
+++ b/flatbuffers/fbs/schedule.fbs
@@ -4,12 +4,12 @@ namespace quantra;
 
 /// Date schedule definition for payment and accrual dates.
 table Schedule {
-    calendar:enums.Calendar;
+    calendar:enums.Calendar = null;
     effective_date:string;
     termination_date:string;
-    frequency:enums.Frequency;
-    convention:enums.BusinessDayConvention;
-    termination_date_convention:enums.BusinessDayConvention;
-    date_generation_rule:enums.DateGenerationRule;
+    frequency:enums.Frequency = null;
+    convention:enums.BusinessDayConvention = null;
+    termination_date_convention:enums.BusinessDayConvention = null;
+    date_generation_rule:enums.DateGenerationRule = null;
     end_of_month:bool;
 }

--- a/flatbuffers/python/quantra/Schedule.py
+++ b/flatbuffers/python/quantra/Schedule.py
@@ -30,7 +30,7 @@ class Schedule(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # Schedule
     def EffectiveDate(self):
@@ -51,28 +51,28 @@ class Schedule(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(10))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # Schedule
     def Convention(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(12))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # Schedule
     def TerminationDateConvention(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(14))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # Schedule
     def DateGenerationRule(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(16))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # Schedule
     def EndOfMonth(self):
@@ -88,7 +88,7 @@ def Start(builder):
     ScheduleStart(builder)
 
 def ScheduleAddCalendar(builder, calendar):
-    builder.PrependInt8Slot(0, calendar, 0)
+    builder.PrependInt8Slot(0, calendar, None)
 
 def AddCalendar(builder, calendar):
     ScheduleAddCalendar(builder, calendar)
@@ -106,25 +106,25 @@ def AddTerminationDate(builder, terminationDate):
     ScheduleAddTerminationDate(builder, terminationDate)
 
 def ScheduleAddFrequency(builder, frequency):
-    builder.PrependInt8Slot(3, frequency, 0)
+    builder.PrependInt8Slot(3, frequency, None)
 
 def AddFrequency(builder, frequency):
     ScheduleAddFrequency(builder, frequency)
 
 def ScheduleAddConvention(builder, convention):
-    builder.PrependInt8Slot(4, convention, 0)
+    builder.PrependInt8Slot(4, convention, None)
 
 def AddConvention(builder, convention):
     ScheduleAddConvention(builder, convention)
 
 def ScheduleAddTerminationDateConvention(builder, terminationDateConvention):
-    builder.PrependInt8Slot(5, terminationDateConvention, 0)
+    builder.PrependInt8Slot(5, terminationDateConvention, None)
 
 def AddTerminationDateConvention(builder, terminationDateConvention):
     ScheduleAddTerminationDateConvention(builder, terminationDateConvention)
 
 def ScheduleAddDateGenerationRule(builder, dateGenerationRule):
-    builder.PrependInt8Slot(6, dateGenerationRule, 0)
+    builder.PrependInt8Slot(6, dateGenerationRule, None)
 
 def AddDateGenerationRule(builder, dateGenerationRule):
     ScheduleAddDateGenerationRule(builder, dateGenerationRule)
@@ -146,13 +146,13 @@ class ScheduleT(object):
 
     # ScheduleT
     def __init__(self):
-        self.calendar = 0  # type: int
+        self.calendar = None  # type: Optional[int]
         self.effectiveDate = None  # type: str
         self.terminationDate = None  # type: str
-        self.frequency = 0  # type: int
-        self.convention = 0  # type: int
-        self.terminationDateConvention = 0  # type: int
-        self.dateGenerationRule = 0  # type: int
+        self.frequency = None  # type: Optional[int]
+        self.convention = None  # type: Optional[int]
+        self.terminationDateConvention = None  # type: Optional[int]
+        self.dateGenerationRule = None  # type: Optional[int]
         self.endOfMonth = False  # type: bool
 
     @classmethod

--- a/scripts/generate_schemas.sh
+++ b/scripts/generate_schemas.sh
@@ -54,15 +54,17 @@ touch "$GEN_PYTHON_DIR/quantra/__init__.py"
 
 # 4. Generate JSON Schemas (only for files with root_type)
 echo "[4/6] Generating JSON schemas..."
-# flatc --jsonschema rejects optional scalars (`field:double = null`), which
-# the wire schemas use for presence-based selection (BondHelper.price etc.).
+# flatc --jsonschema rejects optional scalars (`field:double = null`) and
+# optional enums (`field:enums.Foo = null`), which the wire schemas use for
+# presence-based selection (BondHelper.price, Schedule.calendar, etc.).
 # JSON Schema cannot express scalar presence beyond required[] anyway, so
 # strip the `= null` markers into a temp copy just for this generator — the
-# emitted schemas are identical to what optional-aware output would be.
+# emitted schemas are identical to what optional-aware output would be. The
+# type class allows dots and uppercase so namespaced enum types are matched.
 JSONSCHEMA_FBS_DIR=$(mktemp -d)
 trap 'rm -rf "$JSONSCHEMA_FBS_DIR"' EXIT
 cp "$FBS_DIR"/*.fbs "$JSONSCHEMA_FBS_DIR/"
-sed -i -E 's/^(\s*[A-Za-z0-9_]+\s*:\s*[a-z0-9]+)\s*=\s*null\s*;/\1;/' "$JSONSCHEMA_FBS_DIR"/*.fbs
+sed -i -E 's/^(\s*[A-Za-z0-9_]+\s*:\s*[A-Za-z0-9_.]+)\s*=\s*null\s*;/\1;/' "$JSONSCHEMA_FBS_DIR"/*.fbs
 ROOT_FILES=$(grep -lE '^\s*root_type\s+' "$JSONSCHEMA_FBS_DIR"/*.fbs || true)
 if [ -z "$ROOT_FILES" ]; then
     echo "  No root_type declarations found; skipping."

--- a/src/market/curve_cache_key.cpp
+++ b/src/market/curve_cache_key.cpp
@@ -117,13 +117,24 @@ void CurveKeyBuilder::writeSchedule(
         return;
     }
     buf.writeU8(1);
-    buf.writeU8(static_cast<uint8_t>(sched->calendar()));
+    // The convention enums are presence-required (an omitted convention is a
+    // request error, never a default). Serialize a presence byte plus the value
+    // so a present field never collides with an absent one in the cache key.
+    auto writeOptEnum = [&buf](auto opt) {
+        if (opt.has_value()) {
+            buf.writeU8(1);
+            buf.writeU8(static_cast<uint8_t>(opt.value()));
+        } else {
+            buf.writeU8(0);
+        }
+    };
+    writeOptEnum(sched->calendar());
     buf.writeFbString(sched->effective_date());
     buf.writeFbString(sched->termination_date());
-    buf.writeU8(static_cast<uint8_t>(sched->frequency()));
-    buf.writeU8(static_cast<uint8_t>(sched->convention()));
-    buf.writeU8(static_cast<uint8_t>(sched->termination_date_convention()));
-    buf.writeU8(static_cast<uint8_t>(sched->date_generation_rule()));
+    writeOptEnum(sched->frequency());
+    writeOptEnum(sched->convention());
+    writeOptEnum(sched->termination_date_convention());
+    writeOptEnum(sched->date_generation_rule());
     buf.writeBool(sched->end_of_month());
 }
 

--- a/src/parsers/inflation_curve_parsers.cpp
+++ b/src/parsers/inflation_curve_parsers.cpp
@@ -212,14 +212,23 @@ QuantLib::Schedule buildSchedule(
     if (!scheduleSpec->effective_date() || !scheduleSpec->termination_date()) {
         QUANTRA_INVALID_ARGUMENT(helperLabel + ".schedule requires effective_date and termination_date for curve id: " + curveId);
     }
+    // The convention enums are presence-required: an omitted convention is an
+    // error, never an alphabetical-0 default (calendar Argentina, etc.).
+    if (!scheduleSpec->calendar().has_value() ||
+        !scheduleSpec->frequency().has_value() ||
+        !scheduleSpec->convention().has_value() ||
+        !scheduleSpec->termination_date_convention().has_value() ||
+        !scheduleSpec->date_generation_rule().has_value()) {
+        QUANTRA_INVALID_ARGUMENT(helperLabel + ".schedule requires calendar, frequency, convention, termination_date_convention and date_generation_rule for curve id: " + curveId);
+    }
     return QuantLib::Schedule(
         DateToQL(scheduleSpec->effective_date()->str()),
         DateToQL(scheduleSpec->termination_date()->str()),
-        FrequencyToPeriod(FrequencyToQL(scheduleSpec->frequency())),
-        CalendarToQL(scheduleSpec->calendar()),
-        ConventionToQL(scheduleSpec->convention()),
-        ConventionToQL(scheduleSpec->termination_date_convention()),
-        DateGenerationToQL(scheduleSpec->date_generation_rule()),
+        FrequencyToPeriod(FrequencyToQL(scheduleSpec->frequency().value())),
+        CalendarToQL(scheduleSpec->calendar().value()),
+        ConventionToQL(scheduleSpec->convention().value()),
+        ConventionToQL(scheduleSpec->termination_date_convention().value()),
+        DateGenerationToQL(scheduleSpec->date_generation_rule().value()),
         scheduleSpec->end_of_month());
 }
 

--- a/src/parsers/schedule_parser.cpp
+++ b/src/parsers/schedule_parser.cpp
@@ -40,11 +40,21 @@ std::shared_ptr<QuantLib::Schedule> ScheduleParser::parse(const quantra::Schedul
         QUANTRA_INVALID_ARGUMENT("Schedule.effective_date is required");
     if (!schedule->termination_date())
         QUANTRA_INVALID_ARGUMENT("Schedule.termination_date is required");
+    if (!schedule->calendar().has_value())
+        QUANTRA_INVALID_ARGUMENT("Schedule.calendar is required");
+    if (!schedule->frequency().has_value())
+        QUANTRA_INVALID_ARGUMENT("Schedule.frequency is required");
+    if (!schedule->convention().has_value())
+        QUANTRA_INVALID_ARGUMENT("Schedule.convention is required");
+    if (!schedule->termination_date_convention().has_value())
+        QUANTRA_INVALID_ARGUMENT("Schedule.termination_date_convention is required");
+    if (!schedule->date_generation_rule().has_value())
+        QUANTRA_INVALID_ARGUMENT("Schedule.date_generation_rule is required");
 
     const QuantLib::Date effective = DateToQL(schedule->effective_date()->str());
     const QuantLib::Date termination = DateToQL(schedule->termination_date()->str());
     const QuantLib::Period period =
-        FrequencyToPeriod(FrequencyToQL(schedule->frequency()));
+        FrequencyToPeriod(FrequencyToQL(schedule->frequency().value()));
 
     const long spanDays = termination - effective;
     const long periodDays = approxDaysPerPeriod(period);
@@ -66,9 +76,9 @@ std::shared_ptr<QuantLib::Schedule> ScheduleParser::parse(const quantra::Schedul
         effective,
         termination,
         period,
-        CalendarToQL(schedule->calendar()),
-        ConventionToQL(schedule->convention()),
-        ConventionToQL(schedule->termination_date_convention()),
-        DateGenerationToQL(schedule->date_generation_rule()),
+        CalendarToQL(schedule->calendar().value()),
+        ConventionToQL(schedule->convention().value()),
+        ConventionToQL(schedule->termination_date_convention().value()),
+        DateGenerationToQL(schedule->date_generation_rule().value()),
         schedule->end_of_month());
 }

--- a/tests/contract/error_contract_test.py
+++ b/tests/contract/error_contract_test.py
@@ -145,6 +145,16 @@ def _ec_abusive_schedule(arr_key, product_key):
         sch["frequency"] = "Daily"
         return req
     return f
+def _ec_del_schedule_field(arr_key, product_key, field):
+    """Drop a convention field from the product's schedule. The Schedule
+    convention enums are presence-required: an omitted convention is an error,
+    never an alphabetical-0 default (e.g. calendar Argentina)."""
+    def f(req):
+        req[arr_key][0][product_key]["schedule"].pop(field, None)
+        return req
+    return f
+
+
 def _ec_set_credit_curve_field(field, value):
     def f(req):
         req["pricing"]["credit"]["credit_curves"][0][field] = value
@@ -250,6 +260,17 @@ SCENARIOS = [
     # ---- 400 INVALID_ARGUMENT: unbounded schedule generation guard ----
     ("ec:400 fixed_rate_bond 300y daily schedule rejected", "fixed_rate_bond",
      "fixed_rate_bond_request.json", 400, _ec_abusive_schedule("bonds", "fixed_rate_bond")),
+    # ---- 400 INVALID_ARGUMENT: schedule convention presence ----
+    # A Schedule convention enum omitted from the request must be rejected, not
+    # silently defaulted to the alphabetical-0 value (calendar Argentina, etc.).
+    ("ec:400 fixed_rate_bond schedule missing calendar", "fixed_rate_bond",
+     "fixed_rate_bond_request.json", 400,
+     _ec_del_schedule_field("bonds", "fixed_rate_bond", "calendar"),
+     _ec_body_contains("Schedule.calendar is required")),
+    ("ec:400 fixed_rate_bond schedule missing convention", "fixed_rate_bond",
+     "fixed_rate_bond_request.json", 400,
+     _ec_del_schedule_field("bonds", "fixed_rate_bond", "convention"),
+     _ec_body_contains("Schedule.convention is required")),
     # ---- 400 INVALID_ARGUMENT: fail-closed enum handling ----
     # The CDS credit-curve bootstrap supports LogLinear only; ForwardFlat
     # and LogCubic used to be silently priced as LogLinear. The complex request


### PR DESCRIPTION
**Schema v3, step 3a (wire-breaking): the shared `Schedule` table.** Its convention enums had no defaults, so an omitted field silently took the alphabetical-0 value (calendar=Argentina, etc.). Now they require explicit presence.

- `schedule.fbs`: `calendar`, `frequency`, `convention`, `termination_date_convention`, `date_generation_rule` → optional (`= null`).
- `ScheduleParser` (and the separate inflation-helper `buildSchedule` path) require each: present → use it; absent → `INVALID_ARGUMENT` naming the field.
- Cache key serializes a presence byte per schedule enum (absent never keys the same as present).
- `generate_schemas.sh`: the `= null` jsonschema strip now also matches namespaced enum types (flatc `--jsonschema` rejects optional scalars).

**No example/catalog JSON needed editing** — all 152 schedule objects already set every convention field. +2 error-contract scenarios (schedule missing calendar/convention → 400). Regenerated FlatBuffers included. Full suite green (488 cases).

First of the D1 convention-presence sub-PRs (Schedule → curve helpers → vol → swap legs → bonds → FRA/cap/CDS → coupon pricer). Public VERSION bump is the final release step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
