### PR TITLE
Require explicit coupon-pricer conventions (schema v3, step 3g: coupon pricer)

### DIFF
--- a/flatbuffers/cpp/coupon_pricer_generated.h
+++ b/flatbuffers/cpp/coupon_pricer_generated.h
@@ -32,10 +32,10 @@ struct CouponPricerT;
 struct ConstantOptionletVolatilityT : public ::flatbuffers::NativeTable {
   typedef ConstantOptionletVolatility TableType;
   int32_t settlement_days = 0;
-  quantra::enums::Calendar calendar = quantra::enums::Calendar_Argentina;
-  quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_Following;
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt;
   double volatility = 0.0;
-  quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360;
+  ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt;
 };
 
 /// Constant optionlet volatility for coupon pricer.
@@ -52,17 +52,17 @@ struct ConstantOptionletVolatility FLATBUFFERS_FINAL_CLASS : private ::flatbuffe
   int32_t settlement_days() const {
     return GetField<int32_t>(VT_SETTLEMENT_DAYS, 0);
   }
-  quantra::enums::Calendar calendar() const {
-    return static_cast<quantra::enums::Calendar>(GetField<int8_t>(VT_CALENDAR, 0));
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar() const {
+    return GetOptional<int8_t, quantra::enums::Calendar>(VT_CALENDAR);
   }
-  quantra::enums::BusinessDayConvention business_day_convention() const {
-    return static_cast<quantra::enums::BusinessDayConvention>(GetField<int8_t>(VT_BUSINESS_DAY_CONVENTION, 0));
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention() const {
+    return GetOptional<int8_t, quantra::enums::BusinessDayConvention>(VT_BUSINESS_DAY_CONVENTION);
   }
   double volatility() const {
     return GetField<double>(VT_VOLATILITY, 0.0);
   }
-  quantra::enums::DayCounter day_counter() const {
-    return static_cast<quantra::enums::DayCounter>(GetField<int8_t>(VT_DAY_COUNTER, 0));
+  ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter() const {
+    return GetOptional<int8_t, quantra::enums::DayCounter>(VT_DAY_COUNTER);
   }
   bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -86,16 +86,16 @@ struct ConstantOptionletVolatilityBuilder {
     fbb_.AddElement<int32_t>(ConstantOptionletVolatility::VT_SETTLEMENT_DAYS, settlement_days, 0);
   }
   void add_calendar(quantra::enums::Calendar calendar) {
-    fbb_.AddElement<int8_t>(ConstantOptionletVolatility::VT_CALENDAR, static_cast<int8_t>(calendar), 0);
+    fbb_.AddElement<int8_t>(ConstantOptionletVolatility::VT_CALENDAR, static_cast<int8_t>(calendar));
   }
   void add_business_day_convention(quantra::enums::BusinessDayConvention business_day_convention) {
-    fbb_.AddElement<int8_t>(ConstantOptionletVolatility::VT_BUSINESS_DAY_CONVENTION, static_cast<int8_t>(business_day_convention), 0);
+    fbb_.AddElement<int8_t>(ConstantOptionletVolatility::VT_BUSINESS_DAY_CONVENTION, static_cast<int8_t>(business_day_convention));
   }
   void add_volatility(double volatility) {
     fbb_.AddElement<double>(ConstantOptionletVolatility::VT_VOLATILITY, volatility, 0.0);
   }
   void add_day_counter(quantra::enums::DayCounter day_counter) {
-    fbb_.AddElement<int8_t>(ConstantOptionletVolatility::VT_DAY_COUNTER, static_cast<int8_t>(day_counter), 0);
+    fbb_.AddElement<int8_t>(ConstantOptionletVolatility::VT_DAY_COUNTER, static_cast<int8_t>(day_counter));
   }
   explicit ConstantOptionletVolatilityBuilder(::flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
@@ -111,16 +111,16 @@ struct ConstantOptionletVolatilityBuilder {
 inline ::flatbuffers::Offset<ConstantOptionletVolatility> CreateConstantOptionletVolatility(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     int32_t settlement_days = 0,
-    quantra::enums::Calendar calendar = quantra::enums::Calendar_Argentina,
-    quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_Following,
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt,
     double volatility = 0.0,
-    quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360) {
+    ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt) {
   ConstantOptionletVolatilityBuilder builder_(_fbb);
   builder_.add_volatility(volatility);
   builder_.add_settlement_days(settlement_days);
-  builder_.add_day_counter(day_counter);
-  builder_.add_business_day_convention(business_day_convention);
-  builder_.add_calendar(calendar);
+  if(day_counter) { builder_.add_day_counter(*day_counter); }
+  if(business_day_convention) { builder_.add_business_day_convention(*business_day_convention); }
+  if(calendar) { builder_.add_calendar(*calendar); }
   return builder_.Finish();
 }
 

--- a/flatbuffers/fbs/coupon_pricer.fbs
+++ b/flatbuffers/fbs/coupon_pricer.fbs
@@ -5,10 +5,10 @@ namespace quantra;
 /// Constant optionlet volatility for coupon pricer.
 table ConstantOptionletVolatility {
     settlement_days:int;
-    calendar:enums.Calendar;
-    business_day_convention:enums.BusinessDayConvention;
+    calendar:enums.Calendar = null;
+    business_day_convention:enums.BusinessDayConvention = null;
     volatility:double;
-    day_counter:enums.DayCounter;
+    day_counter:enums.DayCounter = null;
 }
 
 /// Black Ibor coupon pricer with optionlet volatility.

--- a/flatbuffers/python/quantra/ConstantOptionletVolatility.py
+++ b/flatbuffers/python/quantra/ConstantOptionletVolatility.py
@@ -37,14 +37,14 @@ class ConstantOptionletVolatility(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # ConstantOptionletVolatility
     def BusinessDayConvention(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(8))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # ConstantOptionletVolatility
     def Volatility(self):
@@ -58,7 +58,7 @@ class ConstantOptionletVolatility(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(12))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
 def ConstantOptionletVolatilityStart(builder):
     builder.StartObject(5)
@@ -73,13 +73,13 @@ def AddSettlementDays(builder, settlementDays):
     ConstantOptionletVolatilityAddSettlementDays(builder, settlementDays)
 
 def ConstantOptionletVolatilityAddCalendar(builder, calendar):
-    builder.PrependInt8Slot(1, calendar, 0)
+    builder.PrependInt8Slot(1, calendar, None)
 
 def AddCalendar(builder, calendar):
     ConstantOptionletVolatilityAddCalendar(builder, calendar)
 
 def ConstantOptionletVolatilityAddBusinessDayConvention(builder, businessDayConvention):
-    builder.PrependInt8Slot(2, businessDayConvention, 0)
+    builder.PrependInt8Slot(2, businessDayConvention, None)
 
 def AddBusinessDayConvention(builder, businessDayConvention):
     ConstantOptionletVolatilityAddBusinessDayConvention(builder, businessDayConvention)
@@ -91,7 +91,7 @@ def AddVolatility(builder, volatility):
     ConstantOptionletVolatilityAddVolatility(builder, volatility)
 
 def ConstantOptionletVolatilityAddDayCounter(builder, dayCounter):
-    builder.PrependInt8Slot(4, dayCounter, 0)
+    builder.PrependInt8Slot(4, dayCounter, None)
 
 def AddDayCounter(builder, dayCounter):
     ConstantOptionletVolatilityAddDayCounter(builder, dayCounter)
@@ -108,10 +108,10 @@ class ConstantOptionletVolatilityT(object):
     # ConstantOptionletVolatilityT
     def __init__(self):
         self.settlementDays = 0  # type: int
-        self.calendar = 0  # type: int
-        self.businessDayConvention = 0  # type: int
+        self.calendar = None  # type: Optional[int]
+        self.businessDayConvention = None  # type: Optional[int]
         self.volatility = 0.0  # type: float
-        self.dayCounter = 0  # type: int
+        self.dayCounter = None  # type: Optional[int]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):

--- a/src/market/pricing_registry.cpp
+++ b/src/market/pricing_registry.cpp
@@ -373,14 +373,24 @@ PricingRegistry PricingRegistryBuilder::build(const quantra::Pricing* pricing) c
                               "' is missing optionlet_volatility block");
             }
 
+            if (!ov->calendar().has_value()) {
+                QUANTRA_INVALID_ARGUMENT("ConstantOptionletVolatility.calendar is required");
+            }
+            if (!ov->business_day_convention().has_value()) {
+                QUANTRA_INVALID_ARGUMENT("ConstantOptionletVolatility.business_day_convention is required");
+            }
+            if (!ov->day_counter().has_value()) {
+                QUANTRA_INVALID_ARGUMENT("ConstantOptionletVolatility.day_counter is required");
+            }
+
             CouponPricerDomain domain;
             domain.id = id;
             BlackIborCouponPricerDomain d;
             d.settlement_days = ov->settlement_days();
-            d.calendar = CalendarToQL(ov->calendar());
-            d.business_day_convention = ConventionToQL(ov->business_day_convention());
+            d.calendar = CalendarToQL(ov->calendar().value());
+            d.business_day_convention = ConventionToQL(ov->business_day_convention().value());
             d.volatility = ov->volatility();
-            d.day_counter = DayCounterToQL(ov->day_counter());
+            d.day_counter = DayCounterToQL(ov->day_counter().value());
             domain.payload = std::move(d);
             reg.rates.couponPricerDomains.emplace(id, std::move(domain));
         }

--- a/tests/contract/error_contract_test.py
+++ b/tests/contract/error_contract_test.py
@@ -221,6 +221,19 @@ def _ec_del_vol_base_field(field):
     return f
 
 
+def _ec_del_optionlet_vol_field(field):
+    """Drop a convention field from the first coupon pricer's constant optionlet
+    volatility block. The ConstantOptionletVolatility convention enums (calendar,
+    business_day_convention, day_counter) are presence-required: an omitted
+    convention is an error, never an alphabetical-0 default."""
+    def f(req):
+        pricers = req["pricing"]["rates"]["coupon_pricers"]
+        ov = pricers[0]["black_ibor_coupon_pricer"]["optionlet_volatility"]
+        ov.pop(field, None)
+        return req
+    return f
+
+
 def _ec_set_credit_curve_field(field, value):
     def f(req):
         req["pricing"]["credit"]["credit_curves"][0][field] = value
@@ -417,6 +430,21 @@ SCENARIOS = [
      "cds_request.json", 400,
      _ec_del_instrument_field("cds_list", "cds", "side"),
      _ec_body_contains("CDS.side is required")),
+    # ---- 400 INVALID_ARGUMENT: coupon-pricer optionlet-vol convention presence ----
+    # A ConstantOptionletVolatility convention enum omitted from a coupon pricer
+    # must be rejected, not silently defaulted to the alphabetical-0 value.
+    ("ec:400 coupon pricer optionlet vol missing calendar", "floating_rate_bond",
+     "floating_rate_bond_request.json", 400,
+     _ec_del_optionlet_vol_field("calendar"),
+     _ec_body_contains("ConstantOptionletVolatility.calendar is required")),
+    ("ec:400 coupon pricer optionlet vol missing business_day_convention",
+     "floating_rate_bond", "floating_rate_bond_request.json", 400,
+     _ec_del_optionlet_vol_field("business_day_convention"),
+     _ec_body_contains("ConstantOptionletVolatility.business_day_convention is required")),
+    ("ec:400 coupon pricer optionlet vol missing day_counter", "floating_rate_bond",
+     "floating_rate_bond_request.json", 400,
+     _ec_del_optionlet_vol_field("day_counter"),
+     _ec_body_contains("ConstantOptionletVolatility.day_counter is required")),
     # ---- 400 INVALID_ARGUMENT: fail-closed enum handling ----
     # The CDS credit-curve bootstrap supports LogLinear only; ForwardFlat
     # and LogCubic used to be silently priced as LogLinear. The complex request


### PR DESCRIPTION
**Schema v3, step 3g (wire-breaking): coupon pricer.** `ConstantOptionletVolatility` `calendar`, `business_day_convention` and `day_counter` become optional-with-presence — an omitted convention errors (400, naming the field) instead of silently taking the alphabetical-0 value. The single reader in the pricing registry requires presence.

This is the final convention-presence step: every schedule, curve-helper, volatility, swap-leg, bond, FRA, cap/floor and CDS convention is now explicit on the wire.

No example/catalog JSON needed editing. +3 error-contract scenarios. Regenerated FlatBuffers included. Full suite green (506 cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
