### PR TITLE
Require explicit swap-leg conventions (schema v3, step 3d: swap legs)

### DIFF
--- a/flatbuffers/cpp/vanilla_swap_generated.h
+++ b/flatbuffers/cpp/vanilla_swap_generated.h
@@ -44,8 +44,8 @@ struct SwapFixedLegT : public ::flatbuffers::NativeTable {
   std::unique_ptr<quantra::ScheduleT> schedule{};
   double notional = 0.0;
   double rate = 0.0;
-  quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360;
-  quantra::enums::BusinessDayConvention payment_convention = quantra::enums::BusinessDayConvention_Following;
+  ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> payment_convention = ::flatbuffers::nullopt;
   SwapFixedLegT() = default;
   SwapFixedLegT(const SwapFixedLegT &o);
   SwapFixedLegT(SwapFixedLegT&&) FLATBUFFERS_NOEXCEPT = default;
@@ -72,11 +72,11 @@ struct SwapFixedLeg FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   double rate() const {
     return GetField<double>(VT_RATE, 0.0);
   }
-  quantra::enums::DayCounter day_counter() const {
-    return static_cast<quantra::enums::DayCounter>(GetField<int8_t>(VT_DAY_COUNTER, 0));
+  ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter() const {
+    return GetOptional<int8_t, quantra::enums::DayCounter>(VT_DAY_COUNTER);
   }
-  quantra::enums::BusinessDayConvention payment_convention() const {
-    return static_cast<quantra::enums::BusinessDayConvention>(GetField<int8_t>(VT_PAYMENT_CONVENTION, 0));
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> payment_convention() const {
+    return GetOptional<int8_t, quantra::enums::BusinessDayConvention>(VT_PAYMENT_CONVENTION);
   }
   bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -107,10 +107,10 @@ struct SwapFixedLegBuilder {
     fbb_.AddElement<double>(SwapFixedLeg::VT_RATE, rate, 0.0);
   }
   void add_day_counter(quantra::enums::DayCounter day_counter) {
-    fbb_.AddElement<int8_t>(SwapFixedLeg::VT_DAY_COUNTER, static_cast<int8_t>(day_counter), 0);
+    fbb_.AddElement<int8_t>(SwapFixedLeg::VT_DAY_COUNTER, static_cast<int8_t>(day_counter));
   }
   void add_payment_convention(quantra::enums::BusinessDayConvention payment_convention) {
-    fbb_.AddElement<int8_t>(SwapFixedLeg::VT_PAYMENT_CONVENTION, static_cast<int8_t>(payment_convention), 0);
+    fbb_.AddElement<int8_t>(SwapFixedLeg::VT_PAYMENT_CONVENTION, static_cast<int8_t>(payment_convention));
   }
   explicit SwapFixedLegBuilder(::flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
@@ -128,14 +128,14 @@ inline ::flatbuffers::Offset<SwapFixedLeg> CreateSwapFixedLeg(
     ::flatbuffers::Offset<quantra::Schedule> schedule = 0,
     double notional = 0.0,
     double rate = 0.0,
-    quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360,
-    quantra::enums::BusinessDayConvention payment_convention = quantra::enums::BusinessDayConvention_Following) {
+    ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> payment_convention = ::flatbuffers::nullopt) {
   SwapFixedLegBuilder builder_(_fbb);
   builder_.add_rate(rate);
   builder_.add_notional(notional);
   builder_.add_schedule(schedule);
-  builder_.add_payment_convention(payment_convention);
-  builder_.add_day_counter(day_counter);
+  if(payment_convention) { builder_.add_payment_convention(*payment_convention); }
+  if(day_counter) { builder_.add_day_counter(*day_counter); }
   return builder_.Finish();
 }
 
@@ -147,8 +147,8 @@ struct SwapFloatingLegT : public ::flatbuffers::NativeTable {
   double notional = 0.0;
   std::unique_ptr<quantra::IndexRefT> index{};
   double spread = 0.0;
-  quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360;
-  quantra::enums::BusinessDayConvention payment_convention = quantra::enums::BusinessDayConvention_Following;
+  ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> payment_convention = ::flatbuffers::nullopt;
   int32_t fixing_days = 2;
   bool in_arrears = false;
   SwapFloatingLegT() = default;
@@ -184,11 +184,11 @@ struct SwapFloatingLeg FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   double spread() const {
     return GetField<double>(VT_SPREAD, 0.0);
   }
-  quantra::enums::DayCounter day_counter() const {
-    return static_cast<quantra::enums::DayCounter>(GetField<int8_t>(VT_DAY_COUNTER, 0));
+  ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter() const {
+    return GetOptional<int8_t, quantra::enums::DayCounter>(VT_DAY_COUNTER);
   }
-  quantra::enums::BusinessDayConvention payment_convention() const {
-    return static_cast<quantra::enums::BusinessDayConvention>(GetField<int8_t>(VT_PAYMENT_CONVENTION, 0));
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> payment_convention() const {
+    return GetOptional<int8_t, quantra::enums::BusinessDayConvention>(VT_PAYMENT_CONVENTION);
   }
   int32_t fixing_days() const {
     return GetField<int32_t>(VT_FIXING_DAYS, 2);
@@ -232,10 +232,10 @@ struct SwapFloatingLegBuilder {
     fbb_.AddElement<double>(SwapFloatingLeg::VT_SPREAD, spread, 0.0);
   }
   void add_day_counter(quantra::enums::DayCounter day_counter) {
-    fbb_.AddElement<int8_t>(SwapFloatingLeg::VT_DAY_COUNTER, static_cast<int8_t>(day_counter), 0);
+    fbb_.AddElement<int8_t>(SwapFloatingLeg::VT_DAY_COUNTER, static_cast<int8_t>(day_counter));
   }
   void add_payment_convention(quantra::enums::BusinessDayConvention payment_convention) {
-    fbb_.AddElement<int8_t>(SwapFloatingLeg::VT_PAYMENT_CONVENTION, static_cast<int8_t>(payment_convention), 0);
+    fbb_.AddElement<int8_t>(SwapFloatingLeg::VT_PAYMENT_CONVENTION, static_cast<int8_t>(payment_convention));
   }
   void add_fixing_days(int32_t fixing_days) {
     fbb_.AddElement<int32_t>(SwapFloatingLeg::VT_FIXING_DAYS, fixing_days, 2);
@@ -261,8 +261,8 @@ inline ::flatbuffers::Offset<SwapFloatingLeg> CreateSwapFloatingLeg(
     double notional = 0.0,
     ::flatbuffers::Offset<quantra::IndexRef> index = 0,
     double spread = 0.0,
-    quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360,
-    quantra::enums::BusinessDayConvention payment_convention = quantra::enums::BusinessDayConvention_Following,
+    ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> payment_convention = ::flatbuffers::nullopt,
     int32_t fixing_days = 2,
     bool in_arrears = false) {
   SwapFloatingLegBuilder builder_(_fbb);
@@ -272,8 +272,8 @@ inline ::flatbuffers::Offset<SwapFloatingLeg> CreateSwapFloatingLeg(
   builder_.add_index(index);
   builder_.add_schedule(schedule);
   builder_.add_in_arrears(in_arrears);
-  builder_.add_payment_convention(payment_convention);
-  builder_.add_day_counter(day_counter);
+  if(payment_convention) { builder_.add_payment_convention(*payment_convention); }
+  if(day_counter) { builder_.add_day_counter(*day_counter); }
   return builder_.Finish();
 }
 
@@ -415,8 +415,8 @@ struct SwapCmsLegT : public ::flatbuffers::NativeTable {
   std::unique_ptr<quantra::PeriodT> swap_tenor{};
   std::string swaption_vol_id{};
   int32_t fixing_days = -1;
-  quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360;
-  quantra::enums::BusinessDayConvention payment_convention = quantra::enums::BusinessDayConvention_Following;
+  ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> payment_convention = ::flatbuffers::nullopt;
   double gear = 1.0;
   double spread = 0.0;
   std::unique_ptr<quantra::CmsPricerSpecT> pricer{};
@@ -473,12 +473,12 @@ struct SwapCmsLeg FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
     return GetField<int32_t>(VT_FIXING_DAYS, -1);
   }
   /// Coupon accrual day-count convention.
-  quantra::enums::DayCounter day_counter() const {
-    return static_cast<quantra::enums::DayCounter>(GetField<int8_t>(VT_DAY_COUNTER, 0));
+  ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter() const {
+    return GetOptional<int8_t, quantra::enums::DayCounter>(VT_DAY_COUNTER);
   }
   /// Payment business-day convention.
-  quantra::enums::BusinessDayConvention payment_convention() const {
-    return static_cast<quantra::enums::BusinessDayConvention>(GetField<int8_t>(VT_PAYMENT_CONVENTION, 0));
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> payment_convention() const {
+    return GetOptional<int8_t, quantra::enums::BusinessDayConvention>(VT_PAYMENT_CONVENTION);
   }
   /// Coupon gearing multiplier.
   double gear() const {
@@ -551,10 +551,10 @@ struct SwapCmsLegBuilder {
     fbb_.AddElement<int32_t>(SwapCmsLeg::VT_FIXING_DAYS, fixing_days, -1);
   }
   void add_day_counter(quantra::enums::DayCounter day_counter) {
-    fbb_.AddElement<int8_t>(SwapCmsLeg::VT_DAY_COUNTER, static_cast<int8_t>(day_counter), 0);
+    fbb_.AddElement<int8_t>(SwapCmsLeg::VT_DAY_COUNTER, static_cast<int8_t>(day_counter));
   }
   void add_payment_convention(quantra::enums::BusinessDayConvention payment_convention) {
-    fbb_.AddElement<int8_t>(SwapCmsLeg::VT_PAYMENT_CONVENTION, static_cast<int8_t>(payment_convention), 0);
+    fbb_.AddElement<int8_t>(SwapCmsLeg::VT_PAYMENT_CONVENTION, static_cast<int8_t>(payment_convention));
   }
   void add_gear(double gear) {
     fbb_.AddElement<double>(SwapCmsLeg::VT_GEAR, gear, 1.0);
@@ -593,8 +593,8 @@ inline ::flatbuffers::Offset<SwapCmsLeg> CreateSwapCmsLeg(
     ::flatbuffers::Offset<quantra::Period> swap_tenor = 0,
     ::flatbuffers::Offset<::flatbuffers::String> swaption_vol_id = 0,
     int32_t fixing_days = -1,
-    quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360,
-    quantra::enums::BusinessDayConvention payment_convention = quantra::enums::BusinessDayConvention_Following,
+    ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> payment_convention = ::flatbuffers::nullopt,
     double gear = 1.0,
     double spread = 0.0,
     ::flatbuffers::Offset<quantra::CmsPricerSpec> pricer = 0,
@@ -612,8 +612,8 @@ inline ::flatbuffers::Offset<SwapCmsLeg> CreateSwapCmsLeg(
   builder_.add_swap_tenor(swap_tenor);
   builder_.add_swap_index_id(swap_index_id);
   builder_.add_schedule(schedule);
-  builder_.add_payment_convention(payment_convention);
-  builder_.add_day_counter(day_counter);
+  if(payment_convention) { builder_.add_payment_convention(*payment_convention); }
+  if(day_counter) { builder_.add_day_counter(*day_counter); }
   return builder_.Finish();
 }
 
@@ -625,8 +625,8 @@ inline ::flatbuffers::Offset<SwapCmsLeg> CreateSwapCmsLegDirect(
     ::flatbuffers::Offset<quantra::Period> swap_tenor = 0,
     const char *swaption_vol_id = nullptr,
     int32_t fixing_days = -1,
-    quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360,
-    quantra::enums::BusinessDayConvention payment_convention = quantra::enums::BusinessDayConvention_Following,
+    ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> payment_convention = ::flatbuffers::nullopt,
     double gear = 1.0,
     double spread = 0.0,
     ::flatbuffers::Offset<quantra::CmsPricerSpec> pricer = 0,

--- a/flatbuffers/fbs/vanilla_swap.fbs
+++ b/flatbuffers/fbs/vanilla_swap.fbs
@@ -9,8 +9,8 @@ table SwapFixedLeg {
     schedule:Schedule;
     notional:double;
     rate:double;
-    day_counter:enums.DayCounter;
-    payment_convention:enums.BusinessDayConvention;
+    day_counter:enums.DayCounter = null;
+    payment_convention:enums.BusinessDayConvention = null;
 }
 
 /// Floating leg of a swap.
@@ -20,8 +20,8 @@ table SwapFloatingLeg {
     /// Reference to an IndexDef by id (e.g., "EUR_6M").
     index:IndexRef (required);
     spread:double = 0.0;
-    day_counter:enums.DayCounter;
-    payment_convention:enums.BusinessDayConvention;
+    day_counter:enums.DayCounter = null;
+    payment_convention:enums.BusinessDayConvention = null;
     fixing_days:int = 2;
     in_arrears:bool = false;
 }
@@ -62,9 +62,9 @@ table SwapCmsLeg {
     /// Optional fixing days override; if negative, uses swap index spot_days.
     fixing_days:int = -1;
     /// Coupon accrual day-count convention.
-    day_counter:enums.DayCounter;
+    day_counter:enums.DayCounter = null;
     /// Payment business-day convention.
-    payment_convention:enums.BusinessDayConvention;
+    payment_convention:enums.BusinessDayConvention = null;
     /// Coupon gearing multiplier.
     gear:double = 1.0;
     /// Coupon additive spread.

--- a/flatbuffers/python/quantra/SwapCmsLeg.py
+++ b/flatbuffers/python/quantra/SwapCmsLeg.py
@@ -88,7 +88,7 @@ class SwapCmsLeg(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(16))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # Payment business-day convention.
     # SwapCmsLeg
@@ -96,7 +96,7 @@ class SwapCmsLeg(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(18))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # Coupon gearing multiplier.
     # SwapCmsLeg
@@ -186,13 +186,13 @@ def AddFixingDays(builder, fixingDays):
     SwapCmsLegAddFixingDays(builder, fixingDays)
 
 def SwapCmsLegAddDayCounter(builder, dayCounter):
-    builder.PrependInt8Slot(6, dayCounter, 0)
+    builder.PrependInt8Slot(6, dayCounter, None)
 
 def AddDayCounter(builder, dayCounter):
     SwapCmsLegAddDayCounter(builder, dayCounter)
 
 def SwapCmsLegAddPaymentConvention(builder, paymentConvention):
-    builder.PrependInt8Slot(7, paymentConvention, 0)
+    builder.PrependInt8Slot(7, paymentConvention, None)
 
 def AddPaymentConvention(builder, paymentConvention):
     SwapCmsLegAddPaymentConvention(builder, paymentConvention)
@@ -248,8 +248,8 @@ class SwapCmsLegT(object):
         self.swapTenor = None  # type: Optional[PeriodT]
         self.swaptionVolId = None  # type: str
         self.fixingDays = -1  # type: int
-        self.dayCounter = 0  # type: int
-        self.paymentConvention = 0  # type: int
+        self.dayCounter = None  # type: Optional[int]
+        self.paymentConvention = None  # type: Optional[int]
         self.gear = 1.0  # type: float
         self.spread = 0.0  # type: float
         self.pricer = None  # type: Optional[CmsPricerSpecT]

--- a/flatbuffers/python/quantra/SwapFixedLeg.py
+++ b/flatbuffers/python/quantra/SwapFixedLeg.py
@@ -55,14 +55,14 @@ class SwapFixedLeg(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(10))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # SwapFixedLeg
     def PaymentConvention(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(12))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
 def SwapFixedLegStart(builder):
     builder.StartObject(5)
@@ -89,13 +89,13 @@ def AddRate(builder, rate):
     SwapFixedLegAddRate(builder, rate)
 
 def SwapFixedLegAddDayCounter(builder, dayCounter):
-    builder.PrependInt8Slot(3, dayCounter, 0)
+    builder.PrependInt8Slot(3, dayCounter, None)
 
 def AddDayCounter(builder, dayCounter):
     SwapFixedLegAddDayCounter(builder, dayCounter)
 
 def SwapFixedLegAddPaymentConvention(builder, paymentConvention):
-    builder.PrependInt8Slot(4, paymentConvention, 0)
+    builder.PrependInt8Slot(4, paymentConvention, None)
 
 def AddPaymentConvention(builder, paymentConvention):
     SwapFixedLegAddPaymentConvention(builder, paymentConvention)
@@ -118,8 +118,8 @@ class SwapFixedLegT(object):
         self.schedule = None  # type: Optional[ScheduleT]
         self.notional = 0.0  # type: float
         self.rate = 0.0  # type: float
-        self.dayCounter = 0  # type: int
-        self.paymentConvention = 0  # type: int
+        self.dayCounter = None  # type: Optional[int]
+        self.paymentConvention = None  # type: Optional[int]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):

--- a/flatbuffers/python/quantra/SwapFloatingLeg.py
+++ b/flatbuffers/python/quantra/SwapFloatingLeg.py
@@ -67,14 +67,14 @@ class SwapFloatingLeg(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(12))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # SwapFloatingLeg
     def PaymentConvention(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(14))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # SwapFloatingLeg
     def FixingDays(self):
@@ -121,13 +121,13 @@ def AddSpread(builder, spread):
     SwapFloatingLegAddSpread(builder, spread)
 
 def SwapFloatingLegAddDayCounter(builder, dayCounter):
-    builder.PrependInt8Slot(4, dayCounter, 0)
+    builder.PrependInt8Slot(4, dayCounter, None)
 
 def AddDayCounter(builder, dayCounter):
     SwapFloatingLegAddDayCounter(builder, dayCounter)
 
 def SwapFloatingLegAddPaymentConvention(builder, paymentConvention):
-    builder.PrependInt8Slot(5, paymentConvention, 0)
+    builder.PrependInt8Slot(5, paymentConvention, None)
 
 def AddPaymentConvention(builder, paymentConvention):
     SwapFloatingLegAddPaymentConvention(builder, paymentConvention)
@@ -163,8 +163,8 @@ class SwapFloatingLegT(object):
         self.notional = 0.0  # type: float
         self.index = None  # type: Optional[IndexRefT]
         self.spread = 0.0  # type: float
-        self.dayCounter = 0  # type: int
-        self.paymentConvention = 0  # type: int
+        self.dayCounter = None  # type: Optional[int]
+        self.paymentConvention = None  # type: Optional[int]
         self.fixingDays = 2  # type: int
         self.inArrears = False  # type: bool
 

--- a/src/mappers/basis_swap_mapper.cpp
+++ b/src/mappers/basis_swap_mapper.cpp
@@ -12,13 +12,19 @@ BasisSwapFloatingLegData extractLeg(const quantra::SwapFloatingLeg* fb,
                                     const char* legName,
                                     ScheduleParser& scheduleParser) {
     BasisSwapFloatingLegData leg;
+    if (!fb->day_counter().has_value()) {
+        QUANTRA_INVALID_ARGUMENT("SwapFloatingLeg.day_counter is required");
+    }
+    if (!fb->payment_convention().has_value()) {
+        QUANTRA_INVALID_ARGUMENT("SwapFloatingLeg.payment_convention is required");
+    }
     auto schedule = scheduleParser.parse(fb->schedule());
     leg.schedule = *schedule;
     leg.notional = fb->notional();
     leg.indexId = fb->index()->id()->str();
     leg.spread = fb->spread();
-    leg.dayCounter = DayCounterToQL(fb->day_counter());
-    leg.paymentConvention = ConventionToQL(fb->payment_convention());
+    leg.dayCounter = DayCounterToQL(fb->day_counter().value());
+    leg.paymentConvention = ConventionToQL(fb->payment_convention().value());
     leg.fixingDays = fb->fixing_days();
     leg.inArrears = fb->in_arrears();
     (void)legName;

--- a/src/mappers/ois_swap_mapper.cpp
+++ b/src/mappers/ois_swap_mapper.cpp
@@ -34,6 +34,9 @@ OisSwapTrade extractTrade(const quantra::PriceOisSwap* pricing) {
     if (!fixedFb->schedule()) {
         QUANTRA_INVALID_ARGUMENT("OisSwap.fixed_leg.schedule is required");
     }
+    if (!fixedFb->day_counter().has_value()) {
+        QUANTRA_INVALID_ARGUMENT("SwapFixedLeg.day_counter is required");
+    }
 
     const auto* overnightFb = swap->overnight_leg();
     if (!overnightFb->schedule()) {
@@ -54,7 +57,7 @@ OisSwapTrade extractTrade(const quantra::PriceOisSwap* pricing) {
     trade.fixed.schedule = *fixedSchedule;
     trade.fixed.notional = fixedFb->notional();
     trade.fixed.rate = fixedFb->rate();
-    trade.fixed.dayCounter = DayCounterToQL(fixedFb->day_counter());
+    trade.fixed.dayCounter = DayCounterToQL(fixedFb->day_counter().value());
 
     auto overnightSchedule = scheduleParser.parse(overnightFb->schedule());
     trade.overnight.schedule = *overnightSchedule;

--- a/src/mappers/swaption_mapper.cpp
+++ b/src/mappers/swaption_mapper.cpp
@@ -96,21 +96,25 @@ VanillaSwapTrade extractVanillaUnderlying(const quantra::VanillaSwap* swap) {
     auto fixedLeg = swap->fixed_leg();
     if (fixedLeg->schedule() == nullptr)
         QUANTRA_INVALID_ARGUMENT("VanillaSwap fixed_leg schedule not found");
+    if (!fixedLeg->day_counter().has_value())
+        QUANTRA_INVALID_ARGUMENT("SwapFixedLeg.day_counter is required");
     trade.fixed.schedule = *scheduleParser.parse(fixedLeg->schedule());
     trade.fixed.notional = fixedLeg->notional();
     trade.fixed.rate = fixedLeg->rate();
-    trade.fixed.dayCounter = DayCounterToQL(fixedLeg->day_counter());
+    trade.fixed.dayCounter = DayCounterToQL(fixedLeg->day_counter().value());
 
     auto floatingLeg = swap->floating_leg();
     if (floatingLeg->schedule() == nullptr)
         QUANTRA_INVALID_ARGUMENT("VanillaSwap floating_leg schedule not found");
     if (!floatingLeg->index() || !floatingLeg->index()->id())
         QUANTRA_INVALID_ARGUMENT("VanillaSwap floating_leg index.id is required");
+    if (!floatingLeg->day_counter().has_value())
+        QUANTRA_INVALID_ARGUMENT("SwapFloatingLeg.day_counter is required");
     trade.ibor.schedule = *scheduleParser.parse(floatingLeg->schedule());
     trade.ibor.notional = floatingLeg->notional();
     trade.ibor.indexId = floatingLeg->index()->id()->str();
     trade.ibor.spread = floatingLeg->spread();
-    trade.ibor.dayCounter = DayCounterToQL(floatingLeg->day_counter());
+    trade.ibor.dayCounter = DayCounterToQL(floatingLeg->day_counter().value());
     return trade;
 }
 
@@ -141,10 +145,12 @@ OisSwapTrade extractOisUnderlying(const quantra::OisSwap* swap) {
     auto fixedLeg = swap->fixed_leg();
     if (fixedLeg->schedule() == nullptr)
         QUANTRA_INVALID_ARGUMENT("OisSwap fixed_leg schedule not found");
+    if (!fixedLeg->day_counter().has_value())
+        QUANTRA_INVALID_ARGUMENT("SwapFixedLeg.day_counter is required");
     trade.fixed.schedule = *scheduleParser.parse(fixedLeg->schedule());
     trade.fixed.notional = fixedLeg->notional();
     trade.fixed.rate = fixedLeg->rate();
-    trade.fixed.dayCounter = DayCounterToQL(fixedLeg->day_counter());
+    trade.fixed.dayCounter = DayCounterToQL(fixedLeg->day_counter().value());
 
     auto overnightLeg = swap->overnight_leg();
     if (overnightLeg->schedule() == nullptr)

--- a/src/mappers/vanilla_swap_mapper.cpp
+++ b/src/mappers/vanilla_swap_mapper.cpp
@@ -46,6 +46,12 @@ VanillaSwapTrade extractTrade(const quantra::PriceVanillaSwap* pricing) {
     if (!fixedFb->schedule()) {
         QUANTRA_INVALID_ARGUMENT("VanillaSwap.fixed_leg.schedule is required");
     }
+    if (!fixedFb->day_counter().has_value()) {
+        QUANTRA_INVALID_ARGUMENT("SwapFixedLeg.day_counter is required");
+    }
+    if (!fixedFb->payment_convention().has_value()) {
+        QUANTRA_INVALID_ARGUMENT("SwapFixedLeg.payment_convention is required");
+    }
 
     const bool hasIbor = (swap->floating_leg() != nullptr);
     const bool hasCms = (swap->cms_leg() != nullptr);
@@ -65,8 +71,8 @@ VanillaSwapTrade extractTrade(const quantra::PriceVanillaSwap* pricing) {
     trade.fixed.schedule = *fixedSchedule;
     trade.fixed.notional = fixedFb->notional();
     trade.fixed.rate = fixedFb->rate();
-    trade.fixed.dayCounter = DayCounterToQL(fixedFb->day_counter());
-    trade.fixed.paymentConvention = ConventionToQL(fixedFb->payment_convention());
+    trade.fixed.dayCounter = DayCounterToQL(fixedFb->day_counter().value());
+    trade.fixed.paymentConvention = ConventionToQL(fixedFb->payment_convention().value());
 
     if (hasIbor) {
         const auto* floatFb = swap->floating_leg();
@@ -76,13 +82,16 @@ VanillaSwapTrade extractTrade(const quantra::PriceVanillaSwap* pricing) {
         if (!floatFb->index() || !floatFb->index()->id()) {
             QUANTRA_INVALID_ARGUMENT("VanillaSwap.floating_leg.index.id is required");
         }
+        if (!floatFb->day_counter().has_value()) {
+            QUANTRA_INVALID_ARGUMENT("SwapFloatingLeg.day_counter is required");
+        }
         trade.branch = VanillaSwapTrade::Branch::Ibor;
         auto floatSchedule = scheduleParser.parse(floatFb->schedule());
         trade.ibor.schedule = *floatSchedule;
         trade.ibor.notional = floatFb->notional();
         trade.ibor.indexId = floatFb->index()->id()->str();
         trade.ibor.spread = floatFb->spread();
-        trade.ibor.dayCounter = DayCounterToQL(floatFb->day_counter());
+        trade.ibor.dayCounter = DayCounterToQL(floatFb->day_counter().value());
         return trade;
     }
 
@@ -103,6 +112,12 @@ VanillaSwapTrade extractTrade(const quantra::PriceVanillaSwap* pricing) {
     if (cmsFb->cap() >= 0.0 || cmsFb->floor() >= 0.0) {
         QUANTRA_INVALID_ARGUMENT("CMS leg cap/floor is not supported in v1");
     }
+    if (!cmsFb->day_counter().has_value()) {
+        QUANTRA_INVALID_ARGUMENT("SwapCmsLeg.day_counter is required");
+    }
+    if (!cmsFb->payment_convention().has_value()) {
+        QUANTRA_INVALID_ARGUMENT("SwapCmsLeg.payment_convention is required");
+    }
 
     trade.branch = VanillaSwapTrade::Branch::Cms;
     auto cmsSchedule = scheduleParser.parse(cmsFb->schedule());
@@ -113,8 +128,8 @@ VanillaSwapTrade extractTrade(const quantra::PriceVanillaSwap* pricing) {
         cmsFb->swap_tenor()->n(), TimeUnitToQL(cmsFb->swap_tenor()->unit()));
     trade.cms.swaptionVolId = cmsFb->swaption_vol_id()->str();
     trade.cms.fixingDays = cmsFb->fixing_days();
-    trade.cms.dayCounter = DayCounterToQL(cmsFb->day_counter());
-    trade.cms.paymentConvention = ConventionToQL(cmsFb->payment_convention());
+    trade.cms.dayCounter = DayCounterToQL(cmsFb->day_counter().value());
+    trade.cms.paymentConvention = ConventionToQL(cmsFb->payment_convention().value());
     trade.cms.gear = cmsFb->gear();
     trade.cms.spread = cmsFb->spread();
     trade.cms.pricerParams = extractCmsPricerParams(cmsFb);

--- a/src/parsers/cms_leg_parser.cpp
+++ b/src/parsers/cms_leg_parser.cpp
@@ -55,6 +55,12 @@ QuantLib::Leg CmsLegParser::parse(
     if (leg->cap() >= 0.0 || leg->floor() >= 0.0) {
         QUANTRA_INVALID_ARGUMENT("CMS leg cap/floor is not supported in v1");
     }
+    if (!leg->day_counter().has_value()) {
+        QUANTRA_INVALID_ARGUMENT("SwapCmsLeg.day_counter is required");
+    }
+    if (!leg->payment_convention().has_value()) {
+        QUANTRA_INVALID_ARGUMENT("SwapCmsLeg.payment_convention is required");
+    }
 
     ScheduleParser scheduleParser;
     auto schedule = scheduleParser.parse(leg->schedule());
@@ -67,8 +73,8 @@ QuantLib::Leg CmsLegParser::parse(
 
     QuantLib::CmsLeg cmsBuilder(*schedule, swapIndex);
     cmsBuilder.withNotionals(leg->notional());
-    cmsBuilder.withPaymentDayCounter(DayCounterToQL(leg->day_counter()));
-    cmsBuilder.withPaymentAdjustment(ConventionToQL(leg->payment_convention()));
+    cmsBuilder.withPaymentDayCounter(DayCounterToQL(leg->day_counter().value()));
+    cmsBuilder.withPaymentAdjustment(ConventionToQL(leg->payment_convention().value()));
     cmsBuilder.withGearings(leg->gear());
     cmsBuilder.withSpreads(leg->spread());
 

--- a/src/parsers/ois_swap_parser.cpp
+++ b/src/parsers/ois_swap_parser.cpp
@@ -31,10 +31,13 @@ std::shared_ptr<QuantLib::OvernightIndexedSwap> OisSwapParser::parse(
     if (fixedLeg->schedule() == NULL)
         QUANTRA_INVALID_ARGUMENT("OisSwap fixed_leg schedule not found");
 
+    if (!fixedLeg->day_counter().has_value())
+        QUANTRA_INVALID_ARGUMENT("SwapFixedLeg.day_counter is required");
+
     auto fixedSchedule = scheduleParser.parse(fixedLeg->schedule());
     double fixedNotional = fixedLeg->notional();
     double fixedRate = fixedLeg->rate();
-    DayCounter fixedDayCounter = DayCounterToQL(fixedLeg->day_counter());
+    DayCounter fixedDayCounter = DayCounterToQL(fixedLeg->day_counter().value());
 
     auto overnightLeg = swap->overnight_leg();
     if (overnightLeg->schedule() == NULL)

--- a/src/parsers/vanilla_swap_parser.cpp
+++ b/src/parsers/vanilla_swap_parser.cpp
@@ -32,9 +32,12 @@ std::shared_ptr<QuantLib::VanillaSwap> VanillaSwapParser::parse(
     ScheduleParser scheduleParser;
     auto fixedSchedule = scheduleParser.parse(fixedLeg->schedule());
 
+    if (!fixedLeg->day_counter().has_value())
+        QUANTRA_INVALID_ARGUMENT("SwapFixedLeg.day_counter is required");
+
     double fixedNotional = fixedLeg->notional();
     double fixedRate = fixedLeg->rate();
-    DayCounter fixedDayCounter = DayCounterToQL(fixedLeg->day_counter());
+    DayCounter fixedDayCounter = DayCounterToQL(fixedLeg->day_counter().value());
 
     // Parse floating leg
     auto floatingLeg = swap->floating_leg();
@@ -46,9 +49,12 @@ std::shared_ptr<QuantLib::VanillaSwap> VanillaSwapParser::parse(
 
     auto floatingSchedule = scheduleParser.parse(floatingLeg->schedule());
 
+    if (!floatingLeg->day_counter().has_value())
+        QUANTRA_INVALID_ARGUMENT("SwapFloatingLeg.day_counter is required");
+
     double floatingNotional = floatingLeg->notional();
     double spread = floatingLeg->spread();
-    DayCounter floatingDayCounter = DayCounterToQL(floatingLeg->day_counter());
+    DayCounter floatingDayCounter = DayCounterToQL(floatingLeg->day_counter().value());
 
     // Resolve index from registry and clone with forwarding curve
     std::string indexId = floatingLeg->index()->id()->str();

--- a/tests/contract/error_contract_test.py
+++ b/tests/contract/error_contract_test.py
@@ -165,6 +165,16 @@ def _ec_del_schedule_field(arr_key, product_key, field):
     return f
 
 
+def _ec_del_swap_leg_field(arr_key, swap_key, leg_key, field):
+    """Drop a convention field from a swap leg. The swap-leg convention enums
+    (day_counter, payment_convention) are presence-required: an omitted
+    convention is an error, never an alphabetical-0 default."""
+    def f(req):
+        req[arr_key][0][swap_key][leg_key].pop(field, None)
+        return req
+    return f
+
+
 def _ec_del_vol_base_field(field):
     """Drop a convention field from the first vol surface's base spec. The
     IrVol/BlackVol base convention enums are presence-required: an omitted
@@ -276,6 +286,17 @@ SCENARIOS = [
      "swaption_request.json", 400, _ec_del_field("swaptions", "model")),
     ("ec:400 fixed_rate_bond missing discounting_curve field", "fixed_rate_bond",
      "fixed_rate_bond_request.json", 400, _ec_del_field("bonds", "discounting_curve")),
+    # ---- 400 INVALID_ARGUMENT: swap-leg convention presence ----
+    # A swap-leg convention enum omitted from the request must be rejected, not
+    # silently defaulted to the alphabetical-0 value.
+    ("ec:400 vanilla_swap fixed leg missing day_counter", "vanilla_swap",
+     "vanilla_swap_request.json", 400,
+     _ec_del_swap_leg_field("swaps", "vanilla_swap", "fixed_leg", "day_counter"),
+     _ec_body_contains("SwapFixedLeg.day_counter is required")),
+    ("ec:400 vanilla_swap fixed leg missing payment_convention", "vanilla_swap",
+     "vanilla_swap_request.json", 400,
+     _ec_del_swap_leg_field("swaps", "vanilla_swap", "fixed_leg", "payment_convention"),
+     _ec_body_contains("SwapFixedLeg.payment_convention is required")),
     # ---- 400 INVALID_ARGUMENT: null-deref guards (optional date fields
     #      omitted on curve helpers; pre-guard these crashed the worker) ----
     ("ec:400 fixed_rate_bond curve BondHelper missing issue_date", "fixed_rate_bond",


### PR DESCRIPTION
**Schema v3, step 3d (wire-breaking): swap legs.** `SwapFixedLeg`/`SwapFloatingLeg`/`SwapCmsLeg` `day_counter` and `payment_convention` become optional-with-presence — an omitted convention errors instead of silently taking the alphabetical-0 value. Every direct reader requires presence, including the shared-table couplings: `OisSwap.fixed_leg`, basis-swap legs, and both swaption underlyings.

No example/catalog JSON needed editing. +2 error-contract scenarios. Regenerated FlatBuffers included. Full suite green (494 cases). Step 3d of the D1 sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
