### PR TITLE
Require explicit volatility-spec conventions (schema v3, step 3c: vol)

### DIFF
--- a/flatbuffers/cpp/volatility_generated.h
+++ b/flatbuffers/cpp/volatility_generated.h
@@ -594,9 +594,9 @@ inline ::flatbuffers::Offset<QuoteTensor3D> CreateQuoteTensor3DDirect(
 struct IrVolBaseSpecT : public ::flatbuffers::NativeTable {
   typedef IrVolBaseSpec TableType;
   std::string reference_date{};
-  quantra::enums::Calendar calendar = quantra::enums::Calendar_Argentina;
-  quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_Following;
-  quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360;
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt;
   quantra::enums::VolSurfaceShape shape = quantra::enums::VolSurfaceShape_Constant;
   quantra::enums::VolatilityType volatility_type = quantra::enums::VolatilityType_Normal;
   double displacement = 0.0;
@@ -622,14 +622,14 @@ struct IrVolBaseSpec FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   const ::flatbuffers::String *reference_date() const {
     return GetPointer<const ::flatbuffers::String *>(VT_REFERENCE_DATE);
   }
-  quantra::enums::Calendar calendar() const {
-    return static_cast<quantra::enums::Calendar>(GetField<int8_t>(VT_CALENDAR, 0));
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar() const {
+    return GetOptional<int8_t, quantra::enums::Calendar>(VT_CALENDAR);
   }
-  quantra::enums::BusinessDayConvention business_day_convention() const {
-    return static_cast<quantra::enums::BusinessDayConvention>(GetField<int8_t>(VT_BUSINESS_DAY_CONVENTION, 0));
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention() const {
+    return GetOptional<int8_t, quantra::enums::BusinessDayConvention>(VT_BUSINESS_DAY_CONVENTION);
   }
-  quantra::enums::DayCounter day_counter() const {
-    return static_cast<quantra::enums::DayCounter>(GetField<int8_t>(VT_DAY_COUNTER, 0));
+  ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter() const {
+    return GetOptional<int8_t, quantra::enums::DayCounter>(VT_DAY_COUNTER);
   }
   quantra::enums::VolSurfaceShape shape() const {
     return static_cast<quantra::enums::VolSurfaceShape>(GetField<int8_t>(VT_SHAPE, 0));
@@ -676,13 +676,13 @@ struct IrVolBaseSpecBuilder {
     fbb_.AddOffset(IrVolBaseSpec::VT_REFERENCE_DATE, reference_date);
   }
   void add_calendar(quantra::enums::Calendar calendar) {
-    fbb_.AddElement<int8_t>(IrVolBaseSpec::VT_CALENDAR, static_cast<int8_t>(calendar), 0);
+    fbb_.AddElement<int8_t>(IrVolBaseSpec::VT_CALENDAR, static_cast<int8_t>(calendar));
   }
   void add_business_day_convention(quantra::enums::BusinessDayConvention business_day_convention) {
-    fbb_.AddElement<int8_t>(IrVolBaseSpec::VT_BUSINESS_DAY_CONVENTION, static_cast<int8_t>(business_day_convention), 0);
+    fbb_.AddElement<int8_t>(IrVolBaseSpec::VT_BUSINESS_DAY_CONVENTION, static_cast<int8_t>(business_day_convention));
   }
   void add_day_counter(quantra::enums::DayCounter day_counter) {
-    fbb_.AddElement<int8_t>(IrVolBaseSpec::VT_DAY_COUNTER, static_cast<int8_t>(day_counter), 0);
+    fbb_.AddElement<int8_t>(IrVolBaseSpec::VT_DAY_COUNTER, static_cast<int8_t>(day_counter));
   }
   void add_shape(quantra::enums::VolSurfaceShape shape) {
     fbb_.AddElement<int8_t>(IrVolBaseSpec::VT_SHAPE, static_cast<int8_t>(shape), 0);
@@ -713,9 +713,9 @@ struct IrVolBaseSpecBuilder {
 inline ::flatbuffers::Offset<IrVolBaseSpec> CreateIrVolBaseSpec(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     ::flatbuffers::Offset<::flatbuffers::String> reference_date = 0,
-    quantra::enums::Calendar calendar = quantra::enums::Calendar_Argentina,
-    quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_Following,
-    quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360,
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
     quantra::enums::VolSurfaceShape shape = quantra::enums::VolSurfaceShape_Constant,
     quantra::enums::VolatilityType volatility_type = quantra::enums::VolatilityType_Normal,
     double displacement = 0.0,
@@ -728,18 +728,18 @@ inline ::flatbuffers::Offset<IrVolBaseSpec> CreateIrVolBaseSpec(
   builder_.add_reference_date(reference_date);
   builder_.add_volatility_type(volatility_type);
   builder_.add_shape(shape);
-  builder_.add_day_counter(day_counter);
-  builder_.add_business_day_convention(business_day_convention);
-  builder_.add_calendar(calendar);
+  if(day_counter) { builder_.add_day_counter(*day_counter); }
+  if(business_day_convention) { builder_.add_business_day_convention(*business_day_convention); }
+  if(calendar) { builder_.add_calendar(*calendar); }
   return builder_.Finish();
 }
 
 inline ::flatbuffers::Offset<IrVolBaseSpec> CreateIrVolBaseSpecDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     const char *reference_date = nullptr,
-    quantra::enums::Calendar calendar = quantra::enums::Calendar_Argentina,
-    quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_Following,
-    quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360,
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
     quantra::enums::VolSurfaceShape shape = quantra::enums::VolSurfaceShape_Constant,
     quantra::enums::VolatilityType volatility_type = quantra::enums::VolatilityType_Normal,
     double displacement = 0.0,
@@ -765,9 +765,9 @@ inline ::flatbuffers::Offset<IrVolBaseSpec> CreateIrVolBaseSpecDirect(
 struct BlackVolBaseSpecT : public ::flatbuffers::NativeTable {
   typedef BlackVolBaseSpec TableType;
   std::string reference_date{};
-  quantra::enums::Calendar calendar = quantra::enums::Calendar_Argentina;
-  quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_Following;
-  quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360;
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt;
   quantra::enums::VolSurfaceShape shape = quantra::enums::VolSurfaceShape_Constant;
   double constant_vol = 0.0;
   std::string quote_id{};
@@ -789,14 +789,14 @@ struct BlackVolBaseSpec FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   const ::flatbuffers::String *reference_date() const {
     return GetPointer<const ::flatbuffers::String *>(VT_REFERENCE_DATE);
   }
-  quantra::enums::Calendar calendar() const {
-    return static_cast<quantra::enums::Calendar>(GetField<int8_t>(VT_CALENDAR, 0));
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar() const {
+    return GetOptional<int8_t, quantra::enums::Calendar>(VT_CALENDAR);
   }
-  quantra::enums::BusinessDayConvention business_day_convention() const {
-    return static_cast<quantra::enums::BusinessDayConvention>(GetField<int8_t>(VT_BUSINESS_DAY_CONVENTION, 0));
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention() const {
+    return GetOptional<int8_t, quantra::enums::BusinessDayConvention>(VT_BUSINESS_DAY_CONVENTION);
   }
-  quantra::enums::DayCounter day_counter() const {
-    return static_cast<quantra::enums::DayCounter>(GetField<int8_t>(VT_DAY_COUNTER, 0));
+  ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter() const {
+    return GetOptional<int8_t, quantra::enums::DayCounter>(VT_DAY_COUNTER);
   }
   quantra::enums::VolSurfaceShape shape() const {
     return static_cast<quantra::enums::VolSurfaceShape>(GetField<int8_t>(VT_SHAPE, 0));
@@ -834,13 +834,13 @@ struct BlackVolBaseSpecBuilder {
     fbb_.AddOffset(BlackVolBaseSpec::VT_REFERENCE_DATE, reference_date);
   }
   void add_calendar(quantra::enums::Calendar calendar) {
-    fbb_.AddElement<int8_t>(BlackVolBaseSpec::VT_CALENDAR, static_cast<int8_t>(calendar), 0);
+    fbb_.AddElement<int8_t>(BlackVolBaseSpec::VT_CALENDAR, static_cast<int8_t>(calendar));
   }
   void add_business_day_convention(quantra::enums::BusinessDayConvention business_day_convention) {
-    fbb_.AddElement<int8_t>(BlackVolBaseSpec::VT_BUSINESS_DAY_CONVENTION, static_cast<int8_t>(business_day_convention), 0);
+    fbb_.AddElement<int8_t>(BlackVolBaseSpec::VT_BUSINESS_DAY_CONVENTION, static_cast<int8_t>(business_day_convention));
   }
   void add_day_counter(quantra::enums::DayCounter day_counter) {
-    fbb_.AddElement<int8_t>(BlackVolBaseSpec::VT_DAY_COUNTER, static_cast<int8_t>(day_counter), 0);
+    fbb_.AddElement<int8_t>(BlackVolBaseSpec::VT_DAY_COUNTER, static_cast<int8_t>(day_counter));
   }
   void add_shape(quantra::enums::VolSurfaceShape shape) {
     fbb_.AddElement<int8_t>(BlackVolBaseSpec::VT_SHAPE, static_cast<int8_t>(shape), 0);
@@ -865,9 +865,9 @@ struct BlackVolBaseSpecBuilder {
 inline ::flatbuffers::Offset<BlackVolBaseSpec> CreateBlackVolBaseSpec(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     ::flatbuffers::Offset<::flatbuffers::String> reference_date = 0,
-    quantra::enums::Calendar calendar = quantra::enums::Calendar_Argentina,
-    quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_Following,
-    quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360,
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
     quantra::enums::VolSurfaceShape shape = quantra::enums::VolSurfaceShape_Constant,
     double constant_vol = 0.0,
     ::flatbuffers::Offset<::flatbuffers::String> quote_id = 0) {
@@ -876,18 +876,18 @@ inline ::flatbuffers::Offset<BlackVolBaseSpec> CreateBlackVolBaseSpec(
   builder_.add_quote_id(quote_id);
   builder_.add_reference_date(reference_date);
   builder_.add_shape(shape);
-  builder_.add_day_counter(day_counter);
-  builder_.add_business_day_convention(business_day_convention);
-  builder_.add_calendar(calendar);
+  if(day_counter) { builder_.add_day_counter(*day_counter); }
+  if(business_day_convention) { builder_.add_business_day_convention(*business_day_convention); }
+  if(calendar) { builder_.add_calendar(*calendar); }
   return builder_.Finish();
 }
 
 inline ::flatbuffers::Offset<BlackVolBaseSpec> CreateBlackVolBaseSpecDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     const char *reference_date = nullptr,
-    quantra::enums::Calendar calendar = quantra::enums::Calendar_Argentina,
-    quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_Following,
-    quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360,
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
     quantra::enums::VolSurfaceShape shape = quantra::enums::VolSurfaceShape_Constant,
     double constant_vol = 0.0,
     const char *quote_id = nullptr) {

--- a/flatbuffers/fbs/volatility.fbs
+++ b/flatbuffers/fbs/volatility.fbs
@@ -27,9 +27,9 @@ table QuoteTensor3D {
 /// IR volatility base (Normal, Lognormal, ShiftedLognormal). Supports caps/floors and swaptions.
 table IrVolBaseSpec {
     reference_date:string;
-    calendar:enums.Calendar;
-    business_day_convention:enums.BusinessDayConvention;
-    day_counter:enums.DayCounter;
+    calendar:enums.Calendar = null;
+    business_day_convention:enums.BusinessDayConvention = null;
+    day_counter:enums.DayCounter = null;
     shape:enums.VolSurfaceShape = Constant;
     volatility_type:enums.VolatilityType;
     /// Only meaningful for ShiftedLognormal.
@@ -42,9 +42,9 @@ table IrVolBaseSpec {
 /// Equity/FX volatility base (always lognormal, no displacement).
 table BlackVolBaseSpec {
     reference_date:string;
-    calendar:enums.Calendar;
-    business_day_convention:enums.BusinessDayConvention;
-    day_counter:enums.DayCounter;
+    calendar:enums.Calendar = null;
+    business_day_convention:enums.BusinessDayConvention = null;
+    day_counter:enums.DayCounter = null;
     shape:enums.VolSurfaceShape = Constant;
     constant_vol:double;
     /// Optional: resolve constant_vol from pricing.quotes.

--- a/flatbuffers/python/quantra/BlackVolBaseSpec.py
+++ b/flatbuffers/python/quantra/BlackVolBaseSpec.py
@@ -37,21 +37,21 @@ class BlackVolBaseSpec(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # BlackVolBaseSpec
     def BusinessDayConvention(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(8))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # BlackVolBaseSpec
     def DayCounter(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(10))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # BlackVolBaseSpec
     def Shape(self):
@@ -88,19 +88,19 @@ def AddReferenceDate(builder, referenceDate):
     BlackVolBaseSpecAddReferenceDate(builder, referenceDate)
 
 def BlackVolBaseSpecAddCalendar(builder, calendar):
-    builder.PrependInt8Slot(1, calendar, 0)
+    builder.PrependInt8Slot(1, calendar, None)
 
 def AddCalendar(builder, calendar):
     BlackVolBaseSpecAddCalendar(builder, calendar)
 
 def BlackVolBaseSpecAddBusinessDayConvention(builder, businessDayConvention):
-    builder.PrependInt8Slot(2, businessDayConvention, 0)
+    builder.PrependInt8Slot(2, businessDayConvention, None)
 
 def AddBusinessDayConvention(builder, businessDayConvention):
     BlackVolBaseSpecAddBusinessDayConvention(builder, businessDayConvention)
 
 def BlackVolBaseSpecAddDayCounter(builder, dayCounter):
-    builder.PrependInt8Slot(3, dayCounter, 0)
+    builder.PrependInt8Slot(3, dayCounter, None)
 
 def AddDayCounter(builder, dayCounter):
     BlackVolBaseSpecAddDayCounter(builder, dayCounter)
@@ -135,9 +135,9 @@ class BlackVolBaseSpecT(object):
     # BlackVolBaseSpecT
     def __init__(self):
         self.referenceDate = None  # type: str
-        self.calendar = 0  # type: int
-        self.businessDayConvention = 0  # type: int
-        self.dayCounter = 0  # type: int
+        self.calendar = None  # type: Optional[int]
+        self.businessDayConvention = None  # type: Optional[int]
+        self.dayCounter = None  # type: Optional[int]
         self.shape = 0  # type: int
         self.constantVol = 0.0  # type: float
         self.quoteId = None  # type: str

--- a/flatbuffers/python/quantra/IrVolBaseSpec.py
+++ b/flatbuffers/python/quantra/IrVolBaseSpec.py
@@ -37,21 +37,21 @@ class IrVolBaseSpec(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # IrVolBaseSpec
     def BusinessDayConvention(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(8))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # IrVolBaseSpec
     def DayCounter(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(10))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # IrVolBaseSpec
     def Shape(self):
@@ -103,19 +103,19 @@ def AddReferenceDate(builder, referenceDate):
     IrVolBaseSpecAddReferenceDate(builder, referenceDate)
 
 def IrVolBaseSpecAddCalendar(builder, calendar):
-    builder.PrependInt8Slot(1, calendar, 0)
+    builder.PrependInt8Slot(1, calendar, None)
 
 def AddCalendar(builder, calendar):
     IrVolBaseSpecAddCalendar(builder, calendar)
 
 def IrVolBaseSpecAddBusinessDayConvention(builder, businessDayConvention):
-    builder.PrependInt8Slot(2, businessDayConvention, 0)
+    builder.PrependInt8Slot(2, businessDayConvention, None)
 
 def AddBusinessDayConvention(builder, businessDayConvention):
     IrVolBaseSpecAddBusinessDayConvention(builder, businessDayConvention)
 
 def IrVolBaseSpecAddDayCounter(builder, dayCounter):
-    builder.PrependInt8Slot(3, dayCounter, 0)
+    builder.PrependInt8Slot(3, dayCounter, None)
 
 def AddDayCounter(builder, dayCounter):
     IrVolBaseSpecAddDayCounter(builder, dayCounter)
@@ -162,9 +162,9 @@ class IrVolBaseSpecT(object):
     # IrVolBaseSpecT
     def __init__(self):
         self.referenceDate = None  # type: str
-        self.calendar = 0  # type: int
-        self.businessDayConvention = 0  # type: int
-        self.dayCounter = 0  # type: int
+        self.calendar = None  # type: Optional[int]
+        self.businessDayConvention = None  # type: Optional[int]
+        self.dayCounter = None  # type: Optional[int]
         self.shape = 0  # type: int
         self.volatilityType = 0  # type: int
         self.displacement = 0.0  # type: float

--- a/src/parsers/vol_surface_parsers.cpp
+++ b/src/parsers/vol_surface_parsers.cpp
@@ -75,6 +75,15 @@ void validateIrVolBaseCommon(const quantra::IrVolBaseSpec* b, const std::string&
     if (!b->reference_date()) {
         QUANTRA_INVALID_ARGUMENT("reference_date required for vol id: " + id);
     }
+    if (!b->calendar().has_value()) {
+        QUANTRA_INVALID_ARGUMENT("IrVolBaseSpec.calendar is required for vol id: " + id);
+    }
+    if (!b->business_day_convention().has_value()) {
+        QUANTRA_INVALID_ARGUMENT("IrVolBaseSpec.business_day_convention is required for vol id: " + id);
+    }
+    if (!b->day_counter().has_value()) {
+        QUANTRA_INVALID_ARGUMENT("IrVolBaseSpec.day_counter is required for vol id: " + id);
+    }
 
     auto volType = b->volatility_type();
     double disp = b->displacement();
@@ -107,6 +116,15 @@ void validateBlackVolBase(const quantra::BlackVolBaseSpec* b, const std::string&
     }
     if (!b->reference_date()) {
         QUANTRA_INVALID_ARGUMENT("reference_date required for vol id: " + id);
+    }
+    if (!b->calendar().has_value()) {
+        QUANTRA_INVALID_ARGUMENT("BlackVolBaseSpec.calendar is required for vol id: " + id);
+    }
+    if (!b->business_day_convention().has_value()) {
+        QUANTRA_INVALID_ARGUMENT("BlackVolBaseSpec.business_day_convention is required for vol id: " + id);
+    }
+    if (!b->day_counter().has_value()) {
+        QUANTRA_INVALID_ARGUMENT("BlackVolBaseSpec.day_counter is required for vol id: " + id);
     }
     switch (b->shape()) {
         case quantra::enums::VolSurfaceShape_Constant:
@@ -866,9 +884,9 @@ OptionletVolEntry parseOptionletVol(const quantra::VolSurfaceSpec* spec, const Q
     validateIrVolBaseConstant(b, id);
 
     QuantLib::Date ref = DateToQL(b->reference_date()->str());
-    QuantLib::Calendar cal = CalendarToQL(b->calendar());
-    QuantLib::BusinessDayConvention bdc = ConventionToQL(b->business_day_convention());
-    QuantLib::DayCounter dc = DayCounterToQL(b->day_counter());
+    QuantLib::Calendar cal = CalendarToQL(b->calendar().value());
+    QuantLib::BusinessDayConvention bdc = ConventionToQL(b->business_day_convention().value());
+    QuantLib::DayCounter dc = DayCounterToQL(b->day_counter().value());
     double vol = resolveVolValue(b->constant_vol(), b->quote_id(), quotes, id);
     double disp = b->displacement();
     QuantLib::VolatilityType qlType = toQlVolType(b->volatility_type());
@@ -884,9 +902,9 @@ OptionletVolEntry parseOptionletVol(const quantra::VolSurfaceSpec* spec, const Q
     entry.constantVol = vol;
     entry.referenceDate = ref;
     entry.calendar = cal;
-    entry.calendarFb = b->calendar();
+    entry.calendarFb = b->calendar().value();
     entry.businessDayConvention = bdc;
-    entry.businessDayConventionFb = b->business_day_convention();
+    entry.businessDayConventionFb = b->business_day_convention().value();
     entry.dayCounter = dc;
     
     return entry;
@@ -921,9 +939,9 @@ SwaptionVolEntry parseSwaptionVol(const quantra::VolSurfaceSpec* spec, const Quo
             validateIrVolBaseConstant(b, id);
 
             QuantLib::Date ref = DateToQL(b->reference_date()->str());
-            QuantLib::Calendar cal = CalendarToQL(b->calendar());
-            QuantLib::BusinessDayConvention bdc = ConventionToQL(b->business_day_convention());
-            QuantLib::DayCounter dc = DayCounterToQL(b->day_counter());
+            QuantLib::Calendar cal = CalendarToQL(b->calendar().value());
+            QuantLib::BusinessDayConvention bdc = ConventionToQL(b->business_day_convention().value());
+            QuantLib::DayCounter dc = DayCounterToQL(b->day_counter().value());
             double vol = resolveVolValue(b->constant_vol(), b->quote_id(), quotes, id);
             double disp = b->displacement();
             QuantLib::VolatilityType qlType = toQlVolType(b->volatility_type());
@@ -957,9 +975,9 @@ SwaptionVolEntry parseSwaptionVol(const quantra::VolSurfaceSpec* spec, const Quo
             validateSupportedInterpolator(payload->tenor_interpolator(), "tenor_interpolator", id);
 
             QuantLib::Date ref = DateToQL(b->reference_date()->str());
-            QuantLib::Calendar cal = CalendarToQL(b->calendar());
-            QuantLib::BusinessDayConvention bdc = ConventionToQL(b->business_day_convention());
-            QuantLib::DayCounter dc = DayCounterToQL(b->day_counter());
+            QuantLib::Calendar cal = CalendarToQL(b->calendar().value());
+            QuantLib::BusinessDayConvention bdc = ConventionToQL(b->business_day_convention().value());
+            QuantLib::DayCounter dc = DayCounterToQL(b->day_counter().value());
             double disp = b->displacement();
             QuantLib::VolatilityType qlType = toQlVolType(b->volatility_type());
 
@@ -1040,9 +1058,9 @@ SwaptionVolEntry parseSwaptionVol(const quantra::VolSurfaceSpec* spec, const Quo
             validateSupportedInterpolator(payload->strike_interpolator(), "strike_interpolator", id);
 
             QuantLib::Date ref = DateToQL(b->reference_date()->str());
-            QuantLib::Calendar cal = CalendarToQL(b->calendar());
-            QuantLib::BusinessDayConvention bdc = ConventionToQL(b->business_day_convention());
-            QuantLib::DayCounter dc = DayCounterToQL(b->day_counter());
+            QuantLib::Calendar cal = CalendarToQL(b->calendar().value());
+            QuantLib::BusinessDayConvention bdc = ConventionToQL(b->business_day_convention().value());
+            QuantLib::DayCounter dc = DayCounterToQL(b->day_counter().value());
             double disp = b->displacement();
             QuantLib::VolatilityType qlType = toQlVolType(b->volatility_type());
 
@@ -1152,9 +1170,9 @@ SwaptionVolEntry parseSwaptionVol(const quantra::VolSurfaceSpec* spec, const Quo
             }
 
             QuantLib::Date ref = DateToQL(b->reference_date()->str());
-            QuantLib::Calendar cal = CalendarToQL(b->calendar());
-            QuantLib::BusinessDayConvention bdc = ConventionToQL(b->business_day_convention());
-            QuantLib::DayCounter dc = DayCounterToQL(b->day_counter());
+            QuantLib::Calendar cal = CalendarToQL(b->calendar().value());
+            QuantLib::BusinessDayConvention bdc = ConventionToQL(b->business_day_convention().value());
+            QuantLib::DayCounter dc = DayCounterToQL(b->day_counter().value());
             double disp = b->displacement();
             QuantLib::VolatilityType qlType = toQlVolType(b->volatility_type());
 
@@ -1278,9 +1296,9 @@ SwaptionVolEntry parseSwaptionVol(const quantra::VolSurfaceSpec* spec, const Quo
             }
 
             QuantLib::Date ref = DateToQL(b->reference_date()->str());
-            QuantLib::Calendar cal = CalendarToQL(b->calendar());
-            QuantLib::BusinessDayConvention bdc = ConventionToQL(b->business_day_convention());
-            QuantLib::DayCounter dc = DayCounterToQL(b->day_counter());
+            QuantLib::Calendar cal = CalendarToQL(b->calendar().value());
+            QuantLib::BusinessDayConvention bdc = ConventionToQL(b->business_day_convention().value());
+            QuantLib::DayCounter dc = DayCounterToQL(b->day_counter().value());
             double disp = b->displacement();
             QuantLib::VolatilityType qlType = toQlVolType(b->volatility_type());
 
@@ -1460,9 +1478,9 @@ BlackVolEntry parseBlackVol(
     validateBlackVolBase(b, id);
 
     QuantLib::Date ref = DateToQL(b->reference_date()->str());
-    QuantLib::Calendar cal = CalendarToQL(b->calendar());
-    QuantLib::BusinessDayConvention bdc = ConventionToQL(b->business_day_convention());
-    QuantLib::DayCounter dc = DayCounterToQL(b->day_counter());
+    QuantLib::Calendar cal = CalendarToQL(b->calendar().value());
+    QuantLib::BusinessDayConvention bdc = ConventionToQL(b->business_day_convention().value());
+    QuantLib::DayCounter dc = DayCounterToQL(b->day_counter().value());
     const auto shape = b->shape();
 
     const bool hasExpiries = hasNonEmptyPeriods(payload->expiries());
@@ -1827,9 +1845,9 @@ BlackVolEntry parseBlackVol(
     entry.constantVol = built.second;
     entry.referenceDate = ref;
     entry.calendar = cal;
-    entry.calendarFb = b->calendar();
+    entry.calendarFb = b->calendar().value();
     entry.businessDayConvention = bdc;
-    entry.businessDayConventionFb = b->business_day_convention();
+    entry.businessDayConventionFb = b->business_day_convention().value();
     entry.dayCounter = dc;
     if (payload->allow_extrapolation()) {
         entry.handle->enableExtrapolation();

--- a/tests/contract/error_contract_test.py
+++ b/tests/contract/error_contract_test.py
@@ -165,6 +165,21 @@ def _ec_del_schedule_field(arr_key, product_key, field):
     return f
 
 
+def _ec_del_vol_base_field(field):
+    """Drop a convention field from the first vol surface's base spec. The
+    IrVol/BlackVol base convention enums are presence-required: an omitted
+    convention is an error, never an alphabetical-0 default."""
+    def f(req):
+        surfaces = req["pricing"]["volatility"]["vol_surfaces"]
+        payload = surfaces[0]["payload"]
+        # Descend through nested payload wrappers until the base spec is found.
+        while "base" not in payload and "payload" in payload:
+            payload = payload["payload"]
+        payload["base"].pop(field, None)
+        return req
+    return f
+
+
 def _ec_set_credit_curve_field(field, value):
     def f(req):
         req["pricing"]["credit"]["credit_curves"][0][field] = value
@@ -293,6 +308,17 @@ SCENARIOS = [
      "fixed_rate_bond_request.json", 400,
      _ec_del_curve_field("interpolator"),
      _ec_body_contains("TermStructure.interpolator is required")),
+    # ---- 400 INVALID_ARGUMENT: volatility base convention presence ----
+    # An IrVol/BlackVol base convention enum omitted from the request must be
+    # rejected, not silently defaulted to the alphabetical-0 value.
+    ("ec:400 swaption vol base missing day_counter", "swaption",
+     "swaption_request.json", 400,
+     _ec_del_vol_base_field("day_counter"),
+     _ec_body_contains("IrVolBaseSpec.day_counter is required")),
+    ("ec:400 swaption vol base missing calendar", "swaption",
+     "swaption_request.json", 400,
+     _ec_del_vol_base_field("calendar"),
+     _ec_body_contains("IrVolBaseSpec.calendar is required")),
     # ---- 400 INVALID_ARGUMENT: fail-closed enum handling ----
     # The CDS credit-curve bootstrap supports LogLinear only; ForwardFlat
     # and LogCubic used to be silently priced as LogLinear. The complex request


### PR DESCRIPTION
**Schema v3, step 3c (wire-breaking): volatility base specs.** `IrVolBaseSpec` and `BlackVolBaseSpec` convention enums (`calendar`, `business_day_convention`, `day_counter`) become optional-with-presence — an omitted convention errors instead of silently taking the alphabetical-0 value. Presence required in the shared vol-base validators; every read uses `.value()`. Already-defaulted interpolator/shape fields untouched.

No example/catalog JSON needed editing (all vol specs already set these). +2 error-contract scenarios. Regenerated FlatBuffers included. Full suite green in Docker (492 cases). Step 3c of the D1 sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
