### PR TITLE
Require explicit FRA, cap/floor and CDS conventions and product type (schema v3, step 3f)

### DIFF
--- a/flatbuffers/cpp/cap_floor_generated.h
+++ b/flatbuffers/cpp/cap_floor_generated.h
@@ -25,13 +25,13 @@ struct CapFloorT;
 
 struct CapFloorT : public ::flatbuffers::NativeTable {
   typedef CapFloor TableType;
-  quantra::enums::CapFloorType cap_floor_type = quantra::enums::CapFloorType_Cap;
+  ::flatbuffers::Optional<quantra::enums::CapFloorType> cap_floor_type = ::flatbuffers::nullopt;
   double notional = 0.0;
   double strike = 0.0;
   std::unique_ptr<quantra::ScheduleT> schedule{};
   std::unique_ptr<quantra::IndexRefT> index{};
-  quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360;
-  quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_Following;
+  ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt;
   CapFloorT() = default;
   CapFloorT(const CapFloorT &o);
   CapFloorT(CapFloorT&&) FLATBUFFERS_NOEXCEPT = default;
@@ -51,8 +51,8 @@ struct CapFloor FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
     VT_DAY_COUNTER = 14,
     VT_BUSINESS_DAY_CONVENTION = 16
   };
-  quantra::enums::CapFloorType cap_floor_type() const {
-    return static_cast<quantra::enums::CapFloorType>(GetField<int8_t>(VT_CAP_FLOOR_TYPE, 0));
+  ::flatbuffers::Optional<quantra::enums::CapFloorType> cap_floor_type() const {
+    return GetOptional<int8_t, quantra::enums::CapFloorType>(VT_CAP_FLOOR_TYPE);
   }
   double notional() const {
     return GetField<double>(VT_NOTIONAL, 0.0);
@@ -68,11 +68,11 @@ struct CapFloor FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   const quantra::IndexRef *index() const {
     return GetPointer<const quantra::IndexRef *>(VT_INDEX);
   }
-  quantra::enums::DayCounter day_counter() const {
-    return static_cast<quantra::enums::DayCounter>(GetField<int8_t>(VT_DAY_COUNTER, 0));
+  ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter() const {
+    return GetOptional<int8_t, quantra::enums::DayCounter>(VT_DAY_COUNTER);
   }
-  quantra::enums::BusinessDayConvention business_day_convention() const {
-    return static_cast<quantra::enums::BusinessDayConvention>(GetField<int8_t>(VT_BUSINESS_DAY_CONVENTION, 0));
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention() const {
+    return GetOptional<int8_t, quantra::enums::BusinessDayConvention>(VT_BUSINESS_DAY_CONVENTION);
   }
   bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -97,7 +97,7 @@ struct CapFloorBuilder {
   ::flatbuffers::FlatBufferBuilder &fbb_;
   ::flatbuffers::uoffset_t start_;
   void add_cap_floor_type(quantra::enums::CapFloorType cap_floor_type) {
-    fbb_.AddElement<int8_t>(CapFloor::VT_CAP_FLOOR_TYPE, static_cast<int8_t>(cap_floor_type), 0);
+    fbb_.AddElement<int8_t>(CapFloor::VT_CAP_FLOOR_TYPE, static_cast<int8_t>(cap_floor_type));
   }
   void add_notional(double notional) {
     fbb_.AddElement<double>(CapFloor::VT_NOTIONAL, notional, 0.0);
@@ -112,10 +112,10 @@ struct CapFloorBuilder {
     fbb_.AddOffset(CapFloor::VT_INDEX, index);
   }
   void add_day_counter(quantra::enums::DayCounter day_counter) {
-    fbb_.AddElement<int8_t>(CapFloor::VT_DAY_COUNTER, static_cast<int8_t>(day_counter), 0);
+    fbb_.AddElement<int8_t>(CapFloor::VT_DAY_COUNTER, static_cast<int8_t>(day_counter));
   }
   void add_business_day_convention(quantra::enums::BusinessDayConvention business_day_convention) {
-    fbb_.AddElement<int8_t>(CapFloor::VT_BUSINESS_DAY_CONVENTION, static_cast<int8_t>(business_day_convention), 0);
+    fbb_.AddElement<int8_t>(CapFloor::VT_BUSINESS_DAY_CONVENTION, static_cast<int8_t>(business_day_convention));
   }
   explicit CapFloorBuilder(::flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
@@ -131,21 +131,21 @@ struct CapFloorBuilder {
 
 inline ::flatbuffers::Offset<CapFloor> CreateCapFloor(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    quantra::enums::CapFloorType cap_floor_type = quantra::enums::CapFloorType_Cap,
+    ::flatbuffers::Optional<quantra::enums::CapFloorType> cap_floor_type = ::flatbuffers::nullopt,
     double notional = 0.0,
     double strike = 0.0,
     ::flatbuffers::Offset<quantra::Schedule> schedule = 0,
     ::flatbuffers::Offset<quantra::IndexRef> index = 0,
-    quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360,
-    quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_Following) {
+    ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt) {
   CapFloorBuilder builder_(_fbb);
   builder_.add_strike(strike);
   builder_.add_notional(notional);
   builder_.add_index(index);
   builder_.add_schedule(schedule);
-  builder_.add_business_day_convention(business_day_convention);
-  builder_.add_day_counter(day_counter);
-  builder_.add_cap_floor_type(cap_floor_type);
+  if(business_day_convention) { builder_.add_business_day_convention(*business_day_convention); }
+  if(day_counter) { builder_.add_day_counter(*day_counter); }
+  if(cap_floor_type) { builder_.add_cap_floor_type(*cap_floor_type); }
   return builder_.Finish();
 }
 

--- a/flatbuffers/cpp/cds_generated.h
+++ b/flatbuffers/cpp/cds_generated.h
@@ -24,13 +24,13 @@ struct CDST;
 
 struct CDST : public ::flatbuffers::NativeTable {
   typedef CDS TableType;
-  quantra::enums::ProtectionSide side = quantra::enums::ProtectionSide_Buyer;
+  ::flatbuffers::Optional<quantra::enums::ProtectionSide> side = ::flatbuffers::nullopt;
   double notional = 0.0;
   ::flatbuffers::Optional<double> running_coupon = ::flatbuffers::nullopt;
   std::unique_ptr<quantra::ScheduleT> schedule{};
   ::flatbuffers::Optional<double> upfront = ::flatbuffers::nullopt;
-  quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360;
-  quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_Following;
+  ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt;
   bool settles_accrual = true;
   bool pays_at_default_time = true;
   bool rebates_accrual = true;
@@ -66,8 +66,8 @@ struct CDS FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
     VT_TRADE_DATE = 30,
     VT_CASH_SETTLEMENT_DAYS = 32
   };
-  quantra::enums::ProtectionSide side() const {
-    return static_cast<quantra::enums::ProtectionSide>(GetField<int8_t>(VT_SIDE, 0));
+  ::flatbuffers::Optional<quantra::enums::ProtectionSide> side() const {
+    return GetOptional<int8_t, quantra::enums::ProtectionSide>(VT_SIDE);
   }
   double notional() const {
     return GetField<double>(VT_NOTIONAL, 0.0);
@@ -86,11 +86,11 @@ struct CDS FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   ::flatbuffers::Optional<double> upfront() const {
     return GetOptional<double, double>(VT_UPFRONT);
   }
-  quantra::enums::DayCounter day_counter() const {
-    return static_cast<quantra::enums::DayCounter>(GetField<int8_t>(VT_DAY_COUNTER, 0));
+  ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter() const {
+    return GetOptional<int8_t, quantra::enums::DayCounter>(VT_DAY_COUNTER);
   }
-  quantra::enums::BusinessDayConvention business_day_convention() const {
-    return static_cast<quantra::enums::BusinessDayConvention>(GetField<int8_t>(VT_BUSINESS_DAY_CONVENTION, 0));
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention() const {
+    return GetOptional<int8_t, quantra::enums::BusinessDayConvention>(VT_BUSINESS_DAY_CONVENTION);
   }
   bool settles_accrual() const {
     return GetField<uint8_t>(VT_SETTLES_ACCRUAL, 1) != 0;
@@ -149,7 +149,7 @@ struct CDSBuilder {
   ::flatbuffers::FlatBufferBuilder &fbb_;
   ::flatbuffers::uoffset_t start_;
   void add_side(quantra::enums::ProtectionSide side) {
-    fbb_.AddElement<int8_t>(CDS::VT_SIDE, static_cast<int8_t>(side), 0);
+    fbb_.AddElement<int8_t>(CDS::VT_SIDE, static_cast<int8_t>(side));
   }
   void add_notional(double notional) {
     fbb_.AddElement<double>(CDS::VT_NOTIONAL, notional, 0.0);
@@ -164,10 +164,10 @@ struct CDSBuilder {
     fbb_.AddElement<double>(CDS::VT_UPFRONT, upfront);
   }
   void add_day_counter(quantra::enums::DayCounter day_counter) {
-    fbb_.AddElement<int8_t>(CDS::VT_DAY_COUNTER, static_cast<int8_t>(day_counter), 0);
+    fbb_.AddElement<int8_t>(CDS::VT_DAY_COUNTER, static_cast<int8_t>(day_counter));
   }
   void add_business_day_convention(quantra::enums::BusinessDayConvention business_day_convention) {
-    fbb_.AddElement<int8_t>(CDS::VT_BUSINESS_DAY_CONVENTION, static_cast<int8_t>(business_day_convention), 0);
+    fbb_.AddElement<int8_t>(CDS::VT_BUSINESS_DAY_CONVENTION, static_cast<int8_t>(business_day_convention));
   }
   void add_settles_accrual(bool settles_accrual) {
     fbb_.AddElement<uint8_t>(CDS::VT_SETTLES_ACCRUAL, static_cast<uint8_t>(settles_accrual), 1);
@@ -206,13 +206,13 @@ struct CDSBuilder {
 
 inline ::flatbuffers::Offset<CDS> CreateCDS(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    quantra::enums::ProtectionSide side = quantra::enums::ProtectionSide_Buyer,
+    ::flatbuffers::Optional<quantra::enums::ProtectionSide> side = ::flatbuffers::nullopt,
     double notional = 0.0,
     ::flatbuffers::Optional<double> running_coupon = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::Schedule> schedule = 0,
     ::flatbuffers::Optional<double> upfront = ::flatbuffers::nullopt,
-    quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360,
-    quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_Following,
+    ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt,
     bool settles_accrual = true,
     bool pays_at_default_time = true,
     bool rebates_accrual = true,
@@ -234,21 +234,21 @@ inline ::flatbuffers::Offset<CDS> CreateCDS(
   builder_.add_rebates_accrual(rebates_accrual);
   builder_.add_pays_at_default_time(pays_at_default_time);
   builder_.add_settles_accrual(settles_accrual);
-  builder_.add_business_day_convention(business_day_convention);
-  builder_.add_day_counter(day_counter);
-  builder_.add_side(side);
+  if(business_day_convention) { builder_.add_business_day_convention(*business_day_convention); }
+  if(day_counter) { builder_.add_day_counter(*day_counter); }
+  if(side) { builder_.add_side(*side); }
   return builder_.Finish();
 }
 
 inline ::flatbuffers::Offset<CDS> CreateCDSDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    quantra::enums::ProtectionSide side = quantra::enums::ProtectionSide_Buyer,
+    ::flatbuffers::Optional<quantra::enums::ProtectionSide> side = ::flatbuffers::nullopt,
     double notional = 0.0,
     ::flatbuffers::Optional<double> running_coupon = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::Schedule> schedule = 0,
     ::flatbuffers::Optional<double> upfront = ::flatbuffers::nullopt,
-    quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360,
-    quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_Following,
+    ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt,
     bool settles_accrual = true,
     bool pays_at_default_time = true,
     bool rebates_accrual = true,

--- a/flatbuffers/cpp/fra_generated.h
+++ b/flatbuffers/cpp/fra_generated.h
@@ -24,15 +24,15 @@ struct FRAT;
 
 struct FRAT : public ::flatbuffers::NativeTable {
   typedef FRA TableType;
-  quantra::enums::FRAType fra_type = quantra::enums::FRAType_Long;
+  ::flatbuffers::Optional<quantra::enums::FRAType> fra_type = ::flatbuffers::nullopt;
   double notional = 0.0;
   std::string start_date{};
   std::string maturity_date{};
   double strike = 0.0;
   std::unique_ptr<quantra::IndexRefT> index{};
-  quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360;
-  quantra::enums::Calendar calendar = quantra::enums::Calendar_Argentina;
-  quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_Following;
+  ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt;
   FRAT() = default;
   FRAT(const FRAT &o);
   FRAT(FRAT&&) FLATBUFFERS_NOEXCEPT = default;
@@ -54,8 +54,8 @@ struct FRA FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
     VT_CALENDAR = 18,
     VT_BUSINESS_DAY_CONVENTION = 20
   };
-  quantra::enums::FRAType fra_type() const {
-    return static_cast<quantra::enums::FRAType>(GetField<int8_t>(VT_FRA_TYPE, 0));
+  ::flatbuffers::Optional<quantra::enums::FRAType> fra_type() const {
+    return GetOptional<int8_t, quantra::enums::FRAType>(VT_FRA_TYPE);
   }
   double notional() const {
     return GetField<double>(VT_NOTIONAL, 0.0);
@@ -76,14 +76,14 @@ struct FRA FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   const quantra::IndexRef *index() const {
     return GetPointer<const quantra::IndexRef *>(VT_INDEX);
   }
-  quantra::enums::DayCounter day_counter() const {
-    return static_cast<quantra::enums::DayCounter>(GetField<int8_t>(VT_DAY_COUNTER, 0));
+  ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter() const {
+    return GetOptional<int8_t, quantra::enums::DayCounter>(VT_DAY_COUNTER);
   }
-  quantra::enums::Calendar calendar() const {
-    return static_cast<quantra::enums::Calendar>(GetField<int8_t>(VT_CALENDAR, 0));
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar() const {
+    return GetOptional<int8_t, quantra::enums::Calendar>(VT_CALENDAR);
   }
-  quantra::enums::BusinessDayConvention business_day_convention() const {
-    return static_cast<quantra::enums::BusinessDayConvention>(GetField<int8_t>(VT_BUSINESS_DAY_CONVENTION, 0));
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention() const {
+    return GetOptional<int8_t, quantra::enums::BusinessDayConvention>(VT_BUSINESS_DAY_CONVENTION);
   }
   bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -111,7 +111,7 @@ struct FRABuilder {
   ::flatbuffers::FlatBufferBuilder &fbb_;
   ::flatbuffers::uoffset_t start_;
   void add_fra_type(quantra::enums::FRAType fra_type) {
-    fbb_.AddElement<int8_t>(FRA::VT_FRA_TYPE, static_cast<int8_t>(fra_type), 0);
+    fbb_.AddElement<int8_t>(FRA::VT_FRA_TYPE, static_cast<int8_t>(fra_type));
   }
   void add_notional(double notional) {
     fbb_.AddElement<double>(FRA::VT_NOTIONAL, notional, 0.0);
@@ -129,13 +129,13 @@ struct FRABuilder {
     fbb_.AddOffset(FRA::VT_INDEX, index);
   }
   void add_day_counter(quantra::enums::DayCounter day_counter) {
-    fbb_.AddElement<int8_t>(FRA::VT_DAY_COUNTER, static_cast<int8_t>(day_counter), 0);
+    fbb_.AddElement<int8_t>(FRA::VT_DAY_COUNTER, static_cast<int8_t>(day_counter));
   }
   void add_calendar(quantra::enums::Calendar calendar) {
-    fbb_.AddElement<int8_t>(FRA::VT_CALENDAR, static_cast<int8_t>(calendar), 0);
+    fbb_.AddElement<int8_t>(FRA::VT_CALENDAR, static_cast<int8_t>(calendar));
   }
   void add_business_day_convention(quantra::enums::BusinessDayConvention business_day_convention) {
-    fbb_.AddElement<int8_t>(FRA::VT_BUSINESS_DAY_CONVENTION, static_cast<int8_t>(business_day_convention), 0);
+    fbb_.AddElement<int8_t>(FRA::VT_BUSINESS_DAY_CONVENTION, static_cast<int8_t>(business_day_convention));
   }
   explicit FRABuilder(::flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
@@ -151,39 +151,39 @@ struct FRABuilder {
 
 inline ::flatbuffers::Offset<FRA> CreateFRA(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    quantra::enums::FRAType fra_type = quantra::enums::FRAType_Long,
+    ::flatbuffers::Optional<quantra::enums::FRAType> fra_type = ::flatbuffers::nullopt,
     double notional = 0.0,
     ::flatbuffers::Offset<::flatbuffers::String> start_date = 0,
     ::flatbuffers::Offset<::flatbuffers::String> maturity_date = 0,
     double strike = 0.0,
     ::flatbuffers::Offset<quantra::IndexRef> index = 0,
-    quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360,
-    quantra::enums::Calendar calendar = quantra::enums::Calendar_Argentina,
-    quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_Following) {
+    ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt) {
   FRABuilder builder_(_fbb);
   builder_.add_strike(strike);
   builder_.add_notional(notional);
   builder_.add_index(index);
   builder_.add_maturity_date(maturity_date);
   builder_.add_start_date(start_date);
-  builder_.add_business_day_convention(business_day_convention);
-  builder_.add_calendar(calendar);
-  builder_.add_day_counter(day_counter);
-  builder_.add_fra_type(fra_type);
+  if(business_day_convention) { builder_.add_business_day_convention(*business_day_convention); }
+  if(calendar) { builder_.add_calendar(*calendar); }
+  if(day_counter) { builder_.add_day_counter(*day_counter); }
+  if(fra_type) { builder_.add_fra_type(*fra_type); }
   return builder_.Finish();
 }
 
 inline ::flatbuffers::Offset<FRA> CreateFRADirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    quantra::enums::FRAType fra_type = quantra::enums::FRAType_Long,
+    ::flatbuffers::Optional<quantra::enums::FRAType> fra_type = ::flatbuffers::nullopt,
     double notional = 0.0,
     const char *start_date = nullptr,
     const char *maturity_date = nullptr,
     double strike = 0.0,
     ::flatbuffers::Offset<quantra::IndexRef> index = 0,
-    quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360,
-    quantra::enums::Calendar calendar = quantra::enums::Calendar_Argentina,
-    quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_Following) {
+    ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt) {
   auto start_date__ = start_date ? _fbb.CreateString(start_date) : 0;
   auto maturity_date__ = maturity_date ? _fbb.CreateString(maturity_date) : 0;
   return quantra::CreateFRA(

--- a/flatbuffers/fbs/cap_floor.fbs
+++ b/flatbuffers/fbs/cap_floor.fbs
@@ -6,15 +6,15 @@ namespace quantra;
 
 /// Cap or Floor instrument.
 table CapFloor {
-    cap_floor_type:enums.CapFloorType;
+    cap_floor_type:enums.CapFloorType = null;
     notional:double;
     /// Strike rate (e.g., 0.04 for 4%).
     strike:double;
     schedule:Schedule;
     /// Reference to an IndexDef by id (e.g., "EUR_3M").
     index:IndexRef (required);
-    day_counter:enums.DayCounter;
-    business_day_convention:enums.BusinessDayConvention;
+    day_counter:enums.DayCounter = null;
+    business_day_convention:enums.BusinessDayConvention = null;
 }
 
 root_type CapFloor;

--- a/flatbuffers/fbs/cds.fbs
+++ b/flatbuffers/fbs/cds.fbs
@@ -5,7 +5,7 @@ namespace quantra;
 
 /// Credit Default Swap instrument.
 table CDS {
-    side:enums.ProtectionSide;
+    side:enums.ProtectionSide = null;
     notional:double;
     /// Running coupon in decimal (0.01 = 100bps). Required; presence-driven
     /// (a genuine 0 is a valid zero-coupon CDS, an absent value is rejected).
@@ -15,8 +15,8 @@ table CDS {
     /// CreditDefaultSwap constructor (a genuine 0 upfront is representable);
     /// absent selects the plain no-upfront constructor.
     upfront:double = null;
-    day_counter:enums.DayCounter;
-    business_day_convention:enums.BusinessDayConvention;
+    day_counter:enums.DayCounter = null;
+    business_day_convention:enums.BusinessDayConvention = null;
     settles_accrual:bool = true;
     pays_at_default_time:bool = true;
     rebates_accrual:bool = true;

--- a/flatbuffers/fbs/fra.fbs
+++ b/flatbuffers/fbs/fra.fbs
@@ -5,7 +5,7 @@ namespace quantra;
 
 /// Forward Rate Agreement instrument.
 table FRA {
-    fra_type:enums.FRAType;
+    fra_type:enums.FRAType = null;
     notional:double;
     /// When the FRA period starts.
     start_date:string;
@@ -15,9 +15,9 @@ table FRA {
     strike:double;
     /// Reference to an IndexDef by id (e.g., "EUR_3M").
     index:IndexRef (required);
-    day_counter:enums.DayCounter;
-    calendar:enums.Calendar;
-    business_day_convention:enums.BusinessDayConvention;
+    day_counter:enums.DayCounter = null;
+    calendar:enums.Calendar = null;
+    business_day_convention:enums.BusinessDayConvention = null;
 }
 
 root_type FRA;

--- a/flatbuffers/python/quantra/CDS.py
+++ b/flatbuffers/python/quantra/CDS.py
@@ -30,7 +30,7 @@ class CDS(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # CDS
     def Notional(self):
@@ -74,14 +74,14 @@ class CDS(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(14))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # CDS
     def BusinessDayConvention(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(16))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # CDS
     def SettlesAccrual(self):
@@ -146,7 +146,7 @@ def Start(builder):
     CDSStart(builder)
 
 def CDSAddSide(builder, side):
-    builder.PrependInt8Slot(0, side, 0)
+    builder.PrependInt8Slot(0, side, None)
 
 def AddSide(builder, side):
     CDSAddSide(builder, side)
@@ -176,13 +176,13 @@ def AddUpfront(builder, upfront):
     CDSAddUpfront(builder, upfront)
 
 def CDSAddDayCounter(builder, dayCounter):
-    builder.PrependInt8Slot(5, dayCounter, 0)
+    builder.PrependInt8Slot(5, dayCounter, None)
 
 def AddDayCounter(builder, dayCounter):
     CDSAddDayCounter(builder, dayCounter)
 
 def CDSAddBusinessDayConvention(builder, businessDayConvention):
-    builder.PrependInt8Slot(6, businessDayConvention, 0)
+    builder.PrependInt8Slot(6, businessDayConvention, None)
 
 def AddBusinessDayConvention(builder, businessDayConvention):
     CDSAddBusinessDayConvention(builder, businessDayConvention)
@@ -250,13 +250,13 @@ class CDST(object):
 
     # CDST
     def __init__(self):
-        self.side = 0  # type: int
+        self.side = None  # type: Optional[int]
         self.notional = 0.0  # type: float
         self.runningCoupon = None  # type: Optional[float]
         self.schedule = None  # type: Optional[ScheduleT]
         self.upfront = None  # type: Optional[float]
-        self.dayCounter = 0  # type: int
-        self.businessDayConvention = 0  # type: int
+        self.dayCounter = None  # type: Optional[int]
+        self.businessDayConvention = None  # type: Optional[int]
         self.settlesAccrual = True  # type: bool
         self.paysAtDefaultTime = True  # type: bool
         self.rebatesAccrual = True  # type: bool

--- a/flatbuffers/python/quantra/CapFloor.py
+++ b/flatbuffers/python/quantra/CapFloor.py
@@ -30,7 +30,7 @@ class CapFloor(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # CapFloor
     def Notional(self):
@@ -75,14 +75,14 @@ class CapFloor(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(14))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # CapFloor
     def BusinessDayConvention(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(16))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
 def CapFloorStart(builder):
     builder.StartObject(7)
@@ -91,7 +91,7 @@ def Start(builder):
     CapFloorStart(builder)
 
 def CapFloorAddCapFloorType(builder, capFloorType):
-    builder.PrependInt8Slot(0, capFloorType, 0)
+    builder.PrependInt8Slot(0, capFloorType, None)
 
 def AddCapFloorType(builder, capFloorType):
     CapFloorAddCapFloorType(builder, capFloorType)
@@ -121,13 +121,13 @@ def AddIndex(builder, index):
     CapFloorAddIndex(builder, index)
 
 def CapFloorAddDayCounter(builder, dayCounter):
-    builder.PrependInt8Slot(5, dayCounter, 0)
+    builder.PrependInt8Slot(5, dayCounter, None)
 
 def AddDayCounter(builder, dayCounter):
     CapFloorAddDayCounter(builder, dayCounter)
 
 def CapFloorAddBusinessDayConvention(builder, businessDayConvention):
-    builder.PrependInt8Slot(6, businessDayConvention, 0)
+    builder.PrependInt8Slot(6, businessDayConvention, None)
 
 def AddBusinessDayConvention(builder, businessDayConvention):
     CapFloorAddBusinessDayConvention(builder, businessDayConvention)
@@ -147,13 +147,13 @@ class CapFloorT(object):
 
     # CapFloorT
     def __init__(self):
-        self.capFloorType = 0  # type: int
+        self.capFloorType = None  # type: Optional[int]
         self.notional = 0.0  # type: float
         self.strike = 0.0  # type: float
         self.schedule = None  # type: Optional[ScheduleT]
         self.index = None  # type: Optional[IndexRefT]
-        self.dayCounter = 0  # type: int
-        self.businessDayConvention = 0  # type: int
+        self.dayCounter = None  # type: Optional[int]
+        self.businessDayConvention = None  # type: Optional[int]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):

--- a/flatbuffers/python/quantra/FRA.py
+++ b/flatbuffers/python/quantra/FRA.py
@@ -30,7 +30,7 @@ class FRA(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # FRA
     def Notional(self):
@@ -80,21 +80,21 @@ class FRA(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(16))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # FRA
     def Calendar(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(18))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # FRA
     def BusinessDayConvention(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(20))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
 def FRAStart(builder):
     builder.StartObject(9)
@@ -103,7 +103,7 @@ def Start(builder):
     FRAStart(builder)
 
 def FRAAddFraType(builder, fraType):
-    builder.PrependInt8Slot(0, fraType, 0)
+    builder.PrependInt8Slot(0, fraType, None)
 
 def AddFraType(builder, fraType):
     FRAAddFraType(builder, fraType)
@@ -139,19 +139,19 @@ def AddIndex(builder, index):
     FRAAddIndex(builder, index)
 
 def FRAAddDayCounter(builder, dayCounter):
-    builder.PrependInt8Slot(6, dayCounter, 0)
+    builder.PrependInt8Slot(6, dayCounter, None)
 
 def AddDayCounter(builder, dayCounter):
     FRAAddDayCounter(builder, dayCounter)
 
 def FRAAddCalendar(builder, calendar):
-    builder.PrependInt8Slot(7, calendar, 0)
+    builder.PrependInt8Slot(7, calendar, None)
 
 def AddCalendar(builder, calendar):
     FRAAddCalendar(builder, calendar)
 
 def FRAAddBusinessDayConvention(builder, businessDayConvention):
-    builder.PrependInt8Slot(8, businessDayConvention, 0)
+    builder.PrependInt8Slot(8, businessDayConvention, None)
 
 def AddBusinessDayConvention(builder, businessDayConvention):
     FRAAddBusinessDayConvention(builder, businessDayConvention)
@@ -171,15 +171,15 @@ class FRAT(object):
 
     # FRAT
     def __init__(self):
-        self.fraType = 0  # type: int
+        self.fraType = None  # type: Optional[int]
         self.notional = 0.0  # type: float
         self.startDate = None  # type: str
         self.maturityDate = None  # type: str
         self.strike = 0.0  # type: float
         self.index = None  # type: Optional[IndexRefT]
-        self.dayCounter = 0  # type: int
-        self.calendar = 0  # type: int
-        self.businessDayConvention = 0  # type: int
+        self.dayCounter = None  # type: Optional[int]
+        self.calendar = None  # type: Optional[int]
+        self.businessDayConvention = None  # type: Optional[int]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):

--- a/src/mappers/cap_floor_mapper.cpp
+++ b/src/mappers/cap_floor_mapper.cpp
@@ -35,17 +35,26 @@ CapFloorTrade extractTrade(const quantra::PriceCapFloor* pricing) {
     if (!capFloor->index() || !capFloor->index()->id()) {
         QUANTRA_INVALID_ARGUMENT("CapFloor.index.id is required");
     }
+    if (!capFloor->day_counter().has_value()) {
+        QUANTRA_INVALID_ARGUMENT("CapFloor.day_counter is required");
+    }
+    if (!capFloor->business_day_convention().has_value()) {
+        QUANTRA_INVALID_ARGUMENT("CapFloor.business_day_convention is required");
+    }
+    if (!capFloor->cap_floor_type().has_value()) {
+        QUANTRA_INVALID_ARGUMENT("CapFloor.cap_floor_type is required");
+    }
 
     ScheduleParser scheduleParser;
     auto schedule = scheduleParser.parse(capFloor->schedule());
 
     CapFloorTrade trade;
-    trade.capFloorType = CapFloorTypeToQL(capFloor->cap_floor_type());
+    trade.capFloorType = CapFloorTypeToQL(capFloor->cap_floor_type().value());
     trade.schedule = *schedule;
     trade.notional = capFloor->notional();
     trade.strike = capFloor->strike();
-    trade.dayCounter = DayCounterToQL(capFloor->day_counter());
-    trade.businessDayConvention = ConventionToQL(capFloor->business_day_convention());
+    trade.dayCounter = DayCounterToQL(capFloor->day_counter().value());
+    trade.businessDayConvention = ConventionToQL(capFloor->business_day_convention().value());
     trade.includeDetails = pricing->include_details();
 
     trade.discountingCurveId = pricing->discounting_curve()->str();

--- a/src/mappers/cds_mapper.cpp
+++ b/src/mappers/cds_mapper.cpp
@@ -34,8 +34,11 @@ CdsTrade extractTrade(const quantra::PriceCDS* pricing) {
     ScheduleParser scheduleParser;
     auto schedule = scheduleParser.parse(cds->schedule());
 
+    if (!cds->side().has_value()) {
+        QUANTRA_INVALID_ARGUMENT("CDS.side is required");
+    }
     CdsTrade trade;
-    trade.side = ProtectionSideToQL(cds->side());
+    trade.side = ProtectionSideToQL(cds->side().value());
     trade.notional = cds->notional();
     if (!cds->running_coupon().has_value()) {
         QUANTRA_INVALID_ARGUMENT("CDS.running_coupon is required");
@@ -45,8 +48,14 @@ CdsTrade extractTrade(const quantra::PriceCDS* pricing) {
         trade.upfront = cds->upfront().value();
     }
     trade.schedule = *schedule;
-    trade.dayCounter = DayCounterToQL(cds->day_counter());
-    trade.businessDayConvention = ConventionToQL(cds->business_day_convention());
+    if (!cds->day_counter().has_value()) {
+        QUANTRA_INVALID_ARGUMENT("CDS.day_counter is required");
+    }
+    if (!cds->business_day_convention().has_value()) {
+        QUANTRA_INVALID_ARGUMENT("CDS.business_day_convention is required");
+    }
+    trade.dayCounter = DayCounterToQL(cds->day_counter().value());
+    trade.businessDayConvention = ConventionToQL(cds->business_day_convention().value());
     trade.settlesAccrual = cds->settles_accrual();
     trade.paysAtDefaultTime = cds->pays_at_default_time();
     trade.rebatesAccrual = cds->rebates_accrual();

--- a/src/mappers/fra_mapper.cpp
+++ b/src/mappers/fra_mapper.cpp
@@ -32,11 +32,23 @@ FraTrade extractTrade(const quantra::PriceFRA* pricing) {
     if (!fra->index() || !fra->index()->id()) {
         QUANTRA_INVALID_ARGUMENT("FRA.index.id is required");
     }
+    if (!fra->fra_type().has_value()) {
+        QUANTRA_INVALID_ARGUMENT("FRA.fra_type is required");
+    }
+    if (!fra->day_counter().has_value()) {
+        QUANTRA_INVALID_ARGUMENT("FRA.day_counter is required");
+    }
+    if (!fra->calendar().has_value()) {
+        QUANTRA_INVALID_ARGUMENT("FRA.calendar is required");
+    }
+    if (!fra->business_day_convention().has_value()) {
+        QUANTRA_INVALID_ARGUMENT("FRA.business_day_convention is required");
+    }
 
     FraTrade trade;
     trade.startDate = DateToQL(fra->start_date()->str());
     trade.maturityDate = DateToQL(fra->maturity_date()->str());
-    trade.position = FRATypeToQL(fra->fra_type());
+    trade.position = FRATypeToQL(fra->fra_type().value());
     trade.notional = fra->notional();
     trade.strike = fra->strike();
     trade.discountingCurveId = pricing->discounting_curve()->str();

--- a/src/parsers/cap_floor_parser.cpp
+++ b/src/parsers/cap_floor_parser.cpp
@@ -14,6 +14,11 @@ std::shared_ptr<QuantLib::CapFloor> CapFloorParser::parse(
     if (!capFloor->index() || !capFloor->index()->id())
         QUANTRA_INVALID_ARGUMENT("CapFloor index.id is required");
 
+    if (!capFloor->day_counter().has_value())
+        QUANTRA_INVALID_ARGUMENT("CapFloor.day_counter is required");
+    if (!capFloor->business_day_convention().has_value())
+        QUANTRA_INVALID_ARGUMENT("CapFloor.business_day_convention is required");
+
     // Parse schedule
     ScheduleParser scheduleParser;
     auto schedule = scheduleParser.parse(capFloor->schedule());
@@ -25,14 +30,16 @@ std::shared_ptr<QuantLib::CapFloor> CapFloorParser::parse(
     // Create the floating leg (IborLeg)
     Leg leg = IborLeg(*schedule, iborIndex)
         .withNotionals(capFloor->notional())
-        .withPaymentDayCounter(DayCounterToQL(capFloor->day_counter()))
-        .withPaymentAdjustment(ConventionToQL(capFloor->business_day_convention()));
+        .withPaymentDayCounter(DayCounterToQL(capFloor->day_counter().value()))
+        .withPaymentAdjustment(ConventionToQL(capFloor->business_day_convention().value()));
 
     // Parse cap/floor type and create instrument
+    if (!capFloor->cap_floor_type().has_value())
+        QUANTRA_INVALID_ARGUMENT("CapFloor.cap_floor_type is required");
     std::shared_ptr<QuantLib::CapFloor> instrument;
     std::vector<Rate> strikes(1, capFloor->strike());
 
-    switch (capFloor->cap_floor_type()) {
+    switch (capFloor->cap_floor_type().value()) {
         case quantra::enums::CapFloorType_Cap:
             instrument = std::make_shared<QuantLib::Cap>(leg, strikes);
             break;

--- a/src/parsers/fra_parser.cpp
+++ b/src/parsers/fra_parser.cpp
@@ -15,8 +15,10 @@ std::shared_ptr<QuantLib::ForwardRateAgreement> FRAParser::parse(
     Date maturityDate = DateToQL(fra->maturity_date()->str());
 
     // Parse FRA position type
+    if (!fra->fra_type().has_value())
+        QUANTRA_INVALID_ARGUMENT("FRA.fra_type is required");
     QuantLib::Position::Type position;
-    switch (fra->fra_type()) {
+    switch (fra->fra_type().value()) {
         case quantra::enums::FRAType_Long:
             position = QuantLib::Position::Long;
             break;

--- a/tests/contract/error_contract_test.py
+++ b/tests/contract/error_contract_test.py
@@ -175,6 +175,17 @@ def _ec_del_swap_leg_field(arr_key, swap_key, leg_key, field):
     return f
 
 
+def _ec_del_instrument_field(arr_key, product_key, field):
+    """Drop a convention field from the product instrument block. The FRA,
+    cap/floor and CDS convention enums (day_counter, calendar,
+    business_day_convention) are presence-required: an omitted convention is an
+    error, never an alphabetical-0 default."""
+    def f(req):
+        req[arr_key][0][product_key].pop(field, None)
+        return req
+    return f
+
+
 def _ec_del_bond_field(arr_key, bond_key, field):
     """Drop a convention field from the bond block. The bond convention enums
     (accrual_day_counter, payment_convention) are presence-required: an omitted
@@ -375,6 +386,37 @@ SCENARIOS = [
      "swaption_request.json", 400,
      _ec_del_vol_base_field("calendar"),
      _ec_body_contains("IrVolBaseSpec.calendar is required")),
+    # ---- 400 INVALID_ARGUMENT: FRA / cap-floor / CDS convention presence ----
+    # An FRA, cap/floor or CDS convention enum omitted from the request must be
+    # rejected, not silently defaulted to the alphabetical-0 value.
+    ("ec:400 fra missing calendar", "fra",
+     "fra_request.json", 400,
+     _ec_del_instrument_field("fras", "fra", "calendar"),
+     _ec_body_contains("FRA.calendar is required")),
+    ("ec:400 cap_floor missing business_day_convention", "cap_floor",
+     "cap_floor_request.json", 400,
+     _ec_del_instrument_field("cap_floors", "cap_floor", "business_day_convention"),
+     _ec_body_contains("CapFloor.business_day_convention is required")),
+    ("ec:400 cds missing day_counter", "cds",
+     "cds_request.json", 400,
+     _ec_del_instrument_field("cds_list", "cds", "day_counter"),
+     _ec_body_contains("CDS.day_counter is required")),
+    # ---- 400 INVALID_ARGUMENT: FRA / cap-floor / CDS discriminator presence ----
+    # The product-discriminator enums are presence-required: an omitted
+    # discriminator must be rejected, not silently defaulted to the
+    # alphabetical-0 value (Long FRA, Cap, or CDS protection Buyer).
+    ("ec:400 fra missing fra_type", "fra",
+     "fra_request.json", 400,
+     _ec_del_instrument_field("fras", "fra", "fra_type"),
+     _ec_body_contains("FRA.fra_type is required")),
+    ("ec:400 cap_floor missing cap_floor_type", "cap_floor",
+     "cap_floor_request.json", 400,
+     _ec_del_instrument_field("cap_floors", "cap_floor", "cap_floor_type"),
+     _ec_body_contains("CapFloor.cap_floor_type is required")),
+    ("ec:400 cds missing side", "cds",
+     "cds_request.json", 400,
+     _ec_del_instrument_field("cds_list", "cds", "side"),
+     _ec_body_contains("CDS.side is required")),
     # ---- 400 INVALID_ARGUMENT: fail-closed enum handling ----
     # The CDS credit-curve bootstrap supports LogLinear only; ForwardFlat
     # and LogCubic used to be silently priced as LogLinear. The complex request


### PR DESCRIPTION
**Schema v3, step 3f (wire-breaking): FRA / cap-floor / CDS conventions + product type.** Ten enum fields become optional-with-presence — an omitted value errors (400, naming the field) instead of silently decoding to the alphabetical-0 enum:

- Conventions: FRA `day_counter`/`calendar`/`business_day_convention`; CapFloor + CDS `day_counter`/`business_day_convention`.
- Product discriminators: FRA `fra_type`, CapFloor `cap_floor_type`, CDS `side`. This closes a real mis-pricing gap — an omitted CDS `side` previously priced silently as protection **Buyer** (a sign flip); omitted FRA type as Long; omitted cap/floor type as Cap.

No example/catalog JSON needed editing. +6 error-contract scenarios. Regenerated FlatBuffers included. Full suite green (503 cases). Step 3f of the convention-presence sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
