### PR TITLE
Require explicit bond and yield conventions (schema v3, step 3e: bonds)

### DIFF
--- a/flatbuffers/cpp/common_generated.h
+++ b/flatbuffers/cpp/common_generated.h
@@ -239,9 +239,9 @@ inline ::flatbuffers::Offset<Period> CreatePeriod(
 
 struct YieldT : public ::flatbuffers::NativeTable {
   typedef Yield TableType;
-  quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360;
-  quantra::enums::Compounding compounding = quantra::enums::Compounding_Compounded;
-  quantra::enums::Frequency frequency = quantra::enums::Frequency_Annual;
+  ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::Compounding> compounding = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::Frequency> frequency = ::flatbuffers::nullopt;
 };
 
 /// Yield/compounding convention specification.
@@ -253,14 +253,14 @@ struct Yield FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
     VT_COMPOUNDING = 6,
     VT_FREQUENCY = 8
   };
-  quantra::enums::DayCounter day_counter() const {
-    return static_cast<quantra::enums::DayCounter>(GetField<int8_t>(VT_DAY_COUNTER, 0));
+  ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter() const {
+    return GetOptional<int8_t, quantra::enums::DayCounter>(VT_DAY_COUNTER);
   }
-  quantra::enums::Compounding compounding() const {
-    return static_cast<quantra::enums::Compounding>(GetField<int8_t>(VT_COMPOUNDING, 0));
+  ::flatbuffers::Optional<quantra::enums::Compounding> compounding() const {
+    return GetOptional<int8_t, quantra::enums::Compounding>(VT_COMPOUNDING);
   }
-  quantra::enums::Frequency frequency() const {
-    return static_cast<quantra::enums::Frequency>(GetField<int8_t>(VT_FREQUENCY, 0));
+  ::flatbuffers::Optional<quantra::enums::Frequency> frequency() const {
+    return GetOptional<int8_t, quantra::enums::Frequency>(VT_FREQUENCY);
   }
   bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -279,13 +279,13 @@ struct YieldBuilder {
   ::flatbuffers::FlatBufferBuilder &fbb_;
   ::flatbuffers::uoffset_t start_;
   void add_day_counter(quantra::enums::DayCounter day_counter) {
-    fbb_.AddElement<int8_t>(Yield::VT_DAY_COUNTER, static_cast<int8_t>(day_counter), 0);
+    fbb_.AddElement<int8_t>(Yield::VT_DAY_COUNTER, static_cast<int8_t>(day_counter));
   }
   void add_compounding(quantra::enums::Compounding compounding) {
-    fbb_.AddElement<int8_t>(Yield::VT_COMPOUNDING, static_cast<int8_t>(compounding), 0);
+    fbb_.AddElement<int8_t>(Yield::VT_COMPOUNDING, static_cast<int8_t>(compounding));
   }
   void add_frequency(quantra::enums::Frequency frequency) {
-    fbb_.AddElement<int8_t>(Yield::VT_FREQUENCY, static_cast<int8_t>(frequency), 0);
+    fbb_.AddElement<int8_t>(Yield::VT_FREQUENCY, static_cast<int8_t>(frequency));
   }
   explicit YieldBuilder(::flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
@@ -300,13 +300,13 @@ struct YieldBuilder {
 
 inline ::flatbuffers::Offset<Yield> CreateYield(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360,
-    quantra::enums::Compounding compounding = quantra::enums::Compounding_Compounded,
-    quantra::enums::Frequency frequency = quantra::enums::Frequency_Annual) {
+    ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::Compounding> compounding = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::Frequency> frequency = ::flatbuffers::nullopt) {
   YieldBuilder builder_(_fbb);
-  builder_.add_frequency(frequency);
-  builder_.add_compounding(compounding);
-  builder_.add_day_counter(day_counter);
+  if(frequency) { builder_.add_frequency(*frequency); }
+  if(compounding) { builder_.add_compounding(*compounding); }
+  if(day_counter) { builder_.add_day_counter(*day_counter); }
   return builder_.Finish();
 }
 

--- a/flatbuffers/cpp/fixed_rate_bond_generated.h
+++ b/flatbuffers/cpp/fixed_rate_bond_generated.h
@@ -27,8 +27,8 @@ struct FixedRateBondT : public ::flatbuffers::NativeTable {
   int32_t settlement_days = 0;
   double face_amount = 0.0;
   double rate = 0.0;
-  quantra::enums::DayCounter accrual_day_counter = quantra::enums::DayCounter_Actual360;
-  quantra::enums::BusinessDayConvention payment_convention = quantra::enums::BusinessDayConvention_Following;
+  ::flatbuffers::Optional<quantra::enums::DayCounter> accrual_day_counter = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> payment_convention = ::flatbuffers::nullopt;
   double redemption = 0.0;
   std::string issue_date{};
   std::unique_ptr<quantra::ScheduleT> schedule{};
@@ -61,11 +61,11 @@ struct FixedRateBond FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   double rate() const {
     return GetField<double>(VT_RATE, 0.0);
   }
-  quantra::enums::DayCounter accrual_day_counter() const {
-    return static_cast<quantra::enums::DayCounter>(GetField<int8_t>(VT_ACCRUAL_DAY_COUNTER, 0));
+  ::flatbuffers::Optional<quantra::enums::DayCounter> accrual_day_counter() const {
+    return GetOptional<int8_t, quantra::enums::DayCounter>(VT_ACCRUAL_DAY_COUNTER);
   }
-  quantra::enums::BusinessDayConvention payment_convention() const {
-    return static_cast<quantra::enums::BusinessDayConvention>(GetField<int8_t>(VT_PAYMENT_CONVENTION, 0));
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> payment_convention() const {
+    return GetOptional<int8_t, quantra::enums::BusinessDayConvention>(VT_PAYMENT_CONVENTION);
   }
   double redemption() const {
     return GetField<double>(VT_REDEMPTION, 0.0);
@@ -109,10 +109,10 @@ struct FixedRateBondBuilder {
     fbb_.AddElement<double>(FixedRateBond::VT_RATE, rate, 0.0);
   }
   void add_accrual_day_counter(quantra::enums::DayCounter accrual_day_counter) {
-    fbb_.AddElement<int8_t>(FixedRateBond::VT_ACCRUAL_DAY_COUNTER, static_cast<int8_t>(accrual_day_counter), 0);
+    fbb_.AddElement<int8_t>(FixedRateBond::VT_ACCRUAL_DAY_COUNTER, static_cast<int8_t>(accrual_day_counter));
   }
   void add_payment_convention(quantra::enums::BusinessDayConvention payment_convention) {
-    fbb_.AddElement<int8_t>(FixedRateBond::VT_PAYMENT_CONVENTION, static_cast<int8_t>(payment_convention), 0);
+    fbb_.AddElement<int8_t>(FixedRateBond::VT_PAYMENT_CONVENTION, static_cast<int8_t>(payment_convention));
   }
   void add_redemption(double redemption) {
     fbb_.AddElement<double>(FixedRateBond::VT_REDEMPTION, redemption, 0.0);
@@ -139,8 +139,8 @@ inline ::flatbuffers::Offset<FixedRateBond> CreateFixedRateBond(
     int32_t settlement_days = 0,
     double face_amount = 0.0,
     double rate = 0.0,
-    quantra::enums::DayCounter accrual_day_counter = quantra::enums::DayCounter_Actual360,
-    quantra::enums::BusinessDayConvention payment_convention = quantra::enums::BusinessDayConvention_Following,
+    ::flatbuffers::Optional<quantra::enums::DayCounter> accrual_day_counter = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> payment_convention = ::flatbuffers::nullopt,
     double redemption = 0.0,
     ::flatbuffers::Offset<::flatbuffers::String> issue_date = 0,
     ::flatbuffers::Offset<quantra::Schedule> schedule = 0) {
@@ -151,8 +151,8 @@ inline ::flatbuffers::Offset<FixedRateBond> CreateFixedRateBond(
   builder_.add_schedule(schedule);
   builder_.add_issue_date(issue_date);
   builder_.add_settlement_days(settlement_days);
-  builder_.add_payment_convention(payment_convention);
-  builder_.add_accrual_day_counter(accrual_day_counter);
+  if(payment_convention) { builder_.add_payment_convention(*payment_convention); }
+  if(accrual_day_counter) { builder_.add_accrual_day_counter(*accrual_day_counter); }
   return builder_.Finish();
 }
 
@@ -161,8 +161,8 @@ inline ::flatbuffers::Offset<FixedRateBond> CreateFixedRateBondDirect(
     int32_t settlement_days = 0,
     double face_amount = 0.0,
     double rate = 0.0,
-    quantra::enums::DayCounter accrual_day_counter = quantra::enums::DayCounter_Actual360,
-    quantra::enums::BusinessDayConvention payment_convention = quantra::enums::BusinessDayConvention_Following,
+    ::flatbuffers::Optional<quantra::enums::DayCounter> accrual_day_counter = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> payment_convention = ::flatbuffers::nullopt,
     double redemption = 0.0,
     const char *issue_date = nullptr,
     ::flatbuffers::Offset<quantra::Schedule> schedule = 0) {

--- a/flatbuffers/cpp/floating_rate_bond_generated.h
+++ b/flatbuffers/cpp/floating_rate_bond_generated.h
@@ -29,8 +29,8 @@ struct FloatingRateBondT : public ::flatbuffers::NativeTable {
   double face_amount = 0.0;
   std::unique_ptr<quantra::ScheduleT> schedule{};
   std::unique_ptr<quantra::IndexRefT> index{};
-  quantra::enums::DayCounter accrual_day_counter = quantra::enums::DayCounter_Actual360;
-  quantra::enums::BusinessDayConvention payment_convention = quantra::enums::BusinessDayConvention_Following;
+  ::flatbuffers::Optional<quantra::enums::DayCounter> accrual_day_counter = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> payment_convention = ::flatbuffers::nullopt;
   int32_t fixing_days = 0;
   double spread = 0.0;
   bool in_arrears = false;
@@ -72,11 +72,11 @@ struct FloatingRateBond FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   const quantra::IndexRef *index() const {
     return GetPointer<const quantra::IndexRef *>(VT_INDEX);
   }
-  quantra::enums::DayCounter accrual_day_counter() const {
-    return static_cast<quantra::enums::DayCounter>(GetField<int8_t>(VT_ACCRUAL_DAY_COUNTER, 0));
+  ::flatbuffers::Optional<quantra::enums::DayCounter> accrual_day_counter() const {
+    return GetOptional<int8_t, quantra::enums::DayCounter>(VT_ACCRUAL_DAY_COUNTER);
   }
-  quantra::enums::BusinessDayConvention payment_convention() const {
-    return static_cast<quantra::enums::BusinessDayConvention>(GetField<int8_t>(VT_PAYMENT_CONVENTION, 0));
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> payment_convention() const {
+    return GetOptional<int8_t, quantra::enums::BusinessDayConvention>(VT_PAYMENT_CONVENTION);
   }
   int32_t fixing_days() const {
     return GetField<int32_t>(VT_FIXING_DAYS, 0);
@@ -133,10 +133,10 @@ struct FloatingRateBondBuilder {
     fbb_.AddOffset(FloatingRateBond::VT_INDEX, index);
   }
   void add_accrual_day_counter(quantra::enums::DayCounter accrual_day_counter) {
-    fbb_.AddElement<int8_t>(FloatingRateBond::VT_ACCRUAL_DAY_COUNTER, static_cast<int8_t>(accrual_day_counter), 0);
+    fbb_.AddElement<int8_t>(FloatingRateBond::VT_ACCRUAL_DAY_COUNTER, static_cast<int8_t>(accrual_day_counter));
   }
   void add_payment_convention(quantra::enums::BusinessDayConvention payment_convention) {
-    fbb_.AddElement<int8_t>(FloatingRateBond::VT_PAYMENT_CONVENTION, static_cast<int8_t>(payment_convention), 0);
+    fbb_.AddElement<int8_t>(FloatingRateBond::VT_PAYMENT_CONVENTION, static_cast<int8_t>(payment_convention));
   }
   void add_fixing_days(int32_t fixing_days) {
     fbb_.AddElement<int32_t>(FloatingRateBond::VT_FIXING_DAYS, fixing_days, 0);
@@ -171,8 +171,8 @@ inline ::flatbuffers::Offset<FloatingRateBond> CreateFloatingRateBond(
     double face_amount = 0.0,
     ::flatbuffers::Offset<quantra::Schedule> schedule = 0,
     ::flatbuffers::Offset<quantra::IndexRef> index = 0,
-    quantra::enums::DayCounter accrual_day_counter = quantra::enums::DayCounter_Actual360,
-    quantra::enums::BusinessDayConvention payment_convention = quantra::enums::BusinessDayConvention_Following,
+    ::flatbuffers::Optional<quantra::enums::DayCounter> accrual_day_counter = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> payment_convention = ::flatbuffers::nullopt,
     int32_t fixing_days = 0,
     double spread = 0.0,
     bool in_arrears = false,
@@ -188,8 +188,8 @@ inline ::flatbuffers::Offset<FloatingRateBond> CreateFloatingRateBond(
   builder_.add_schedule(schedule);
   builder_.add_settlement_days(settlement_days);
   builder_.add_in_arrears(in_arrears);
-  builder_.add_payment_convention(payment_convention);
-  builder_.add_accrual_day_counter(accrual_day_counter);
+  if(payment_convention) { builder_.add_payment_convention(*payment_convention); }
+  if(accrual_day_counter) { builder_.add_accrual_day_counter(*accrual_day_counter); }
   return builder_.Finish();
 }
 
@@ -199,8 +199,8 @@ inline ::flatbuffers::Offset<FloatingRateBond> CreateFloatingRateBondDirect(
     double face_amount = 0.0,
     ::flatbuffers::Offset<quantra::Schedule> schedule = 0,
     ::flatbuffers::Offset<quantra::IndexRef> index = 0,
-    quantra::enums::DayCounter accrual_day_counter = quantra::enums::DayCounter_Actual360,
-    quantra::enums::BusinessDayConvention payment_convention = quantra::enums::BusinessDayConvention_Following,
+    ::flatbuffers::Optional<quantra::enums::DayCounter> accrual_day_counter = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> payment_convention = ::flatbuffers::nullopt,
     int32_t fixing_days = 0,
     double spread = 0.0,
     bool in_arrears = false,

--- a/flatbuffers/fbs/common.fbs
+++ b/flatbuffers/fbs/common.fbs
@@ -10,9 +10,9 @@ table Period {
 
 /// Yield/compounding convention specification.
 table Yield {
-    day_counter:enums.DayCounter;
-    compounding:enums.Compounding;
-    frequency:enums.Frequency;
+    day_counter:enums.DayCounter = null;
+    compounding:enums.Compounding = null;
+    frequency:enums.Frequency = null;
 }
 
 /// Error message container.

--- a/flatbuffers/fbs/fixed_rate_bond.fbs
+++ b/flatbuffers/fbs/fixed_rate_bond.fbs
@@ -8,8 +8,8 @@ table FixedRateBond {
     settlement_days:int;
     face_amount:double;
     rate:double;
-    accrual_day_counter:enums.DayCounter;
-    payment_convention:enums.BusinessDayConvention;
+    accrual_day_counter:enums.DayCounter = null;
+    payment_convention:enums.BusinessDayConvention = null;
     redemption:double;
     issue_date:string;
     schedule:Schedule;

--- a/flatbuffers/fbs/floating_rate_bond.fbs
+++ b/flatbuffers/fbs/floating_rate_bond.fbs
@@ -11,8 +11,8 @@ table FloatingRateBond {
     schedule:Schedule;
     /// Reference to an IndexDef by id (e.g., "EUR_6M").
     index:IndexRef (required);
-    accrual_day_counter:enums.DayCounter;
-    payment_convention:enums.BusinessDayConvention;
+    accrual_day_counter:enums.DayCounter = null;
+    payment_convention:enums.BusinessDayConvention = null;
     fixing_days:int;
     spread:double;
     in_arrears:bool;

--- a/flatbuffers/python/quantra/FixedRateBond.py
+++ b/flatbuffers/python/quantra/FixedRateBond.py
@@ -51,14 +51,14 @@ class FixedRateBond(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(10))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # FixedRateBond
     def PaymentConvention(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(12))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # FixedRateBond
     def Redemption(self):
@@ -110,13 +110,13 @@ def AddRate(builder, rate):
     FixedRateBondAddRate(builder, rate)
 
 def FixedRateBondAddAccrualDayCounter(builder, accrualDayCounter):
-    builder.PrependInt8Slot(3, accrualDayCounter, 0)
+    builder.PrependInt8Slot(3, accrualDayCounter, None)
 
 def AddAccrualDayCounter(builder, accrualDayCounter):
     FixedRateBondAddAccrualDayCounter(builder, accrualDayCounter)
 
 def FixedRateBondAddPaymentConvention(builder, paymentConvention):
-    builder.PrependInt8Slot(4, paymentConvention, 0)
+    builder.PrependInt8Slot(4, paymentConvention, None)
 
 def AddPaymentConvention(builder, paymentConvention):
     FixedRateBondAddPaymentConvention(builder, paymentConvention)
@@ -157,8 +157,8 @@ class FixedRateBondT(object):
         self.settlementDays = 0  # type: int
         self.faceAmount = 0.0  # type: float
         self.rate = 0.0  # type: float
-        self.accrualDayCounter = 0  # type: int
-        self.paymentConvention = 0  # type: int
+        self.accrualDayCounter = None  # type: Optional[int]
+        self.paymentConvention = None  # type: Optional[int]
         self.redemption = 0.0  # type: float
         self.issueDate = None  # type: str
         self.schedule = None  # type: Optional[ScheduleT]

--- a/flatbuffers/python/quantra/FloatingRateBond.py
+++ b/flatbuffers/python/quantra/FloatingRateBond.py
@@ -67,14 +67,14 @@ class FloatingRateBond(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(12))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # FloatingRateBond
     def PaymentConvention(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(14))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # FloatingRateBond
     def FixingDays(self):
@@ -142,13 +142,13 @@ def AddIndex(builder, index):
     FloatingRateBondAddIndex(builder, index)
 
 def FloatingRateBondAddAccrualDayCounter(builder, accrualDayCounter):
-    builder.PrependInt8Slot(4, accrualDayCounter, 0)
+    builder.PrependInt8Slot(4, accrualDayCounter, None)
 
 def AddAccrualDayCounter(builder, accrualDayCounter):
     FloatingRateBondAddAccrualDayCounter(builder, accrualDayCounter)
 
 def FloatingRateBondAddPaymentConvention(builder, paymentConvention):
-    builder.PrependInt8Slot(5, paymentConvention, 0)
+    builder.PrependInt8Slot(5, paymentConvention, None)
 
 def AddPaymentConvention(builder, paymentConvention):
     FloatingRateBondAddPaymentConvention(builder, paymentConvention)
@@ -202,8 +202,8 @@ class FloatingRateBondT(object):
         self.faceAmount = 0.0  # type: float
         self.schedule = None  # type: Optional[ScheduleT]
         self.index = None  # type: Optional[IndexRefT]
-        self.accrualDayCounter = 0  # type: int
-        self.paymentConvention = 0  # type: int
+        self.accrualDayCounter = None  # type: Optional[int]
+        self.paymentConvention = None  # type: Optional[int]
         self.fixingDays = 0  # type: int
         self.spread = 0.0  # type: float
         self.inArrears = False  # type: bool

--- a/flatbuffers/python/quantra/Yield.py
+++ b/flatbuffers/python/quantra/Yield.py
@@ -30,21 +30,21 @@ class Yield(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # Yield
     def Compounding(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # Yield
     def Frequency(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(8))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
 def YieldStart(builder):
     builder.StartObject(3)
@@ -53,19 +53,19 @@ def Start(builder):
     YieldStart(builder)
 
 def YieldAddDayCounter(builder, dayCounter):
-    builder.PrependInt8Slot(0, dayCounter, 0)
+    builder.PrependInt8Slot(0, dayCounter, None)
 
 def AddDayCounter(builder, dayCounter):
     YieldAddDayCounter(builder, dayCounter)
 
 def YieldAddCompounding(builder, compounding):
-    builder.PrependInt8Slot(1, compounding, 0)
+    builder.PrependInt8Slot(1, compounding, None)
 
 def AddCompounding(builder, compounding):
     YieldAddCompounding(builder, compounding)
 
 def YieldAddFrequency(builder, frequency):
-    builder.PrependInt8Slot(2, frequency, 0)
+    builder.PrependInt8Slot(2, frequency, None)
 
 def AddFrequency(builder, frequency):
     YieldAddFrequency(builder, frequency)
@@ -81,9 +81,9 @@ class YieldT(object):
 
     # YieldT
     def __init__(self):
-        self.dayCounter = 0  # type: int
-        self.compounding = 0  # type: int
-        self.frequency = 0  # type: int
+        self.dayCounter = None  # type: Optional[int]
+        self.compounding = None  # type: Optional[int]
+        self.frequency = None  # type: Optional[int]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):

--- a/src/mappers/fixed_rate_bond_mapper.cpp
+++ b/src/mappers/fixed_rate_bond_mapper.cpp
@@ -35,9 +35,18 @@ FixedRateBondInputs FixedRateBondMapper::toInputs(
         FixedRateBondTrade trade;
         trade.bond = bondParser.parse(it->fixed_rate_bond());
         trade.discountingCurveId = it->discounting_curve()->str();
-        trade.yieldDc = DayCounterToQL(it->yield()->day_counter());
-        trade.yieldComp = CompoundingToQL(it->yield()->compounding());
-        trade.yieldFreq = FrequencyToQL(it->yield()->frequency());
+        if (!it->yield()->day_counter().has_value()) {
+            QUANTRA_INVALID_ARGUMENT("Yield.day_counter is required");
+        }
+        if (!it->yield()->compounding().has_value()) {
+            QUANTRA_INVALID_ARGUMENT("Yield.compounding is required");
+        }
+        if (!it->yield()->frequency().has_value()) {
+            QUANTRA_INVALID_ARGUMENT("Yield.frequency is required");
+        }
+        trade.yieldDc = DayCounterToQL(it->yield()->day_counter().value());
+        trade.yieldComp = CompoundingToQL(it->yield()->compounding().value());
+        trade.yieldFreq = FrequencyToQL(it->yield()->frequency().value());
         inputs.trades.push_back(std::move(trade));
     }
 

--- a/src/mappers/floating_rate_bond_mapper.cpp
+++ b/src/mappers/floating_rate_bond_mapper.cpp
@@ -51,8 +51,12 @@ FloatingRateBondTrade extractTrade(const quantra::PriceFloatingRateBond* pricing
     trade.settlement_days = fbBond->settlement_days();
     trade.face_amount = fbBond->face_amount();
     trade.schedule = *scheduleParser.parse(fbBond->schedule());
-    trade.accrual_day_counter = DayCounterToQL(fbBond->accrual_day_counter());
-    trade.payment_convention = ConventionToQL(fbBond->payment_convention());
+    if (!fbBond->accrual_day_counter().has_value())
+        QUANTRA_INVALID_ARGUMENT("FloatingRateBond.accrual_day_counter is required");
+    if (!fbBond->payment_convention().has_value())
+        QUANTRA_INVALID_ARGUMENT("FloatingRateBond.payment_convention is required");
+    trade.accrual_day_counter = DayCounterToQL(fbBond->accrual_day_counter().value());
+    trade.payment_convention = ConventionToQL(fbBond->payment_convention().value());
     trade.fixing_days = fbBond->fixing_days();
     trade.spread = fbBond->spread();
     trade.in_arrears = fbBond->in_arrears();

--- a/src/parsers/fixed_rate_bond_parser.cpp
+++ b/src/parsers/fixed_rate_bond_parser.cpp
@@ -7,13 +7,18 @@ std::shared_ptr<QuantLib::FixedRateBond> FixedRateBondParser::parse(const quantr
 
     ScheduleParser schedule_parser = ScheduleParser();
 
+    if (!bond->accrual_day_counter().has_value())
+        QUANTRA_INVALID_ARGUMENT("FixedRateBond.accrual_day_counter is required");
+    if (!bond->payment_convention().has_value())
+        QUANTRA_INVALID_ARGUMENT("FixedRateBond.payment_convention is required");
+
     return std::make_shared<QuantLib::FixedRateBond>(
         bond->settlement_days(),
         bond->face_amount(),
         *schedule_parser.parse(bond->schedule()),
         std::vector<Rate>(1, bond->rate()),
-        DayCounterToQL(bond->accrual_day_counter()),
-        ConventionToQL(bond->payment_convention()),
+        DayCounterToQL(bond->accrual_day_counter().value()),
+        ConventionToQL(bond->payment_convention().value()),
         bond->redemption(),
         DateToQL(bond->issue_date()->str()));
 }

--- a/src/parsers/floating_rate_bond_parser.cpp
+++ b/src/parsers/floating_rate_bond_parser.cpp
@@ -16,13 +16,18 @@ std::shared_ptr<QuantLib::FloatingRateBond> FloatingRateBondParser::parse(
     std::string indexId = bond->index()->id()->str();
     auto iborIndex = indices.getIborWithCurve(indexId, forwarding_term_structure_);
 
+    if (!bond->accrual_day_counter().has_value())
+        QUANTRA_INVALID_ARGUMENT("FloatingRateBond.accrual_day_counter is required");
+    if (!bond->payment_convention().has_value())
+        QUANTRA_INVALID_ARGUMENT("FloatingRateBond.payment_convention is required");
+
     return std::make_shared<QuantLib::FloatingRateBond>(
         bond->settlement_days(),
         bond->face_amount(),
         *schedule_parser.parse(bond->schedule()),
         iborIndex,
-        DayCounterToQL(bond->accrual_day_counter()),
-        ConventionToQL(bond->payment_convention()),
+        DayCounterToQL(bond->accrual_day_counter().value()),
+        ConventionToQL(bond->payment_convention().value()),
         bond->fixing_days(),
         std::vector<Real>(1, 1.0),
         std::vector<Spread>(1, bond->spread()),

--- a/src/parsers/yield_parser.cpp
+++ b/src/parsers/yield_parser.cpp
@@ -7,9 +7,16 @@ std::shared_ptr<YieldStruct> YieldParser::parse(const quantra::Yield *yield)
     if (yield == NULL)
         QUANTRA_INVALID_ARGUMENT("Yield not found");
 
+    if (!yield->day_counter().has_value())
+        QUANTRA_INVALID_ARGUMENT("Yield.day_counter is required");
+    if (!yield->compounding().has_value())
+        QUANTRA_INVALID_ARGUMENT("Yield.compounding is required");
+    if (!yield->frequency().has_value())
+        QUANTRA_INVALID_ARGUMENT("Yield.frequency is required");
+
     return std::make_shared<YieldStruct>(
         YieldStruct{
-            DayCounterToQL(yield->day_counter()),
-            CompoundingToQL(yield->compounding()),
-            FrequencyToQL(yield->frequency())});
+            DayCounterToQL(yield->day_counter().value()),
+            CompoundingToQL(yield->compounding().value()),
+            FrequencyToQL(yield->frequency().value())});
 }

--- a/tests/contract/error_contract_test.py
+++ b/tests/contract/error_contract_test.py
@@ -175,6 +175,26 @@ def _ec_del_swap_leg_field(arr_key, swap_key, leg_key, field):
     return f
 
 
+def _ec_del_bond_field(arr_key, bond_key, field):
+    """Drop a convention field from the bond block. The bond convention enums
+    (accrual_day_counter, payment_convention) are presence-required: an omitted
+    convention is an error, never an alphabetical-0 default."""
+    def f(req):
+        req[arr_key][0][bond_key].pop(field, None)
+        return req
+    return f
+
+
+def _ec_del_yield_field(arr_key, field):
+    """Drop a convention field from the yield block carried by a bond request.
+    The Yield convention enums (day_counter, frequency) are presence-required:
+    an omitted convention is an error, never an alphabetical-0 default."""
+    def f(req):
+        req[arr_key][0]["yield"].pop(field, None)
+        return req
+    return f
+
+
 def _ec_del_vol_base_field(field):
     """Drop a convention field from the first vol surface's base spec. The
     IrVol/BlackVol base convention enums are presence-required: an omitted
@@ -297,6 +317,21 @@ SCENARIOS = [
      "vanilla_swap_request.json", 400,
      _ec_del_swap_leg_field("swaps", "vanilla_swap", "fixed_leg", "payment_convention"),
      _ec_body_contains("SwapFixedLeg.payment_convention is required")),
+    # ---- 400 INVALID_ARGUMENT: bond / yield convention presence ----
+    # A bond or yield convention enum omitted from the request must be rejected,
+    # not silently defaulted to the alphabetical-0 value.
+    ("ec:400 fixed_rate_bond missing accrual_day_counter", "fixed_rate_bond",
+     "fixed_rate_bond_request.json", 400,
+     _ec_del_bond_field("bonds", "fixed_rate_bond", "accrual_day_counter"),
+     _ec_body_contains("FixedRateBond.accrual_day_counter is required")),
+    ("ec:400 fixed_rate_bond yield missing compounding", "fixed_rate_bond",
+     "fixed_rate_bond_request.json", 400,
+     _ec_del_yield_field("bonds", "compounding"),
+     _ec_body_contains("Yield.compounding is required")),
+    ("ec:400 fixed_rate_bond yield missing frequency", "fixed_rate_bond",
+     "fixed_rate_bond_request.json", 400,
+     _ec_del_yield_field("bonds", "frequency"),
+     _ec_body_contains("Yield.frequency is required")),
     # ---- 400 INVALID_ARGUMENT: null-deref guards (optional date fields
     #      omitted on curve helpers; pre-guard these crashed the worker) ----
     ("ec:400 fixed_rate_bond curve BondHelper missing issue_date", "fixed_rate_bond",


### PR DESCRIPTION
**Schema v3, step 3e (wire-breaking): bonds & yield.** `FixedRateBond`/`FloatingRateBond` `accrual_day_counter` and `payment_convention`, plus the `Yield` spec's `day_counter`, `compounding` and `frequency`, become optional-with-presence — an omitted convention errors (400, naming the field) instead of silently taking the alphabetical-0 value. Every direct reader requires presence, including the `Yield` table shared by both bond paths.

No example/catalog JSON needed editing. +3 error-contract scenarios. Regenerated FlatBuffers included. Full suite green (497 cases). Step 3e of the convention-presence sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
