### PR TITLE
Require explicit curve-helper conventions (schema v3, step 3b: helpers)

### DIFF
--- a/flatbuffers/cpp/term_structure_generated.h
+++ b/flatbuffers/cpp/term_structure_generated.h
@@ -542,9 +542,9 @@ struct DepositHelperT : public ::flatbuffers::NativeTable {
   ::flatbuffers::Optional<double> rate = ::flatbuffers::nullopt;
   std::unique_ptr<quantra::PeriodT> tenor{};
   int32_t fixing_days = 0;
-  quantra::enums::Calendar calendar = quantra::enums::Calendar_Argentina;
-  quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_Following;
-  quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360;
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt;
   std::string quote_id{};
   DepositHelperT() = default;
   DepositHelperT(const DepositHelperT &o);
@@ -575,14 +575,14 @@ struct DepositHelper FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   int32_t fixing_days() const {
     return GetField<int32_t>(VT_FIXING_DAYS, 0);
   }
-  quantra::enums::Calendar calendar() const {
-    return static_cast<quantra::enums::Calendar>(GetField<int8_t>(VT_CALENDAR, 0));
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar() const {
+    return GetOptional<int8_t, quantra::enums::Calendar>(VT_CALENDAR);
   }
-  quantra::enums::BusinessDayConvention business_day_convention() const {
-    return static_cast<quantra::enums::BusinessDayConvention>(GetField<int8_t>(VT_BUSINESS_DAY_CONVENTION, 0));
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention() const {
+    return GetOptional<int8_t, quantra::enums::BusinessDayConvention>(VT_BUSINESS_DAY_CONVENTION);
   }
-  quantra::enums::DayCounter day_counter() const {
-    return static_cast<quantra::enums::DayCounter>(GetField<int8_t>(VT_DAY_COUNTER, 0));
+  ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter() const {
+    return GetOptional<int8_t, quantra::enums::DayCounter>(VT_DAY_COUNTER);
   }
   /// Optional: reference a shared quote by id instead of inline rate.
   const ::flatbuffers::String *quote_id() const {
@@ -620,13 +620,13 @@ struct DepositHelperBuilder {
     fbb_.AddElement<int32_t>(DepositHelper::VT_FIXING_DAYS, fixing_days, 0);
   }
   void add_calendar(quantra::enums::Calendar calendar) {
-    fbb_.AddElement<int8_t>(DepositHelper::VT_CALENDAR, static_cast<int8_t>(calendar), 0);
+    fbb_.AddElement<int8_t>(DepositHelper::VT_CALENDAR, static_cast<int8_t>(calendar));
   }
   void add_business_day_convention(quantra::enums::BusinessDayConvention business_day_convention) {
-    fbb_.AddElement<int8_t>(DepositHelper::VT_BUSINESS_DAY_CONVENTION, static_cast<int8_t>(business_day_convention), 0);
+    fbb_.AddElement<int8_t>(DepositHelper::VT_BUSINESS_DAY_CONVENTION, static_cast<int8_t>(business_day_convention));
   }
   void add_day_counter(quantra::enums::DayCounter day_counter) {
-    fbb_.AddElement<int8_t>(DepositHelper::VT_DAY_COUNTER, static_cast<int8_t>(day_counter), 0);
+    fbb_.AddElement<int8_t>(DepositHelper::VT_DAY_COUNTER, static_cast<int8_t>(day_counter));
   }
   void add_quote_id(::flatbuffers::Offset<::flatbuffers::String> quote_id) {
     fbb_.AddOffset(DepositHelper::VT_QUOTE_ID, quote_id);
@@ -647,18 +647,18 @@ inline ::flatbuffers::Offset<DepositHelper> CreateDepositHelper(
     ::flatbuffers::Optional<double> rate = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::Period> tenor = 0,
     int32_t fixing_days = 0,
-    quantra::enums::Calendar calendar = quantra::enums::Calendar_Argentina,
-    quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_Following,
-    quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360,
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<::flatbuffers::String> quote_id = 0) {
   DepositHelperBuilder builder_(_fbb);
   if(rate) { builder_.add_rate(*rate); }
   builder_.add_quote_id(quote_id);
   builder_.add_fixing_days(fixing_days);
   builder_.add_tenor(tenor);
-  builder_.add_day_counter(day_counter);
-  builder_.add_business_day_convention(business_day_convention);
-  builder_.add_calendar(calendar);
+  if(day_counter) { builder_.add_day_counter(*day_counter); }
+  if(business_day_convention) { builder_.add_business_day_convention(*business_day_convention); }
+  if(calendar) { builder_.add_calendar(*calendar); }
   return builder_.Finish();
 }
 
@@ -667,9 +667,9 @@ inline ::flatbuffers::Offset<DepositHelper> CreateDepositHelperDirect(
     ::flatbuffers::Optional<double> rate = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::Period> tenor = 0,
     int32_t fixing_days = 0,
-    quantra::enums::Calendar calendar = quantra::enums::Calendar_Argentina,
-    quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_Following,
-    quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360,
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
     const char *quote_id = nullptr) {
   auto quote_id__ = quote_id ? _fbb.CreateString(quote_id) : 0;
   return quantra::CreateDepositHelper(
@@ -691,9 +691,9 @@ struct FRAHelperT : public ::flatbuffers::NativeTable {
   int32_t months_to_start = 0;
   int32_t months_to_end = 0;
   int32_t fixing_days = 0;
-  quantra::enums::Calendar calendar = quantra::enums::Calendar_Argentina;
-  quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_Following;
-  quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360;
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt;
   std::string quote_id{};
 };
 
@@ -724,14 +724,14 @@ struct FRAHelper FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   int32_t fixing_days() const {
     return GetField<int32_t>(VT_FIXING_DAYS, 0);
   }
-  quantra::enums::Calendar calendar() const {
-    return static_cast<quantra::enums::Calendar>(GetField<int8_t>(VT_CALENDAR, 0));
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar() const {
+    return GetOptional<int8_t, quantra::enums::Calendar>(VT_CALENDAR);
   }
-  quantra::enums::BusinessDayConvention business_day_convention() const {
-    return static_cast<quantra::enums::BusinessDayConvention>(GetField<int8_t>(VT_BUSINESS_DAY_CONVENTION, 0));
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention() const {
+    return GetOptional<int8_t, quantra::enums::BusinessDayConvention>(VT_BUSINESS_DAY_CONVENTION);
   }
-  quantra::enums::DayCounter day_counter() const {
-    return static_cast<quantra::enums::DayCounter>(GetField<int8_t>(VT_DAY_COUNTER, 0));
+  ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter() const {
+    return GetOptional<int8_t, quantra::enums::DayCounter>(VT_DAY_COUNTER);
   }
   const ::flatbuffers::String *quote_id() const {
     return GetPointer<const ::flatbuffers::String *>(VT_QUOTE_ID);
@@ -771,13 +771,13 @@ struct FRAHelperBuilder {
     fbb_.AddElement<int32_t>(FRAHelper::VT_FIXING_DAYS, fixing_days, 0);
   }
   void add_calendar(quantra::enums::Calendar calendar) {
-    fbb_.AddElement<int8_t>(FRAHelper::VT_CALENDAR, static_cast<int8_t>(calendar), 0);
+    fbb_.AddElement<int8_t>(FRAHelper::VT_CALENDAR, static_cast<int8_t>(calendar));
   }
   void add_business_day_convention(quantra::enums::BusinessDayConvention business_day_convention) {
-    fbb_.AddElement<int8_t>(FRAHelper::VT_BUSINESS_DAY_CONVENTION, static_cast<int8_t>(business_day_convention), 0);
+    fbb_.AddElement<int8_t>(FRAHelper::VT_BUSINESS_DAY_CONVENTION, static_cast<int8_t>(business_day_convention));
   }
   void add_day_counter(quantra::enums::DayCounter day_counter) {
-    fbb_.AddElement<int8_t>(FRAHelper::VT_DAY_COUNTER, static_cast<int8_t>(day_counter), 0);
+    fbb_.AddElement<int8_t>(FRAHelper::VT_DAY_COUNTER, static_cast<int8_t>(day_counter));
   }
   void add_quote_id(::flatbuffers::Offset<::flatbuffers::String> quote_id) {
     fbb_.AddOffset(FRAHelper::VT_QUOTE_ID, quote_id);
@@ -799,9 +799,9 @@ inline ::flatbuffers::Offset<FRAHelper> CreateFRAHelper(
     int32_t months_to_start = 0,
     int32_t months_to_end = 0,
     int32_t fixing_days = 0,
-    quantra::enums::Calendar calendar = quantra::enums::Calendar_Argentina,
-    quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_Following,
-    quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360,
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<::flatbuffers::String> quote_id = 0) {
   FRAHelperBuilder builder_(_fbb);
   if(rate) { builder_.add_rate(*rate); }
@@ -809,9 +809,9 @@ inline ::flatbuffers::Offset<FRAHelper> CreateFRAHelper(
   builder_.add_fixing_days(fixing_days);
   builder_.add_months_to_end(months_to_end);
   builder_.add_months_to_start(months_to_start);
-  builder_.add_day_counter(day_counter);
-  builder_.add_business_day_convention(business_day_convention);
-  builder_.add_calendar(calendar);
+  if(day_counter) { builder_.add_day_counter(*day_counter); }
+  if(business_day_convention) { builder_.add_business_day_convention(*business_day_convention); }
+  if(calendar) { builder_.add_calendar(*calendar); }
   return builder_.Finish();
 }
 
@@ -821,9 +821,9 @@ inline ::flatbuffers::Offset<FRAHelper> CreateFRAHelperDirect(
     int32_t months_to_start = 0,
     int32_t months_to_end = 0,
     int32_t fixing_days = 0,
-    quantra::enums::Calendar calendar = quantra::enums::Calendar_Argentina,
-    quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_Following,
-    quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360,
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
     const char *quote_id = nullptr) {
   auto quote_id__ = quote_id ? _fbb.CreateString(quote_id) : 0;
   return quantra::CreateFRAHelper(
@@ -845,9 +845,9 @@ struct FutureHelperT : public ::flatbuffers::NativeTable {
   ::flatbuffers::Optional<double> rate = ::flatbuffers::nullopt;
   std::string future_start_date{};
   int32_t future_months = 0;
-  quantra::enums::Calendar calendar = quantra::enums::Calendar_Argentina;
-  quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_Following;
-  quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360;
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt;
   ::flatbuffers::Optional<double> futures_price = ::flatbuffers::nullopt;
   double convexity_adjustment = 0.0;
   std::string quote_id{};
@@ -879,14 +879,14 @@ struct FutureHelper FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   int32_t future_months() const {
     return GetField<int32_t>(VT_FUTURE_MONTHS, 0);
   }
-  quantra::enums::Calendar calendar() const {
-    return static_cast<quantra::enums::Calendar>(GetField<int8_t>(VT_CALENDAR, 0));
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar() const {
+    return GetOptional<int8_t, quantra::enums::Calendar>(VT_CALENDAR);
   }
-  quantra::enums::BusinessDayConvention business_day_convention() const {
-    return static_cast<quantra::enums::BusinessDayConvention>(GetField<int8_t>(VT_BUSINESS_DAY_CONVENTION, 0));
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention() const {
+    return GetOptional<int8_t, quantra::enums::BusinessDayConvention>(VT_BUSINESS_DAY_CONVENTION);
   }
-  quantra::enums::DayCounter day_counter() const {
-    return static_cast<quantra::enums::DayCounter>(GetField<int8_t>(VT_DAY_COUNTER, 0));
+  ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter() const {
+    return GetOptional<int8_t, quantra::enums::DayCounter>(VT_DAY_COUNTER);
   }
   /// Futures price (e.g., 95.25); when present, rate is ignored.
   ::flatbuffers::Optional<double> futures_price() const {
@@ -933,13 +933,13 @@ struct FutureHelperBuilder {
     fbb_.AddElement<int32_t>(FutureHelper::VT_FUTURE_MONTHS, future_months, 0);
   }
   void add_calendar(quantra::enums::Calendar calendar) {
-    fbb_.AddElement<int8_t>(FutureHelper::VT_CALENDAR, static_cast<int8_t>(calendar), 0);
+    fbb_.AddElement<int8_t>(FutureHelper::VT_CALENDAR, static_cast<int8_t>(calendar));
   }
   void add_business_day_convention(quantra::enums::BusinessDayConvention business_day_convention) {
-    fbb_.AddElement<int8_t>(FutureHelper::VT_BUSINESS_DAY_CONVENTION, static_cast<int8_t>(business_day_convention), 0);
+    fbb_.AddElement<int8_t>(FutureHelper::VT_BUSINESS_DAY_CONVENTION, static_cast<int8_t>(business_day_convention));
   }
   void add_day_counter(quantra::enums::DayCounter day_counter) {
-    fbb_.AddElement<int8_t>(FutureHelper::VT_DAY_COUNTER, static_cast<int8_t>(day_counter), 0);
+    fbb_.AddElement<int8_t>(FutureHelper::VT_DAY_COUNTER, static_cast<int8_t>(day_counter));
   }
   void add_futures_price(double futures_price) {
     fbb_.AddElement<double>(FutureHelper::VT_FUTURES_PRICE, futures_price);
@@ -966,9 +966,9 @@ inline ::flatbuffers::Offset<FutureHelper> CreateFutureHelper(
     ::flatbuffers::Optional<double> rate = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<::flatbuffers::String> future_start_date = 0,
     int32_t future_months = 0,
-    quantra::enums::Calendar calendar = quantra::enums::Calendar_Argentina,
-    quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_Following,
-    quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360,
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
     ::flatbuffers::Optional<double> futures_price = ::flatbuffers::nullopt,
     double convexity_adjustment = 0.0,
     ::flatbuffers::Offset<::flatbuffers::String> quote_id = 0) {
@@ -979,9 +979,9 @@ inline ::flatbuffers::Offset<FutureHelper> CreateFutureHelper(
   builder_.add_quote_id(quote_id);
   builder_.add_future_months(future_months);
   builder_.add_future_start_date(future_start_date);
-  builder_.add_day_counter(day_counter);
-  builder_.add_business_day_convention(business_day_convention);
-  builder_.add_calendar(calendar);
+  if(day_counter) { builder_.add_day_counter(*day_counter); }
+  if(business_day_convention) { builder_.add_business_day_convention(*business_day_convention); }
+  if(calendar) { builder_.add_calendar(*calendar); }
   return builder_.Finish();
 }
 
@@ -990,9 +990,9 @@ inline ::flatbuffers::Offset<FutureHelper> CreateFutureHelperDirect(
     ::flatbuffers::Optional<double> rate = ::flatbuffers::nullopt,
     const char *future_start_date = nullptr,
     int32_t future_months = 0,
-    quantra::enums::Calendar calendar = quantra::enums::Calendar_Argentina,
-    quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_Following,
-    quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360,
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
     ::flatbuffers::Optional<double> futures_price = ::flatbuffers::nullopt,
     double convexity_adjustment = 0.0,
     const char *quote_id = nullptr) {
@@ -1017,10 +1017,10 @@ struct SwapHelperT : public ::flatbuffers::NativeTable {
   typedef SwapHelper TableType;
   ::flatbuffers::Optional<double> rate = ::flatbuffers::nullopt;
   std::unique_ptr<quantra::PeriodT> tenor{};
-  quantra::enums::Calendar calendar = quantra::enums::Calendar_Argentina;
-  quantra::enums::Frequency sw_fixed_leg_frequency = quantra::enums::Frequency_Annual;
-  quantra::enums::BusinessDayConvention sw_fixed_leg_convention = quantra::enums::BusinessDayConvention_Following;
-  quantra::enums::DayCounter sw_fixed_leg_day_counter = quantra::enums::DayCounter_Actual360;
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::Frequency> sw_fixed_leg_frequency = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> sw_fixed_leg_convention = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::DayCounter> sw_fixed_leg_day_counter = ::flatbuffers::nullopt;
   std::unique_ptr<quantra::IndexRefT> float_index{};
   double spread = 0.0;
   int32_t fwd_start_days = 0;
@@ -1056,17 +1056,17 @@ struct SwapHelper FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   const quantra::Period *tenor() const {
     return GetPointer<const quantra::Period *>(VT_TENOR);
   }
-  quantra::enums::Calendar calendar() const {
-    return static_cast<quantra::enums::Calendar>(GetField<int8_t>(VT_CALENDAR, 0));
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar() const {
+    return GetOptional<int8_t, quantra::enums::Calendar>(VT_CALENDAR);
   }
-  quantra::enums::Frequency sw_fixed_leg_frequency() const {
-    return static_cast<quantra::enums::Frequency>(GetField<int8_t>(VT_SW_FIXED_LEG_FREQUENCY, 0));
+  ::flatbuffers::Optional<quantra::enums::Frequency> sw_fixed_leg_frequency() const {
+    return GetOptional<int8_t, quantra::enums::Frequency>(VT_SW_FIXED_LEG_FREQUENCY);
   }
-  quantra::enums::BusinessDayConvention sw_fixed_leg_convention() const {
-    return static_cast<quantra::enums::BusinessDayConvention>(GetField<int8_t>(VT_SW_FIXED_LEG_CONVENTION, 0));
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> sw_fixed_leg_convention() const {
+    return GetOptional<int8_t, quantra::enums::BusinessDayConvention>(VT_SW_FIXED_LEG_CONVENTION);
   }
-  quantra::enums::DayCounter sw_fixed_leg_day_counter() const {
-    return static_cast<quantra::enums::DayCounter>(GetField<int8_t>(VT_SW_FIXED_LEG_DAY_COUNTER, 0));
+  ::flatbuffers::Optional<quantra::enums::DayCounter> sw_fixed_leg_day_counter() const {
+    return GetOptional<int8_t, quantra::enums::DayCounter>(VT_SW_FIXED_LEG_DAY_COUNTER);
   }
   /// Reference to an IndexDef by id (e.g., "EUR_6M").
   const quantra::IndexRef *float_index() const {
@@ -1120,16 +1120,16 @@ struct SwapHelperBuilder {
     fbb_.AddOffset(SwapHelper::VT_TENOR, tenor);
   }
   void add_calendar(quantra::enums::Calendar calendar) {
-    fbb_.AddElement<int8_t>(SwapHelper::VT_CALENDAR, static_cast<int8_t>(calendar), 0);
+    fbb_.AddElement<int8_t>(SwapHelper::VT_CALENDAR, static_cast<int8_t>(calendar));
   }
   void add_sw_fixed_leg_frequency(quantra::enums::Frequency sw_fixed_leg_frequency) {
-    fbb_.AddElement<int8_t>(SwapHelper::VT_SW_FIXED_LEG_FREQUENCY, static_cast<int8_t>(sw_fixed_leg_frequency), 0);
+    fbb_.AddElement<int8_t>(SwapHelper::VT_SW_FIXED_LEG_FREQUENCY, static_cast<int8_t>(sw_fixed_leg_frequency));
   }
   void add_sw_fixed_leg_convention(quantra::enums::BusinessDayConvention sw_fixed_leg_convention) {
-    fbb_.AddElement<int8_t>(SwapHelper::VT_SW_FIXED_LEG_CONVENTION, static_cast<int8_t>(sw_fixed_leg_convention), 0);
+    fbb_.AddElement<int8_t>(SwapHelper::VT_SW_FIXED_LEG_CONVENTION, static_cast<int8_t>(sw_fixed_leg_convention));
   }
   void add_sw_fixed_leg_day_counter(quantra::enums::DayCounter sw_fixed_leg_day_counter) {
-    fbb_.AddElement<int8_t>(SwapHelper::VT_SW_FIXED_LEG_DAY_COUNTER, static_cast<int8_t>(sw_fixed_leg_day_counter), 0);
+    fbb_.AddElement<int8_t>(SwapHelper::VT_SW_FIXED_LEG_DAY_COUNTER, static_cast<int8_t>(sw_fixed_leg_day_counter));
   }
   void add_float_index(::flatbuffers::Offset<quantra::IndexRef> float_index) {
     fbb_.AddOffset(SwapHelper::VT_FLOAT_INDEX, float_index);
@@ -1162,10 +1162,10 @@ inline ::flatbuffers::Offset<SwapHelper> CreateSwapHelper(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     ::flatbuffers::Optional<double> rate = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::Period> tenor = 0,
-    quantra::enums::Calendar calendar = quantra::enums::Calendar_Argentina,
-    quantra::enums::Frequency sw_fixed_leg_frequency = quantra::enums::Frequency_Annual,
-    quantra::enums::BusinessDayConvention sw_fixed_leg_convention = quantra::enums::BusinessDayConvention_Following,
-    quantra::enums::DayCounter sw_fixed_leg_day_counter = quantra::enums::DayCounter_Actual360,
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::Frequency> sw_fixed_leg_frequency = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> sw_fixed_leg_convention = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::DayCounter> sw_fixed_leg_day_counter = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::IndexRef> float_index = 0,
     double spread = 0.0,
     int32_t fwd_start_days = 0,
@@ -1179,10 +1179,10 @@ inline ::flatbuffers::Offset<SwapHelper> CreateSwapHelper(
   builder_.add_fwd_start_days(fwd_start_days);
   builder_.add_float_index(float_index);
   builder_.add_tenor(tenor);
-  builder_.add_sw_fixed_leg_day_counter(sw_fixed_leg_day_counter);
-  builder_.add_sw_fixed_leg_convention(sw_fixed_leg_convention);
-  builder_.add_sw_fixed_leg_frequency(sw_fixed_leg_frequency);
-  builder_.add_calendar(calendar);
+  if(sw_fixed_leg_day_counter) { builder_.add_sw_fixed_leg_day_counter(*sw_fixed_leg_day_counter); }
+  if(sw_fixed_leg_convention) { builder_.add_sw_fixed_leg_convention(*sw_fixed_leg_convention); }
+  if(sw_fixed_leg_frequency) { builder_.add_sw_fixed_leg_frequency(*sw_fixed_leg_frequency); }
+  if(calendar) { builder_.add_calendar(*calendar); }
   return builder_.Finish();
 }
 
@@ -1190,10 +1190,10 @@ inline ::flatbuffers::Offset<SwapHelper> CreateSwapHelperDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     ::flatbuffers::Optional<double> rate = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::Period> tenor = 0,
-    quantra::enums::Calendar calendar = quantra::enums::Calendar_Argentina,
-    quantra::enums::Frequency sw_fixed_leg_frequency = quantra::enums::Frequency_Annual,
-    quantra::enums::BusinessDayConvention sw_fixed_leg_convention = quantra::enums::BusinessDayConvention_Following,
-    quantra::enums::DayCounter sw_fixed_leg_day_counter = quantra::enums::DayCounter_Actual360,
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::Frequency> sw_fixed_leg_frequency = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> sw_fixed_leg_convention = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::DayCounter> sw_fixed_leg_day_counter = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::IndexRef> float_index = 0,
     double spread = 0.0,
     int32_t fwd_start_days = 0,
@@ -1224,8 +1224,8 @@ struct BondHelperT : public ::flatbuffers::NativeTable {
   double face_amount = 0.0;
   std::unique_ptr<quantra::ScheduleT> schedule{};
   double coupon_rate = 0.0;
-  quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360;
-  quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_Following;
+  ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt;
   double redemption = 0.0;
   std::string issue_date{};
   ::flatbuffers::Optional<double> price = ::flatbuffers::nullopt;
@@ -1270,11 +1270,11 @@ struct BondHelper FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   double coupon_rate() const {
     return GetField<double>(VT_COUPON_RATE, 0.0);
   }
-  quantra::enums::DayCounter day_counter() const {
-    return static_cast<quantra::enums::DayCounter>(GetField<int8_t>(VT_DAY_COUNTER, 0));
+  ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter() const {
+    return GetOptional<int8_t, quantra::enums::DayCounter>(VT_DAY_COUNTER);
   }
-  quantra::enums::BusinessDayConvention business_day_convention() const {
-    return static_cast<quantra::enums::BusinessDayConvention>(GetField<int8_t>(VT_BUSINESS_DAY_CONVENTION, 0));
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention() const {
+    return GetOptional<int8_t, quantra::enums::BusinessDayConvention>(VT_BUSINESS_DAY_CONVENTION);
   }
   double redemption() const {
     return GetField<double>(VT_REDEMPTION, 0.0);
@@ -1332,10 +1332,10 @@ struct BondHelperBuilder {
     fbb_.AddElement<double>(BondHelper::VT_COUPON_RATE, coupon_rate, 0.0);
   }
   void add_day_counter(quantra::enums::DayCounter day_counter) {
-    fbb_.AddElement<int8_t>(BondHelper::VT_DAY_COUNTER, static_cast<int8_t>(day_counter), 0);
+    fbb_.AddElement<int8_t>(BondHelper::VT_DAY_COUNTER, static_cast<int8_t>(day_counter));
   }
   void add_business_day_convention(quantra::enums::BusinessDayConvention business_day_convention) {
-    fbb_.AddElement<int8_t>(BondHelper::VT_BUSINESS_DAY_CONVENTION, static_cast<int8_t>(business_day_convention), 0);
+    fbb_.AddElement<int8_t>(BondHelper::VT_BUSINESS_DAY_CONVENTION, static_cast<int8_t>(business_day_convention));
   }
   void add_redemption(double redemption) {
     fbb_.AddElement<double>(BondHelper::VT_REDEMPTION, redemption, 0.0);
@@ -1367,8 +1367,8 @@ inline ::flatbuffers::Offset<BondHelper> CreateBondHelper(
     double face_amount = 0.0,
     ::flatbuffers::Offset<quantra::Schedule> schedule = 0,
     double coupon_rate = 0.0,
-    quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360,
-    quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_Following,
+    ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt,
     double redemption = 0.0,
     ::flatbuffers::Offset<::flatbuffers::String> issue_date = 0,
     ::flatbuffers::Optional<double> price = ::flatbuffers::nullopt,
@@ -1383,8 +1383,8 @@ inline ::flatbuffers::Offset<BondHelper> CreateBondHelper(
   builder_.add_issue_date(issue_date);
   builder_.add_schedule(schedule);
   builder_.add_settlement_days(settlement_days);
-  builder_.add_business_day_convention(business_day_convention);
-  builder_.add_day_counter(day_counter);
+  if(business_day_convention) { builder_.add_business_day_convention(*business_day_convention); }
+  if(day_counter) { builder_.add_day_counter(*day_counter); }
   return builder_.Finish();
 }
 
@@ -1395,8 +1395,8 @@ inline ::flatbuffers::Offset<BondHelper> CreateBondHelperDirect(
     double face_amount = 0.0,
     ::flatbuffers::Offset<quantra::Schedule> schedule = 0,
     double coupon_rate = 0.0,
-    quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360,
-    quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_Following,
+    ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt,
     double redemption = 0.0,
     const char *issue_date = nullptr,
     ::flatbuffers::Optional<double> price = ::flatbuffers::nullopt,
@@ -1964,7 +1964,7 @@ struct TenorBasisSwapHelperT : public ::flatbuffers::NativeTable {
   std::unique_ptr<quantra::PeriodT> tenor{};
   std::unique_ptr<quantra::IndexRefT> index_short{};
   std::unique_ptr<quantra::IndexRefT> index_long{};
-  quantra::enums::Calendar calendar = quantra::enums::Calendar_Argentina;
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt;
   std::unique_ptr<quantra::HelperDependenciesT> deps{};
   std::string quote_id{};
   TenorBasisSwapHelperT() = default;
@@ -2001,8 +2001,8 @@ struct TenorBasisSwapHelper FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Tab
   const quantra::IndexRef *index_long() const {
     return GetPointer<const quantra::IndexRef *>(VT_INDEX_LONG);
   }
-  quantra::enums::Calendar calendar() const {
-    return static_cast<quantra::enums::Calendar>(GetField<int8_t>(VT_CALENDAR, 0));
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar() const {
+    return GetOptional<int8_t, quantra::enums::Calendar>(VT_CALENDAR);
   }
   const quantra::HelperDependencies *deps() const {
     return GetPointer<const quantra::HelperDependencies *>(VT_DEPS);
@@ -2048,7 +2048,7 @@ struct TenorBasisSwapHelperBuilder {
     fbb_.AddOffset(TenorBasisSwapHelper::VT_INDEX_LONG, index_long);
   }
   void add_calendar(quantra::enums::Calendar calendar) {
-    fbb_.AddElement<int8_t>(TenorBasisSwapHelper::VT_CALENDAR, static_cast<int8_t>(calendar), 0);
+    fbb_.AddElement<int8_t>(TenorBasisSwapHelper::VT_CALENDAR, static_cast<int8_t>(calendar));
   }
   void add_deps(::flatbuffers::Offset<quantra::HelperDependencies> deps) {
     fbb_.AddOffset(TenorBasisSwapHelper::VT_DEPS, deps);
@@ -2075,7 +2075,7 @@ inline ::flatbuffers::Offset<TenorBasisSwapHelper> CreateTenorBasisSwapHelper(
     ::flatbuffers::Offset<quantra::Period> tenor = 0,
     ::flatbuffers::Offset<quantra::IndexRef> index_short = 0,
     ::flatbuffers::Offset<quantra::IndexRef> index_long = 0,
-    quantra::enums::Calendar calendar = quantra::enums::Calendar_Argentina,
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::HelperDependencies> deps = 0,
     ::flatbuffers::Offset<::flatbuffers::String> quote_id = 0) {
   TenorBasisSwapHelperBuilder builder_(_fbb);
@@ -2085,7 +2085,7 @@ inline ::flatbuffers::Offset<TenorBasisSwapHelper> CreateTenorBasisSwapHelper(
   builder_.add_index_long(index_long);
   builder_.add_index_short(index_short);
   builder_.add_tenor(tenor);
-  builder_.add_calendar(calendar);
+  if(calendar) { builder_.add_calendar(*calendar); }
   return builder_.Finish();
 }
 
@@ -2095,7 +2095,7 @@ inline ::flatbuffers::Offset<TenorBasisSwapHelper> CreateTenorBasisSwapHelperDir
     ::flatbuffers::Offset<quantra::Period> tenor = 0,
     ::flatbuffers::Offset<quantra::IndexRef> index_short = 0,
     ::flatbuffers::Offset<quantra::IndexRef> index_long = 0,
-    quantra::enums::Calendar calendar = quantra::enums::Calendar_Argentina,
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::HelperDependencies> deps = 0,
     const char *quote_id = nullptr) {
   auto quote_id__ = quote_id ? _fbb.CreateString(quote_id) : 0;
@@ -2546,8 +2546,8 @@ inline ::flatbuffers::Offset<PointsWrapper> CreatePointsWrapper(
 struct TermStructureT : public ::flatbuffers::NativeTable {
   typedef TermStructure TableType;
   std::string id{};
-  quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360;
-  quantra::enums::Interpolator interpolator = quantra::enums::Interpolator_BackwardFlat;
+  ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::Interpolator> interpolator = ::flatbuffers::nullopt;
   quantra::enums::BootstrapTrait bootstrap_trait = quantra::enums::BootstrapTrait_Discount;
   std::vector<std::unique_ptr<quantra::PointsWrapperT>> points{};
   std::string reference_date{};
@@ -2572,11 +2572,11 @@ struct TermStructure FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   const ::flatbuffers::String *id() const {
     return GetPointer<const ::flatbuffers::String *>(VT_ID);
   }
-  quantra::enums::DayCounter day_counter() const {
-    return static_cast<quantra::enums::DayCounter>(GetField<int8_t>(VT_DAY_COUNTER, 0));
+  ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter() const {
+    return GetOptional<int8_t, quantra::enums::DayCounter>(VT_DAY_COUNTER);
   }
-  quantra::enums::Interpolator interpolator() const {
-    return static_cast<quantra::enums::Interpolator>(GetField<int8_t>(VT_INTERPOLATOR, 0));
+  ::flatbuffers::Optional<quantra::enums::Interpolator> interpolator() const {
+    return GetOptional<int8_t, quantra::enums::Interpolator>(VT_INTERPOLATOR);
   }
   quantra::enums::BootstrapTrait bootstrap_trait() const {
     return static_cast<quantra::enums::BootstrapTrait>(GetField<int8_t>(VT_BOOTSTRAP_TRAIT, 0));
@@ -2614,10 +2614,10 @@ struct TermStructureBuilder {
     fbb_.AddOffset(TermStructure::VT_ID, id);
   }
   void add_day_counter(quantra::enums::DayCounter day_counter) {
-    fbb_.AddElement<int8_t>(TermStructure::VT_DAY_COUNTER, static_cast<int8_t>(day_counter), 0);
+    fbb_.AddElement<int8_t>(TermStructure::VT_DAY_COUNTER, static_cast<int8_t>(day_counter));
   }
   void add_interpolator(quantra::enums::Interpolator interpolator) {
-    fbb_.AddElement<int8_t>(TermStructure::VT_INTERPOLATOR, static_cast<int8_t>(interpolator), 0);
+    fbb_.AddElement<int8_t>(TermStructure::VT_INTERPOLATOR, static_cast<int8_t>(interpolator));
   }
   void add_bootstrap_trait(quantra::enums::BootstrapTrait bootstrap_trait) {
     fbb_.AddElement<int8_t>(TermStructure::VT_BOOTSTRAP_TRAIT, static_cast<int8_t>(bootstrap_trait), 0);
@@ -2642,8 +2642,8 @@ struct TermStructureBuilder {
 inline ::flatbuffers::Offset<TermStructure> CreateTermStructure(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     ::flatbuffers::Offset<::flatbuffers::String> id = 0,
-    quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360,
-    quantra::enums::Interpolator interpolator = quantra::enums::Interpolator_BackwardFlat,
+    ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::Interpolator> interpolator = ::flatbuffers::nullopt,
     quantra::enums::BootstrapTrait bootstrap_trait = quantra::enums::BootstrapTrait_Discount,
     ::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<quantra::PointsWrapper>>> points = 0,
     ::flatbuffers::Offset<::flatbuffers::String> reference_date = 0) {
@@ -2652,16 +2652,16 @@ inline ::flatbuffers::Offset<TermStructure> CreateTermStructure(
   builder_.add_points(points);
   builder_.add_id(id);
   builder_.add_bootstrap_trait(bootstrap_trait);
-  builder_.add_interpolator(interpolator);
-  builder_.add_day_counter(day_counter);
+  if(interpolator) { builder_.add_interpolator(*interpolator); }
+  if(day_counter) { builder_.add_day_counter(*day_counter); }
   return builder_.Finish();
 }
 
 inline ::flatbuffers::Offset<TermStructure> CreateTermStructureDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     const char *id = nullptr,
-    quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360,
-    quantra::enums::Interpolator interpolator = quantra::enums::Interpolator_BackwardFlat,
+    ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::Interpolator> interpolator = ::flatbuffers::nullopt,
     quantra::enums::BootstrapTrait bootstrap_trait = quantra::enums::BootstrapTrait_Discount,
     const std::vector<::flatbuffers::Offset<quantra::PointsWrapper>> *points = nullptr,
     const char *reference_date = nullptr) {

--- a/flatbuffers/fbs/term_structure.fbs
+++ b/flatbuffers/fbs/term_structure.fbs
@@ -28,9 +28,9 @@ table DepositHelper {
     rate:double = null;
     tenor:Period;
     fixing_days:int;
-    calendar:enums.Calendar;
-    business_day_convention:enums.BusinessDayConvention;
-    day_counter:enums.DayCounter;
+    calendar:enums.Calendar = null;
+    business_day_convention:enums.BusinessDayConvention = null;
+    day_counter:enums.DayCounter = null;
     /// Optional: reference a shared quote by id instead of inline rate.
     quote_id:string;
 }
@@ -42,9 +42,9 @@ table FRAHelper {
     months_to_start:int;
     months_to_end:int;
     fixing_days:int;
-    calendar:enums.Calendar;
-    business_day_convention:enums.BusinessDayConvention;
-    day_counter:enums.DayCounter;
+    calendar:enums.Calendar = null;
+    business_day_convention:enums.BusinessDayConvention = null;
+    day_counter:enums.DayCounter = null;
     quote_id:string;
 }
 
@@ -55,9 +55,9 @@ table FutureHelper {
     rate:double = null;
     future_start_date:string;
     future_months:int;
-    calendar:enums.Calendar;
-    business_day_convention:enums.BusinessDayConvention;
-    day_counter:enums.DayCounter;
+    calendar:enums.Calendar = null;
+    business_day_convention:enums.BusinessDayConvention = null;
+    day_counter:enums.DayCounter = null;
     /// Futures price (e.g., 95.25); when present, rate is ignored.
     futures_price:double = null;
     /// Convexity adjustment added to implied rate.
@@ -70,10 +70,10 @@ table SwapHelper {
     /// Swap rate. One of rate or quote_id must be provided.
     rate:double = null;
     tenor:Period;
-    calendar:enums.Calendar;
-    sw_fixed_leg_frequency:enums.Frequency;
-    sw_fixed_leg_convention:enums.BusinessDayConvention;
-    sw_fixed_leg_day_counter:enums.DayCounter;
+    calendar:enums.Calendar = null;
+    sw_fixed_leg_frequency:enums.Frequency = null;
+    sw_fixed_leg_convention:enums.BusinessDayConvention = null;
+    sw_fixed_leg_day_counter:enums.DayCounter = null;
     /// Reference to an IndexDef by id (e.g., "EUR_6M").
     float_index:IndexRef (required);
     spread:double;
@@ -92,8 +92,8 @@ table BondHelper {
     face_amount:double;
     schedule:Schedule;
     coupon_rate:double;
-    day_counter:enums.DayCounter;
-    business_day_convention:enums.BusinessDayConvention;
+    day_counter:enums.DayCounter = null;
+    business_day_convention:enums.BusinessDayConvention = null;
     redemption:double;
     issue_date:string;
     /// Bond (clean) price; when present, rate is ignored.
@@ -160,7 +160,7 @@ table TenorBasisSwapHelper {
     index_short:IndexRef (required);
     /// Long tenor index (e.g., "EUR_6M").
     index_long:IndexRef (required);
-    calendar:enums.Calendar;
+    calendar:enums.Calendar = null;
     deps:HelperDependencies;
     quote_id:string;
 }
@@ -213,8 +213,8 @@ table PointsWrapper {
 /// Term structure (yield curve) definition.
 table TermStructure {
     id:string;
-    day_counter:enums.DayCounter;
-    interpolator:enums.Interpolator;
+    day_counter:enums.DayCounter = null;
+    interpolator:enums.Interpolator = null;
     bootstrap_trait:enums.BootstrapTrait;
     points:[PointsWrapper];
     reference_date:string;

--- a/flatbuffers/python/quantra/BondHelper.py
+++ b/flatbuffers/python/quantra/BondHelper.py
@@ -71,14 +71,14 @@ class BondHelper(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(14))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # BondHelper
     def BusinessDayConvention(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(16))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # BondHelper
     def Redemption(self):
@@ -146,13 +146,13 @@ def AddCouponRate(builder, couponRate):
     BondHelperAddCouponRate(builder, couponRate)
 
 def BondHelperAddDayCounter(builder, dayCounter):
-    builder.PrependInt8Slot(5, dayCounter, 0)
+    builder.PrependInt8Slot(5, dayCounter, None)
 
 def AddDayCounter(builder, dayCounter):
     BondHelperAddDayCounter(builder, dayCounter)
 
 def BondHelperAddBusinessDayConvention(builder, businessDayConvention):
-    builder.PrependInt8Slot(6, businessDayConvention, 0)
+    builder.PrependInt8Slot(6, businessDayConvention, None)
 
 def AddBusinessDayConvention(builder, businessDayConvention):
     BondHelperAddBusinessDayConvention(builder, businessDayConvention)
@@ -201,8 +201,8 @@ class BondHelperT(object):
         self.faceAmount = 0.0  # type: float
         self.schedule = None  # type: Optional[ScheduleT]
         self.couponRate = 0.0  # type: float
-        self.dayCounter = 0  # type: int
-        self.businessDayConvention = 0  # type: int
+        self.dayCounter = None  # type: Optional[int]
+        self.businessDayConvention = None  # type: Optional[int]
         self.redemption = 0.0  # type: float
         self.issueDate = None  # type: str
         self.price = None  # type: Optional[float]

--- a/flatbuffers/python/quantra/DepositHelper.py
+++ b/flatbuffers/python/quantra/DepositHelper.py
@@ -56,21 +56,21 @@ class DepositHelper(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(10))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # DepositHelper
     def BusinessDayConvention(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(12))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # DepositHelper
     def DayCounter(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(14))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # Optional: reference a shared quote by id instead of inline rate.
     # DepositHelper
@@ -105,19 +105,19 @@ def AddFixingDays(builder, fixingDays):
     DepositHelperAddFixingDays(builder, fixingDays)
 
 def DepositHelperAddCalendar(builder, calendar):
-    builder.PrependInt8Slot(3, calendar, 0)
+    builder.PrependInt8Slot(3, calendar, None)
 
 def AddCalendar(builder, calendar):
     DepositHelperAddCalendar(builder, calendar)
 
 def DepositHelperAddBusinessDayConvention(builder, businessDayConvention):
-    builder.PrependInt8Slot(4, businessDayConvention, 0)
+    builder.PrependInt8Slot(4, businessDayConvention, None)
 
 def AddBusinessDayConvention(builder, businessDayConvention):
     DepositHelperAddBusinessDayConvention(builder, businessDayConvention)
 
 def DepositHelperAddDayCounter(builder, dayCounter):
-    builder.PrependInt8Slot(5, dayCounter, 0)
+    builder.PrependInt8Slot(5, dayCounter, None)
 
 def AddDayCounter(builder, dayCounter):
     DepositHelperAddDayCounter(builder, dayCounter)
@@ -146,9 +146,9 @@ class DepositHelperT(object):
         self.rate = None  # type: Optional[float]
         self.tenor = None  # type: Optional[PeriodT]
         self.fixingDays = 0  # type: int
-        self.calendar = 0  # type: int
-        self.businessDayConvention = 0  # type: int
-        self.dayCounter = 0  # type: int
+        self.calendar = None  # type: Optional[int]
+        self.businessDayConvention = None  # type: Optional[int]
+        self.dayCounter = None  # type: Optional[int]
         self.quoteId = None  # type: str
 
     @classmethod

--- a/flatbuffers/python/quantra/FRAHelper.py
+++ b/flatbuffers/python/quantra/FRAHelper.py
@@ -59,21 +59,21 @@ class FRAHelper(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(12))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # FRAHelper
     def BusinessDayConvention(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(14))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # FRAHelper
     def DayCounter(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(16))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # FRAHelper
     def QuoteId(self):
@@ -113,19 +113,19 @@ def AddFixingDays(builder, fixingDays):
     FRAHelperAddFixingDays(builder, fixingDays)
 
 def FRAHelperAddCalendar(builder, calendar):
-    builder.PrependInt8Slot(4, calendar, 0)
+    builder.PrependInt8Slot(4, calendar, None)
 
 def AddCalendar(builder, calendar):
     FRAHelperAddCalendar(builder, calendar)
 
 def FRAHelperAddBusinessDayConvention(builder, businessDayConvention):
-    builder.PrependInt8Slot(5, businessDayConvention, 0)
+    builder.PrependInt8Slot(5, businessDayConvention, None)
 
 def AddBusinessDayConvention(builder, businessDayConvention):
     FRAHelperAddBusinessDayConvention(builder, businessDayConvention)
 
 def FRAHelperAddDayCounter(builder, dayCounter):
-    builder.PrependInt8Slot(6, dayCounter, 0)
+    builder.PrependInt8Slot(6, dayCounter, None)
 
 def AddDayCounter(builder, dayCounter):
     FRAHelperAddDayCounter(builder, dayCounter)
@@ -151,9 +151,9 @@ class FRAHelperT(object):
         self.monthsToStart = 0  # type: int
         self.monthsToEnd = 0  # type: int
         self.fixingDays = 0  # type: int
-        self.calendar = 0  # type: int
-        self.businessDayConvention = 0  # type: int
-        self.dayCounter = 0  # type: int
+        self.calendar = None  # type: Optional[int]
+        self.businessDayConvention = None  # type: Optional[int]
+        self.dayCounter = None  # type: Optional[int]
         self.quoteId = None  # type: str
 
     @classmethod

--- a/flatbuffers/python/quantra/FutureHelper.py
+++ b/flatbuffers/python/quantra/FutureHelper.py
@@ -53,21 +53,21 @@ class FutureHelper(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(10))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # FutureHelper
     def BusinessDayConvention(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(12))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # FutureHelper
     def DayCounter(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(14))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # Futures price (e.g., 95.25); when present, rate is ignored.
     # FutureHelper
@@ -117,19 +117,19 @@ def AddFutureMonths(builder, futureMonths):
     FutureHelperAddFutureMonths(builder, futureMonths)
 
 def FutureHelperAddCalendar(builder, calendar):
-    builder.PrependInt8Slot(3, calendar, 0)
+    builder.PrependInt8Slot(3, calendar, None)
 
 def AddCalendar(builder, calendar):
     FutureHelperAddCalendar(builder, calendar)
 
 def FutureHelperAddBusinessDayConvention(builder, businessDayConvention):
-    builder.PrependInt8Slot(4, businessDayConvention, 0)
+    builder.PrependInt8Slot(4, businessDayConvention, None)
 
 def AddBusinessDayConvention(builder, businessDayConvention):
     FutureHelperAddBusinessDayConvention(builder, businessDayConvention)
 
 def FutureHelperAddDayCounter(builder, dayCounter):
-    builder.PrependInt8Slot(5, dayCounter, 0)
+    builder.PrependInt8Slot(5, dayCounter, None)
 
 def AddDayCounter(builder, dayCounter):
     FutureHelperAddDayCounter(builder, dayCounter)
@@ -166,9 +166,9 @@ class FutureHelperT(object):
         self.rate = None  # type: Optional[float]
         self.futureStartDate = None  # type: str
         self.futureMonths = 0  # type: int
-        self.calendar = 0  # type: int
-        self.businessDayConvention = 0  # type: int
-        self.dayCounter = 0  # type: int
+        self.calendar = None  # type: Optional[int]
+        self.businessDayConvention = None  # type: Optional[int]
+        self.dayCounter = None  # type: Optional[int]
         self.futuresPrice = None  # type: Optional[float]
         self.convexityAdjustment = 0.0  # type: float
         self.quoteId = None  # type: str

--- a/flatbuffers/python/quantra/SwapHelper.py
+++ b/flatbuffers/python/quantra/SwapHelper.py
@@ -49,28 +49,28 @@ class SwapHelper(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(8))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # SwapHelper
     def SwFixedLegFrequency(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(10))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # SwapHelper
     def SwFixedLegConvention(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(12))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # SwapHelper
     def SwFixedLegDayCounter(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(14))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # Reference to an IndexDef by id (e.g., "EUR_6M").
     # SwapHelper
@@ -136,25 +136,25 @@ def AddTenor(builder, tenor):
     SwapHelperAddTenor(builder, tenor)
 
 def SwapHelperAddCalendar(builder, calendar):
-    builder.PrependInt8Slot(2, calendar, 0)
+    builder.PrependInt8Slot(2, calendar, None)
 
 def AddCalendar(builder, calendar):
     SwapHelperAddCalendar(builder, calendar)
 
 def SwapHelperAddSwFixedLegFrequency(builder, swFixedLegFrequency):
-    builder.PrependInt8Slot(3, swFixedLegFrequency, 0)
+    builder.PrependInt8Slot(3, swFixedLegFrequency, None)
 
 def AddSwFixedLegFrequency(builder, swFixedLegFrequency):
     SwapHelperAddSwFixedLegFrequency(builder, swFixedLegFrequency)
 
 def SwapHelperAddSwFixedLegConvention(builder, swFixedLegConvention):
-    builder.PrependInt8Slot(4, swFixedLegConvention, 0)
+    builder.PrependInt8Slot(4, swFixedLegConvention, None)
 
 def AddSwFixedLegConvention(builder, swFixedLegConvention):
     SwapHelperAddSwFixedLegConvention(builder, swFixedLegConvention)
 
 def SwapHelperAddSwFixedLegDayCounter(builder, swFixedLegDayCounter):
-    builder.PrependInt8Slot(5, swFixedLegDayCounter, 0)
+    builder.PrependInt8Slot(5, swFixedLegDayCounter, None)
 
 def AddSwFixedLegDayCounter(builder, swFixedLegDayCounter):
     SwapHelperAddSwFixedLegDayCounter(builder, swFixedLegDayCounter)
@@ -206,10 +206,10 @@ class SwapHelperT(object):
     def __init__(self):
         self.rate = None  # type: Optional[float]
         self.tenor = None  # type: Optional[PeriodT]
-        self.calendar = 0  # type: int
-        self.swFixedLegFrequency = 0  # type: int
-        self.swFixedLegConvention = 0  # type: int
-        self.swFixedLegDayCounter = 0  # type: int
+        self.calendar = None  # type: Optional[int]
+        self.swFixedLegFrequency = None  # type: Optional[int]
+        self.swFixedLegConvention = None  # type: Optional[int]
+        self.swFixedLegDayCounter = None  # type: Optional[int]
         self.floatIndex = None  # type: Optional[IndexRefT]
         self.spread = 0.0  # type: float
         self.fwdStartDays = 0  # type: int

--- a/flatbuffers/python/quantra/TenorBasisSwapHelper.py
+++ b/flatbuffers/python/quantra/TenorBasisSwapHelper.py
@@ -72,7 +72,7 @@ class TenorBasisSwapHelper(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(12))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # TenorBasisSwapHelper
     def Deps(self):
@@ -123,7 +123,7 @@ def AddIndexLong(builder, indexLong):
     TenorBasisSwapHelperAddIndexLong(builder, indexLong)
 
 def TenorBasisSwapHelperAddCalendar(builder, calendar):
-    builder.PrependInt8Slot(4, calendar, 0)
+    builder.PrependInt8Slot(4, calendar, None)
 
 def AddCalendar(builder, calendar):
     TenorBasisSwapHelperAddCalendar(builder, calendar)
@@ -159,7 +159,7 @@ class TenorBasisSwapHelperT(object):
         self.tenor = None  # type: Optional[PeriodT]
         self.indexShort = None  # type: Optional[IndexRefT]
         self.indexLong = None  # type: Optional[IndexRefT]
-        self.calendar = 0  # type: int
+        self.calendar = None  # type: Optional[int]
         self.deps = None  # type: Optional[HelperDependenciesT]
         self.quoteId = None  # type: str
 

--- a/flatbuffers/python/quantra/TermStructure.py
+++ b/flatbuffers/python/quantra/TermStructure.py
@@ -37,14 +37,14 @@ class TermStructure(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # TermStructure
     def Interpolator(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(8))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # TermStructure
     def BootstrapTrait(self):
@@ -98,13 +98,13 @@ def AddId(builder, id):
     TermStructureAddId(builder, id)
 
 def TermStructureAddDayCounter(builder, dayCounter):
-    builder.PrependInt8Slot(1, dayCounter, 0)
+    builder.PrependInt8Slot(1, dayCounter, None)
 
 def AddDayCounter(builder, dayCounter):
     TermStructureAddDayCounter(builder, dayCounter)
 
 def TermStructureAddInterpolator(builder, interpolator):
-    builder.PrependInt8Slot(2, interpolator, 0)
+    builder.PrependInt8Slot(2, interpolator, None)
 
 def AddInterpolator(builder, interpolator):
     TermStructureAddInterpolator(builder, interpolator)
@@ -149,8 +149,8 @@ class TermStructureT(object):
     # TermStructureT
     def __init__(self):
         self.id = None  # type: str
-        self.dayCounter = 0  # type: int
-        self.interpolator = 0  # type: int
+        self.dayCounter = None  # type: Optional[int]
+        self.interpolator = None  # type: Optional[int]
         self.bootstrapTrait = 0  # type: int
         self.points = None  # type: List[PointsWrapperT]
         self.referenceDate = None  # type: str

--- a/src/mappers/bootstrap_curves_mapper.cpp
+++ b/src/mappers/bootstrap_curves_mapper.cpp
@@ -30,10 +30,26 @@ const quantra::TermStructure* findCurveSpecById(
 QuantLib::Calendar calendarFromTermStructure(const quantra::TermStructure* ts) {
     if (ts->points() && ts->points()->size() > 0) {
         const auto* first = ts->points()->Get(0);
-        if (auto h = first->point_as_DepositHelper()) return CalendarToQL(h->calendar());
-        if (auto h = first->point_as_SwapHelper())    return CalendarToQL(h->calendar());
-        if (auto h = first->point_as_FRAHelper())     return CalendarToQL(h->calendar());
-        if (auto h = first->point_as_FutureHelper())  return CalendarToQL(h->calendar());
+        if (auto h = first->point_as_DepositHelper()) {
+            if (!h->calendar().has_value())
+                QUANTRA_INVALID_ARGUMENT("DepositHelper.calendar is required");
+            return CalendarToQL(h->calendar().value());
+        }
+        if (auto h = first->point_as_SwapHelper()) {
+            if (!h->calendar().has_value())
+                QUANTRA_INVALID_ARGUMENT("SwapHelper.calendar is required");
+            return CalendarToQL(h->calendar().value());
+        }
+        if (auto h = first->point_as_FRAHelper()) {
+            if (!h->calendar().has_value())
+                QUANTRA_INVALID_ARGUMENT("FRAHelper.calendar is required");
+            return CalendarToQL(h->calendar().value());
+        }
+        if (auto h = first->point_as_FutureHelper()) {
+            if (!h->calendar().has_value())
+                QUANTRA_INVALID_ARGUMENT("FutureHelper.calendar is required");
+            return CalendarToQL(h->calendar().value());
+        }
         if (auto h = first->point_as_OISHelper())     return CalendarToQL(h->calendar());
     }
     return QuantLib::TARGET();
@@ -68,16 +84,20 @@ std::vector<QuantLib::Date> extractPillarDates(
             }
             QuantLib::Period tenor(
                 deposit->tenor()->n(), TimeUnitToQL(deposit->tenor()->unit()));
+            if (!deposit->business_day_convention().has_value())
+                QUANTRA_INVALID_ARGUMENT("DepositHelper.business_day_convention is required");
             maturityDate = calendar.advance(
-                referenceDate, tenor, ConventionToQL(deposit->business_day_convention()));
+                referenceDate, tenor, ConventionToQL(deposit->business_day_convention().value()));
         } else if (auto swap = point->point_as_SwapHelper()) {
             if (!swap->tenor()) {
                 QUANTRA_INVALID_ARGUMENT("SwapHelper.tenor is required");
             }
             QuantLib::Period tenor(
                 swap->tenor()->n(), TimeUnitToQL(swap->tenor()->unit()));
+            if (!swap->sw_fixed_leg_convention().has_value())
+                QUANTRA_INVALID_ARGUMENT("SwapHelper.sw_fixed_leg_convention is required");
             maturityDate = calendar.advance(
-                referenceDate, tenor, ConventionToQL(swap->sw_fixed_leg_convention()));
+                referenceDate, tenor, ConventionToQL(swap->sw_fixed_leg_convention().value()));
         } else if (auto fra = point->point_as_FRAHelper()) {
             QuantLib::Period startPeriod(fra->months_to_start(), QuantLib::Months);
             QuantLib::Period tenor(

--- a/src/market/curve_cache_key.cpp
+++ b/src/market/curve_cache_key.cpp
@@ -151,6 +151,18 @@ std::vector<uint8_t> CurveKeyBuilder::serializePoint(
     auto ptype = pw->point_type();
     buf.writeU8(static_cast<uint8_t>(ptype));
 
+    // The convention enums are presence-required (an omitted convention is a
+    // request error, never a default). Serialize a presence byte plus the value
+    // so a present field never collides with an absent one in the cache key.
+    auto writeOptEnum = [&buf](auto opt) {
+        if (opt.has_value()) {
+            buf.writeU8(1);
+            buf.writeU8(static_cast<uint8_t>(opt.value()));
+        } else {
+            buf.writeU8(0);
+        }
+    };
+
     switch (ptype) {
 
     case quantra::Point_DepositHelper: {
@@ -160,9 +172,9 @@ std::vector<uint8_t> CurveKeyBuilder::serializePoint(
         buf.writeI32(p->tenor() ? p->tenor()->n() : 0);
         buf.writeU8(static_cast<uint8_t>(p->tenor() ? p->tenor()->unit() : quantra::enums::TimeUnit_Days));
         buf.writeI32(p->fixing_days());
-        buf.writeU8(static_cast<uint8_t>(p->calendar()));
-        buf.writeU8(static_cast<uint8_t>(p->business_day_convention()));
-        buf.writeU8(static_cast<uint8_t>(p->day_counter()));
+        writeOptEnum(p->calendar());
+        writeOptEnum(p->business_day_convention());
+        writeOptEnum(p->day_counter());
         break;
     }
 
@@ -173,9 +185,9 @@ std::vector<uint8_t> CurveKeyBuilder::serializePoint(
         buf.writeI32(p->months_to_start());
         buf.writeI32(p->months_to_end());
         buf.writeI32(p->fixing_days());
-        buf.writeU8(static_cast<uint8_t>(p->calendar()));
-        buf.writeU8(static_cast<uint8_t>(p->business_day_convention()));
-        buf.writeU8(static_cast<uint8_t>(p->day_counter()));
+        writeOptEnum(p->calendar());
+        writeOptEnum(p->business_day_convention());
+        writeOptEnum(p->day_counter());
         break;
     }
 
@@ -192,9 +204,9 @@ std::vector<uint8_t> CurveKeyBuilder::serializePoint(
         buf.writeDouble(resolveQuoteValue(priceValue, p->quote_id(), ctx));
         buf.writeFbString(p->future_start_date());
         buf.writeI32(p->future_months());
-        buf.writeU8(static_cast<uint8_t>(p->calendar()));
-        buf.writeU8(static_cast<uint8_t>(p->business_day_convention()));
-        buf.writeU8(static_cast<uint8_t>(p->day_counter()));
+        writeOptEnum(p->calendar());
+        writeOptEnum(p->business_day_convention());
+        writeOptEnum(p->day_counter());
         buf.writeU8(p->futures_price().has_value() ? 1 : 0);
         buf.writeDouble(p->futures_price().value_or(0.0));
         buf.writeU8(p->rate().has_value() ? 1 : 0);
@@ -209,10 +221,10 @@ std::vector<uint8_t> CurveKeyBuilder::serializePoint(
         buf.writeU8(p->rate().has_value() ? 1 : 0);
         buf.writeI32(p->tenor() ? p->tenor()->n() : 0);
         buf.writeU8(static_cast<uint8_t>(p->tenor() ? p->tenor()->unit() : quantra::enums::TimeUnit_Days));
-        buf.writeU8(static_cast<uint8_t>(p->calendar()));
-        buf.writeU8(static_cast<uint8_t>(p->sw_fixed_leg_frequency()));
-        buf.writeU8(static_cast<uint8_t>(p->sw_fixed_leg_convention()));
-        buf.writeU8(static_cast<uint8_t>(p->sw_fixed_leg_day_counter()));
+        writeOptEnum(p->calendar());
+        writeOptEnum(p->sw_fixed_leg_frequency());
+        writeOptEnum(p->sw_fixed_leg_convention());
+        writeOptEnum(p->sw_fixed_leg_day_counter());
         writeIndexRef(buf, p->float_index());
         buf.writeDouble(p->spread());
         buf.writeI32(p->fwd_start_days());
@@ -238,8 +250,8 @@ std::vector<uint8_t> CurveKeyBuilder::serializePoint(
         buf.writeDouble(p->face_amount());
         writeSchedule(buf, p->schedule());
         buf.writeDouble(p->coupon_rate());
-        buf.writeU8(static_cast<uint8_t>(p->day_counter()));
-        buf.writeU8(static_cast<uint8_t>(p->business_day_convention()));
+        writeOptEnum(p->day_counter());
+        writeOptEnum(p->business_day_convention());
         buf.writeDouble(p->redemption());
         buf.writeFbString(p->issue_date());
         break;
@@ -298,7 +310,7 @@ std::vector<uint8_t> CurveKeyBuilder::serializePoint(
         buf.writeU8(static_cast<uint8_t>(p->tenor() ? p->tenor()->unit() : quantra::enums::TimeUnit_Days));
         writeIndexRef(buf, p->index_short());
         writeIndexRef(buf, p->index_long());
-        buf.writeU8(static_cast<uint8_t>(p->calendar()));
+        writeOptEnum(p->calendar());
         writeDeps(buf, p->deps());
         break;
     }
@@ -463,8 +475,19 @@ void CurveKeyBuilder::writeCurveHeader(
 {
     buf.writeTag("yc-key-v3");
     buf.writeString(asOfDate);
-    buf.writeU8(static_cast<uint8_t>(ts->day_counter()));
-    buf.writeU8(static_cast<uint8_t>(ts->interpolator()));
+    // day_counter and interpolator are presence-required (an omitted convention
+    // is a request error, never a default). Serialize a presence byte plus the
+    // value so a present field never collides with an absent one in the key.
+    auto writeOptEnum = [&buf](auto opt) {
+        if (opt.has_value()) {
+            buf.writeU8(1);
+            buf.writeU8(static_cast<uint8_t>(opt.value()));
+        } else {
+            buf.writeU8(0);
+        }
+    };
+    writeOptEnum(ts->day_counter());
+    writeOptEnum(ts->interpolator());
     buf.writeU8(static_cast<uint8_t>(ts->bootstrap_trait()));
     buf.writeFbString(ts->reference_date());
 }

--- a/src/market/curve_serializer.h
+++ b/src/market/curve_serializer.h
@@ -74,8 +74,10 @@ public:
         // Metadata
         auto refDate = curve->referenceDate();
         data.reference_date = DateToIso(refDate);
-        data.day_counter = static_cast<uint8_t>(ts->day_counter());
-        data.interpolator = static_cast<uint8_t>(ts->interpolator());
+        // Reached only after a successful bootstrap, where TermStructureParser
+        // has already required both fields to be present.
+        data.day_counter = static_cast<uint8_t>(ts->day_counter().value());
+        data.interpolator = static_cast<uint8_t>(ts->interpolator().value());
 
         // Try to extract actual pillar nodes from PiecewiseYieldCurve
         std::vector<QuantLib::Date> pillarDates;
@@ -192,7 +194,7 @@ private:
 
         using namespace QuantLib;
 
-        auto interp = ts->interpolator();
+        auto interp = ts->interpolator().value();
         auto trait  = ts->bootstrap_trait();
 
         // Try the expected combination first (most likely hit)

--- a/src/parsers/term_structure_parser.cpp
+++ b/src/parsers/term_structure_parser.cpp
@@ -35,6 +35,11 @@ std::shared_ptr<YieldTermStructure> TermStructureParser::parse(
     if (!points || points->size() == 0)
         QUANTRA_INVALID_ARGUMENT("Empty list of points for term structure");
 
+    if (!ts->day_counter().has_value())
+        QUANTRA_INVALID_ARGUMENT("TermStructure.day_counter is required");
+    if (!ts->interpolator().has_value())
+        QUANTRA_INVALID_ARGUMENT("TermStructure.interpolator is required");
+
     bool hasZeroPoints = false;
     for (flatbuffers::uoffset_t i = 0; i < points->size(); i++) {
         if (points->Get(i)->point_type() == quantra::Point_ZeroRatePoint) {
@@ -134,9 +139,9 @@ std::shared_ptr<YieldTermStructure> TermStructureParser::buildCurve(
         ref = Settings::instance().evaluationDate();
     }
     
-    DayCounter dc = DayCounterToQL(ts->day_counter());
+    DayCounter dc = DayCounterToQL(ts->day_counter().value());
 
-    switch (ts->interpolator()) {
+    switch (ts->interpolator().value()) {
     case enums::Interpolator_BackwardFlat:
         switch (ts->bootstrap_trait()) {
         case enums::BootstrapTrait_Discount:
@@ -250,9 +255,9 @@ std::shared_ptr<YieldTermStructure> TermStructureParser::buildZeroCurve(
         QUANTRA_INVALID_ARGUMENT("Zero curve requires matching non-empty date/rate vectors");
     }
 
-    DayCounter dc = DayCounterToQL(ts->day_counter());
+    DayCounter dc = DayCounterToQL(ts->day_counter().value());
 
-    switch (ts->interpolator()) {
+    switch (ts->interpolator().value()) {
     case enums::Interpolator_Linear:
         return std::make_shared<InterpolatedZeroCurve<Linear>>(
             dates, zeroRates, dc, Calendar(), Linear(), compounding, frequency);

--- a/src/parsers/term_structure_point_parser.cpp
+++ b/src/parsers/term_structure_point_parser.cpp
@@ -84,14 +84,21 @@ std::shared_ptr<RateHelper> TermStructurePointParser::parse(
         }
         auto q = resolveQuote(rateValue, point->quote_id(), quotes, quantra::QuoteType_Curve, bump);
 
+        if (!point->calendar().has_value())
+            QUANTRA_INVALID_ARGUMENT("DepositHelper.calendar is required");
+        if (!point->business_day_convention().has_value())
+            QUANTRA_INVALID_ARGUMENT("DepositHelper.business_day_convention is required");
+        if (!point->day_counter().has_value())
+            QUANTRA_INVALID_ARGUMENT("DepositHelper.day_counter is required");
+
         return std::make_shared<DepositRateHelper>(
             q,
             point->tenor()->n() * TimeUnitToQL(point->tenor()->unit()),
             point->fixing_days(),
-            CalendarToQL(point->calendar()),
-            ConventionToQL(point->business_day_convention()),
+            CalendarToQL(point->calendar().value()),
+            ConventionToQL(point->business_day_convention().value()),
             true,
-            DayCounterToQL(point->day_counter()));
+            DayCounterToQL(point->day_counter().value()));
     }
 
     // ------------------------------------------------------------------
@@ -110,15 +117,22 @@ std::shared_ptr<RateHelper> TermStructurePointParser::parse(
         }
         auto q = resolveQuote(rateValue, point->quote_id(), quotes, quantra::QuoteType_Curve, bump);
 
+        if (!point->calendar().has_value())
+            QUANTRA_INVALID_ARGUMENT("FRAHelper.calendar is required");
+        if (!point->business_day_convention().has_value())
+            QUANTRA_INVALID_ARGUMENT("FRAHelper.business_day_convention is required");
+        if (!point->day_counter().has_value())
+            QUANTRA_INVALID_ARGUMENT("FRAHelper.day_counter is required");
+
         return std::make_shared<FraRateHelper>(
             q,
             point->months_to_start(),
             point->months_to_end(),
             point->fixing_days(),
-            CalendarToQL(point->calendar()),
-            ConventionToQL(point->business_day_convention()),
+            CalendarToQL(point->calendar().value()),
+            ConventionToQL(point->business_day_convention().value()),
             true,
-            DayCounterToQL(point->day_counter()));
+            DayCounterToQL(point->day_counter().value()));
     }
 
     // ------------------------------------------------------------------
@@ -149,6 +163,12 @@ std::shared_ptr<RateHelper> TermStructurePointParser::parse(
         if (!point->future_start_date()) {
             QUANTRA_INVALID_ARGUMENT("FutureHelper.future_start_date is required");
         }
+        if (!point->calendar().has_value())
+            QUANTRA_INVALID_ARGUMENT("FutureHelper.calendar is required");
+        if (!point->business_day_convention().has_value())
+            QUANTRA_INVALID_ARGUMENT("FutureHelper.business_day_convention is required");
+        if (!point->day_counter().has_value())
+            QUANTRA_INVALID_ARGUMENT("FutureHelper.day_counter is required");
 
         auto convexity = Handle<Quote>(
             std::make_shared<SimpleQuote>(point->convexity_adjustment()));
@@ -157,10 +177,10 @@ std::shared_ptr<RateHelper> TermStructurePointParser::parse(
             q,
             DateToQL(point->future_start_date()->str()),
             point->future_months(),
-            CalendarToQL(point->calendar()),
-            ConventionToQL(point->business_day_convention()),
+            CalendarToQL(point->calendar().value()),
+            ConventionToQL(point->business_day_convention().value()),
             true,
-            DayCounterToQL(point->day_counter()),
+            DayCounterToQL(point->day_counter().value()),
             convexity);
     }
 
@@ -235,13 +255,22 @@ std::shared_ptr<RateHelper> TermStructurePointParser::parse(
             discount = resolveCurve(point->deps()->discount_curve(), curves);
         }
 
+        if (!point->calendar().has_value())
+            QUANTRA_INVALID_ARGUMENT("SwapHelper.calendar is required");
+        if (!point->sw_fixed_leg_frequency().has_value())
+            QUANTRA_INVALID_ARGUMENT("SwapHelper.sw_fixed_leg_frequency is required");
+        if (!point->sw_fixed_leg_convention().has_value())
+            QUANTRA_INVALID_ARGUMENT("SwapHelper.sw_fixed_leg_convention is required");
+        if (!point->sw_fixed_leg_day_counter().has_value())
+            QUANTRA_INVALID_ARGUMENT("SwapHelper.sw_fixed_leg_day_counter is required");
+
         return std::make_shared<SwapRateHelper>(
             q,
             point->tenor()->n() * TimeUnitToQL(point->tenor()->unit()),
-            CalendarToQL(point->calendar()),
-            FrequencyToQL(point->sw_fixed_leg_frequency()),
-            ConventionToQL(point->sw_fixed_leg_convention()),
-            DayCounterToQL(point->sw_fixed_leg_day_counter()),
+            CalendarToQL(point->calendar().value()),
+            FrequencyToQL(point->sw_fixed_leg_frequency().value()),
+            ConventionToQL(point->sw_fixed_leg_convention().value()),
+            DayCounterToQL(point->sw_fixed_leg_day_counter().value()),
             ibor,
             spread,
             point->fwd_start_days() * Days,
@@ -274,6 +303,10 @@ std::shared_ptr<RateHelper> TermStructurePointParser::parse(
         if (!point->issue_date()) {
             QUANTRA_INVALID_ARGUMENT("BondHelper.issue_date is required");
         }
+        if (!point->day_counter().has_value())
+            QUANTRA_INVALID_ARGUMENT("BondHelper.day_counter is required");
+        if (!point->business_day_convention().has_value())
+            QUANTRA_INVALID_ARGUMENT("BondHelper.business_day_convention is required");
 
         return std::make_shared<FixedRateBondHelper>(
             q,
@@ -281,8 +314,8 @@ std::shared_ptr<RateHelper> TermStructurePointParser::parse(
             point->face_amount(),
             *schedule_parser.parse(point->schedule()),
             std::vector<Rate>(1, point->coupon_rate()),
-            DayCounterToQL(point->day_counter()),
-            ConventionToQL(point->business_day_convention()),
+            DayCounterToQL(point->day_counter().value()),
+            ConventionToQL(point->business_day_convention().value()),
             point->redemption(),
             DateToQL(point->issue_date()->str()));
     }

--- a/tests/contract/error_contract_test.py
+++ b/tests/contract/error_contract_test.py
@@ -116,6 +116,16 @@ def _ec_del_curve_point_field(point_type, field):
     return f
 
 
+def _ec_del_curve_field(field):
+    """Drop a top-level convention field from the first pricing curve
+    (TermStructure). day_counter and interpolator are presence-required: an
+    omitted convention is an error, never an alphabetical-0 default."""
+    def f(req):
+        req["pricing"]["rates"]["curves"][0].pop(field, None)
+        return req
+    return f
+
+
 def _ec_future_helper_missing_start_date():
     """Replace the first curve point with a FutureHelper that omits
     future_start_date (optional in the schema, deref'd by the parser)."""
@@ -271,6 +281,18 @@ SCENARIOS = [
      "fixed_rate_bond_request.json", 400,
      _ec_del_schedule_field("bonds", "fixed_rate_bond", "convention"),
      _ec_body_contains("Schedule.convention is required")),
+    # ---- 400 INVALID_ARGUMENT: curve-helper / term-structure convention presence ----
+    # A curve-helper convention enum omitted from the request must be rejected,
+    # not silently defaulted to the alphabetical-0 value. Same for the
+    # TermStructure's own day_counter / interpolator.
+    ("ec:400 fixed_rate_bond curve DepositHelper missing day_counter", "fixed_rate_bond",
+     "fixed_rate_bond_request.json", 400,
+     _ec_del_curve_point_field("DepositHelper", "day_counter"),
+     _ec_body_contains("DepositHelper.day_counter is required")),
+    ("ec:400 fixed_rate_bond curve TermStructure missing interpolator", "fixed_rate_bond",
+     "fixed_rate_bond_request.json", 400,
+     _ec_del_curve_field("interpolator"),
+     _ec_body_contains("TermStructure.interpolator is required")),
     # ---- 400 INVALID_ARGUMENT: fail-closed enum handling ----
     # The CDS credit-curve bootstrap supports LogLinear only; ForwardFlat
     # and LogCubic used to be silently priced as LogLinear. The complex request


### PR DESCRIPTION
**Schema v3, step 3b (wire-breaking): curve-helper conventions.** Extends the convention-presence work to `term_structure.fbs`, so an omitted calendar/convention/day-counter/interpolator on a curve helper errors instead of silently taking the alphabetical-0 value.

**18 fields** → optional-with-presence (`= null`): Deposit/FRA/Future `{calendar, business_day_convention, day_counter}`; SwapHelper `{calendar, sw_fixed_leg_frequency/convention/day_counter}`; BondHelper `{day_counter, business_day_convention}`; `TenorBasisSwapHelper.calendar`; TermStructure `{day_counter, interpolator}`. OIS/DatedOIS/ZeroRatePoint/FxSwap fields with existing sane defaults and all quote/rate/spread fields are untouched.

Every direct reader requires presence (present → `.value()`; absent → `INVALID_ARGUMENT` naming the field): both term-structure parsers, the cache key (presence byte per enum), the curve serializer, and the bootstrap-curves mapper.

**No example/catalog JSON needed editing** — all curated requests already specify these. +2 error-contract scenarios. Regenerated FlatBuffers included. Full suite green in Docker (490 cases).

Step 3b of the D1 convention-presence sub-PRs (Schedule ✓ → helpers → vol → swap legs → bonds → FRA/cap/CDS → coupon pricer). VERSION bump is the final release step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
