### PR TITLE
Enforce required identity and structural fields (schema v3, step 4)

### DIFF
--- a/flatbuffers/cpp/basis_swap_response_generated.h
+++ b/flatbuffers/cpp/basis_swap_response_generated.h
@@ -223,7 +223,7 @@ struct PriceBasisSwapResponse FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::T
   }
   bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyOffset(verifier, VT_SWAPS) &&
+           VerifyOffsetRequired(verifier, VT_SWAPS) &&
            verifier.VerifyVector(swaps()) &&
            verifier.VerifyVectorOfTables(swaps()) &&
            verifier.EndTable();
@@ -247,6 +247,7 @@ struct PriceBasisSwapResponseBuilder {
   ::flatbuffers::Offset<PriceBasisSwapResponse> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = ::flatbuffers::Offset<PriceBasisSwapResponse>(end);
+    fbb_.Required(o, PriceBasisSwapResponse::VT_SWAPS);
     return o;
   }
 };
@@ -377,7 +378,7 @@ inline ::flatbuffers::Offset<PriceBasisSwapResponse> CreatePriceBasisSwapRespons
   (void)_rehasher;
   (void)_o;
   struct _VectorArgs { ::flatbuffers::FlatBufferBuilder *__fbb; const PriceBasisSwapResponseT* __o; const ::flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
-  auto _swaps = _o->swaps.size() ? _fbb.CreateVector<::flatbuffers::Offset<quantra::BasisSwapResponse>> (_o->swaps.size(), [](size_t i, _VectorArgs *__va) { return CreateBasisSwapResponse(*__va->__fbb, __va->__o->swaps[i].get(), __va->__rehasher); }, &_va ) : 0;
+  auto _swaps = _fbb.CreateVector<::flatbuffers::Offset<quantra::BasisSwapResponse>> (_o->swaps.size(), [](size_t i, _VectorArgs *__va) { return CreateBasisSwapResponse(*__va->__fbb, __va->__o->swaps[i].get(), __va->__rehasher); }, &_va );
   return quantra::CreatePriceBasisSwapResponse(
       _fbb,
       _swaps);

--- a/flatbuffers/cpp/cap_floor_response_generated.h
+++ b/flatbuffers/cpp/cap_floor_response_generated.h
@@ -318,7 +318,7 @@ struct PriceCapFloorResponse FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Ta
   }
   bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyOffset(verifier, VT_CAP_FLOORS) &&
+           VerifyOffsetRequired(verifier, VT_CAP_FLOORS) &&
            verifier.VerifyVector(cap_floors()) &&
            verifier.VerifyVectorOfTables(cap_floors()) &&
            verifier.EndTable();
@@ -342,6 +342,7 @@ struct PriceCapFloorResponseBuilder {
   ::flatbuffers::Offset<PriceCapFloorResponse> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = ::flatbuffers::Offset<PriceCapFloorResponse>(end);
+    fbb_.Required(o, PriceCapFloorResponse::VT_CAP_FLOORS);
     return o;
   }
 };
@@ -493,7 +494,7 @@ inline ::flatbuffers::Offset<PriceCapFloorResponse> CreatePriceCapFloorResponse(
   (void)_rehasher;
   (void)_o;
   struct _VectorArgs { ::flatbuffers::FlatBufferBuilder *__fbb; const PriceCapFloorResponseT* __o; const ::flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
-  auto _cap_floors = _o->cap_floors.size() ? _fbb.CreateVector<::flatbuffers::Offset<quantra::CapFloorResponse>> (_o->cap_floors.size(), [](size_t i, _VectorArgs *__va) { return CreateCapFloorResponse(*__va->__fbb, __va->__o->cap_floors[i].get(), __va->__rehasher); }, &_va ) : 0;
+  auto _cap_floors = _fbb.CreateVector<::flatbuffers::Offset<quantra::CapFloorResponse>> (_o->cap_floors.size(), [](size_t i, _VectorArgs *__va) { return CreateCapFloorResponse(*__va->__fbb, __va->__o->cap_floors[i].get(), __va->__rehasher); }, &_va );
   return quantra::CreatePriceCapFloorResponse(
       _fbb,
       _cap_floors);

--- a/flatbuffers/cpp/cds_response_generated.h
+++ b/flatbuffers/cpp/cds_response_generated.h
@@ -164,7 +164,7 @@ struct PriceCDSResponse FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   }
   bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyOffset(verifier, VT_CDS_LIST) &&
+           VerifyOffsetRequired(verifier, VT_CDS_LIST) &&
            verifier.VerifyVector(cds_list()) &&
            verifier.VerifyVectorOfTables(cds_list()) &&
            verifier.EndTable();
@@ -188,6 +188,7 @@ struct PriceCDSResponseBuilder {
   ::flatbuffers::Offset<PriceCDSResponse> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = ::flatbuffers::Offset<PriceCDSResponse>(end);
+    fbb_.Required(o, PriceCDSResponse::VT_CDS_LIST);
     return o;
   }
 };
@@ -301,7 +302,7 @@ inline ::flatbuffers::Offset<PriceCDSResponse> CreatePriceCDSResponse(::flatbuff
   (void)_rehasher;
   (void)_o;
   struct _VectorArgs { ::flatbuffers::FlatBufferBuilder *__fbb; const PriceCDSResponseT* __o; const ::flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
-  auto _cds_list = _o->cds_list.size() ? _fbb.CreateVector<::flatbuffers::Offset<quantra::CDSValues>> (_o->cds_list.size(), [](size_t i, _VectorArgs *__va) { return CreateCDSValues(*__va->__fbb, __va->__o->cds_list[i].get(), __va->__rehasher); }, &_va ) : 0;
+  auto _cds_list = _fbb.CreateVector<::flatbuffers::Offset<quantra::CDSValues>> (_o->cds_list.size(), [](size_t i, _VectorArgs *__va) { return CreateCDSValues(*__va->__fbb, __va->__o->cds_list[i].get(), __va->__rehasher); }, &_va );
   return quantra::CreatePriceCDSResponse(
       _fbb,
       _cds_list);

--- a/flatbuffers/cpp/equity_option_response_generated.h
+++ b/flatbuffers/cpp/equity_option_response_generated.h
@@ -239,7 +239,7 @@ struct PriceEquityOptionResponse FLATBUFFERS_FINAL_CLASS : private ::flatbuffers
   }
   bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyOffset(verifier, VT_OPTIONS) &&
+           VerifyOffsetRequired(verifier, VT_OPTIONS) &&
            verifier.VerifyVector(options()) &&
            verifier.VerifyVectorOfTables(options()) &&
            verifier.EndTable();
@@ -263,6 +263,7 @@ struct PriceEquityOptionResponseBuilder {
   ::flatbuffers::Offset<PriceEquityOptionResponse> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = ::flatbuffers::Offset<PriceEquityOptionResponse>(end);
+    fbb_.Required(o, PriceEquityOptionResponse::VT_OPTIONS);
     return o;
   }
 };
@@ -372,7 +373,7 @@ inline ::flatbuffers::Offset<PriceEquityOptionResponse> CreatePriceEquityOptionR
   (void)_rehasher;
   (void)_o;
   struct _VectorArgs { ::flatbuffers::FlatBufferBuilder *__fbb; const PriceEquityOptionResponseT* __o; const ::flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
-  auto _options = _o->options.size() ? _fbb.CreateVector<::flatbuffers::Offset<quantra::EquityOptionResponse>> (_o->options.size(), [](size_t i, _VectorArgs *__va) { return CreateEquityOptionResponse(*__va->__fbb, __va->__o->options[i].get(), __va->__rehasher); }, &_va ) : 0;
+  auto _options = _fbb.CreateVector<::flatbuffers::Offset<quantra::EquityOptionResponse>> (_o->options.size(), [](size_t i, _VectorArgs *__va) { return CreateEquityOptionResponse(*__va->__fbb, __va->__o->options[i].get(), __va->__rehasher); }, &_va );
   return quantra::CreatePriceEquityOptionResponse(
       _fbb,
       _options);

--- a/flatbuffers/cpp/fixed_rate_bond_response_generated.h
+++ b/flatbuffers/cpp/fixed_rate_bond_response_generated.h
@@ -244,7 +244,7 @@ struct PriceFixedRateBondResponse FLATBUFFERS_FINAL_CLASS : private ::flatbuffer
   }
   bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyOffset(verifier, VT_BONDS) &&
+           VerifyOffsetRequired(verifier, VT_BONDS) &&
            verifier.VerifyVector(bonds()) &&
            verifier.VerifyVectorOfTables(bonds()) &&
            verifier.EndTable();
@@ -268,6 +268,7 @@ struct PriceFixedRateBondResponseBuilder {
   ::flatbuffers::Offset<PriceFixedRateBondResponse> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = ::flatbuffers::Offset<PriceFixedRateBondResponse>(end);
+    fbb_.Required(o, PriceFixedRateBondResponse::VT_BONDS);
     return o;
   }
 };
@@ -407,7 +408,7 @@ inline ::flatbuffers::Offset<PriceFixedRateBondResponse> CreatePriceFixedRateBon
   (void)_rehasher;
   (void)_o;
   struct _VectorArgs { ::flatbuffers::FlatBufferBuilder *__fbb; const PriceFixedRateBondResponseT* __o; const ::flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
-  auto _bonds = _o->bonds.size() ? _fbb.CreateVector<::flatbuffers::Offset<quantra::FixedRateBondResponse>> (_o->bonds.size(), [](size_t i, _VectorArgs *__va) { return CreateFixedRateBondResponse(*__va->__fbb, __va->__o->bonds[i].get(), __va->__rehasher); }, &_va ) : 0;
+  auto _bonds = _fbb.CreateVector<::flatbuffers::Offset<quantra::FixedRateBondResponse>> (_o->bonds.size(), [](size_t i, _VectorArgs *__va) { return CreateFixedRateBondResponse(*__va->__fbb, __va->__o->bonds[i].get(), __va->__rehasher); }, &_va );
   return quantra::CreatePriceFixedRateBondResponse(
       _fbb,
       _bonds);

--- a/flatbuffers/cpp/floating_rate_bond_response_generated.h
+++ b/flatbuffers/cpp/floating_rate_bond_response_generated.h
@@ -244,7 +244,7 @@ struct PriceFloatingRateBondResponse FLATBUFFERS_FINAL_CLASS : private ::flatbuf
   }
   bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyOffset(verifier, VT_BONDS) &&
+           VerifyOffsetRequired(verifier, VT_BONDS) &&
            verifier.VerifyVector(bonds()) &&
            verifier.VerifyVectorOfTables(bonds()) &&
            verifier.EndTable();
@@ -268,6 +268,7 @@ struct PriceFloatingRateBondResponseBuilder {
   ::flatbuffers::Offset<PriceFloatingRateBondResponse> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = ::flatbuffers::Offset<PriceFloatingRateBondResponse>(end);
+    fbb_.Required(o, PriceFloatingRateBondResponse::VT_BONDS);
     return o;
   }
 };
@@ -407,7 +408,7 @@ inline ::flatbuffers::Offset<PriceFloatingRateBondResponse> CreatePriceFloatingR
   (void)_rehasher;
   (void)_o;
   struct _VectorArgs { ::flatbuffers::FlatBufferBuilder *__fbb; const PriceFloatingRateBondResponseT* __o; const ::flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
-  auto _bonds = _o->bonds.size() ? _fbb.CreateVector<::flatbuffers::Offset<quantra::FloatingRateBondResponse>> (_o->bonds.size(), [](size_t i, _VectorArgs *__va) { return CreateFloatingRateBondResponse(*__va->__fbb, __va->__o->bonds[i].get(), __va->__rehasher); }, &_va ) : 0;
+  auto _bonds = _fbb.CreateVector<::flatbuffers::Offset<quantra::FloatingRateBondResponse>> (_o->bonds.size(), [](size_t i, _VectorArgs *__va) { return CreateFloatingRateBondResponse(*__va->__fbb, __va->__o->bonds[i].get(), __va->__rehasher); }, &_va );
   return quantra::CreatePriceFloatingRateBondResponse(
       _fbb,
       _bonds);

--- a/flatbuffers/cpp/fra_response_generated.h
+++ b/flatbuffers/cpp/fra_response_generated.h
@@ -149,7 +149,7 @@ struct PriceFRAResponse FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   }
   bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyOffset(verifier, VT_FRAS) &&
+           VerifyOffsetRequired(verifier, VT_FRAS) &&
            verifier.VerifyVector(fras()) &&
            verifier.VerifyVectorOfTables(fras()) &&
            verifier.EndTable();
@@ -173,6 +173,7 @@ struct PriceFRAResponseBuilder {
   ::flatbuffers::Offset<PriceFRAResponse> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = ::flatbuffers::Offset<PriceFRAResponse>(end);
+    fbb_.Required(o, PriceFRAResponse::VT_FRAS);
     return o;
   }
 };
@@ -261,7 +262,7 @@ inline ::flatbuffers::Offset<PriceFRAResponse> CreatePriceFRAResponse(::flatbuff
   (void)_rehasher;
   (void)_o;
   struct _VectorArgs { ::flatbuffers::FlatBufferBuilder *__fbb; const PriceFRAResponseT* __o; const ::flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
-  auto _fras = _o->fras.size() ? _fbb.CreateVector<::flatbuffers::Offset<quantra::FRAResponse>> (_o->fras.size(), [](size_t i, _VectorArgs *__va) { return CreateFRAResponse(*__va->__fbb, __va->__o->fras[i].get(), __va->__rehasher); }, &_va ) : 0;
+  auto _fras = _fbb.CreateVector<::flatbuffers::Offset<quantra::FRAResponse>> (_o->fras.size(), [](size_t i, _VectorArgs *__va) { return CreateFRAResponse(*__va->__fbb, __va->__o->fras[i].get(), __va->__rehasher); }, &_va );
   return quantra::CreatePriceFRAResponse(
       _fbb,
       _fras);

--- a/flatbuffers/cpp/ois_swap_response_generated.h
+++ b/flatbuffers/cpp/ois_swap_response_generated.h
@@ -221,7 +221,7 @@ struct PriceOisSwapResponse FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Tab
   }
   bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyOffset(verifier, VT_SWAPS) &&
+           VerifyOffsetRequired(verifier, VT_SWAPS) &&
            verifier.VerifyVector(swaps()) &&
            verifier.VerifyVectorOfTables(swaps()) &&
            verifier.EndTable();
@@ -245,6 +245,7 @@ struct PriceOisSwapResponseBuilder {
   ::flatbuffers::Offset<PriceOisSwapResponse> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = ::flatbuffers::Offset<PriceOisSwapResponse>(end);
+    fbb_.Required(o, PriceOisSwapResponse::VT_SWAPS);
     return o;
   }
 };
@@ -375,7 +376,7 @@ inline ::flatbuffers::Offset<PriceOisSwapResponse> CreatePriceOisSwapResponse(::
   (void)_rehasher;
   (void)_o;
   struct _VectorArgs { ::flatbuffers::FlatBufferBuilder *__fbb; const PriceOisSwapResponseT* __o; const ::flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
-  auto _swaps = _o->swaps.size() ? _fbb.CreateVector<::flatbuffers::Offset<quantra::OisSwapResponse>> (_o->swaps.size(), [](size_t i, _VectorArgs *__va) { return CreateOisSwapResponse(*__va->__fbb, __va->__o->swaps[i].get(), __va->__rehasher); }, &_va ) : 0;
+  auto _swaps = _fbb.CreateVector<::flatbuffers::Offset<quantra::OisSwapResponse>> (_o->swaps.size(), [](size_t i, _VectorArgs *__va) { return CreateOisSwapResponse(*__va->__fbb, __va->__o->swaps[i].get(), __va->__rehasher); }, &_va );
   return quantra::CreatePriceOisSwapResponse(
       _fbb,
       _swaps);

--- a/flatbuffers/cpp/swaption_response_generated.h
+++ b/flatbuffers/cpp/swaption_response_generated.h
@@ -471,7 +471,7 @@ struct PriceSwaptionResponse FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Ta
   }
   bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyOffset(verifier, VT_SWAPTIONS) &&
+           VerifyOffsetRequired(verifier, VT_SWAPTIONS) &&
            verifier.VerifyVector(swaptions()) &&
            verifier.VerifyVectorOfTables(swaptions()) &&
            VerifyOffset(verifier, VT_DIAGNOSTICS) &&
@@ -501,6 +501,7 @@ struct PriceSwaptionResponseBuilder {
   ::flatbuffers::Offset<PriceSwaptionResponse> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = ::flatbuffers::Offset<PriceSwaptionResponse>(end);
+    fbb_.Required(o, PriceSwaptionResponse::VT_SWAPTIONS);
     return o;
   }
 };
@@ -664,7 +665,7 @@ inline ::flatbuffers::Offset<PriceSwaptionResponse> CreatePriceSwaptionResponse(
   (void)_rehasher;
   (void)_o;
   struct _VectorArgs { ::flatbuffers::FlatBufferBuilder *__fbb; const PriceSwaptionResponseT* __o; const ::flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
-  auto _swaptions = _o->swaptions.size() ? _fbb.CreateVector<::flatbuffers::Offset<quantra::SwaptionResponse>> (_o->swaptions.size(), [](size_t i, _VectorArgs *__va) { return CreateSwaptionResponse(*__va->__fbb, __va->__o->swaptions[i].get(), __va->__rehasher); }, &_va ) : 0;
+  auto _swaptions = _fbb.CreateVector<::flatbuffers::Offset<quantra::SwaptionResponse>> (_o->swaptions.size(), [](size_t i, _VectorArgs *__va) { return CreateSwaptionResponse(*__va->__fbb, __va->__o->swaptions[i].get(), __va->__rehasher); }, &_va );
   auto _diagnostics = _o->diagnostics.size() ? _fbb.CreateVector<::flatbuffers::Offset<quantra::SwaptionVolDiagnostics>> (_o->diagnostics.size(), [](size_t i, _VectorArgs *__va) { return CreateSwaptionVolDiagnostics(*__va->__fbb, __va->__o->diagnostics[i].get(), __va->__rehasher); }, &_va ) : 0;
   return quantra::CreatePriceSwaptionResponse(
       _fbb,

--- a/flatbuffers/cpp/vanilla_swap_response_generated.h
+++ b/flatbuffers/cpp/vanilla_swap_response_generated.h
@@ -668,7 +668,7 @@ struct PriceVanillaSwapResponse FLATBUFFERS_FINAL_CLASS : private ::flatbuffers:
   }
   bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyOffset(verifier, VT_SWAPS) &&
+           VerifyOffsetRequired(verifier, VT_SWAPS) &&
            verifier.VerifyVector(swaps()) &&
            verifier.VerifyVectorOfTables(swaps()) &&
            verifier.EndTable();
@@ -692,6 +692,7 @@ struct PriceVanillaSwapResponseBuilder {
   ::flatbuffers::Offset<PriceVanillaSwapResponse> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = ::flatbuffers::Offset<PriceVanillaSwapResponse>(end);
+    fbb_.Required(o, PriceVanillaSwapResponse::VT_SWAPS);
     return o;
   }
 };
@@ -968,7 +969,7 @@ inline ::flatbuffers::Offset<PriceVanillaSwapResponse> CreatePriceVanillaSwapRes
   (void)_rehasher;
   (void)_o;
   struct _VectorArgs { ::flatbuffers::FlatBufferBuilder *__fbb; const PriceVanillaSwapResponseT* __o; const ::flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
-  auto _swaps = _o->swaps.size() ? _fbb.CreateVector<::flatbuffers::Offset<quantra::VanillaSwapResponse>> (_o->swaps.size(), [](size_t i, _VectorArgs *__va) { return CreateVanillaSwapResponse(*__va->__fbb, __va->__o->swaps[i].get(), __va->__rehasher); }, &_va ) : 0;
+  auto _swaps = _fbb.CreateVector<::flatbuffers::Offset<quantra::VanillaSwapResponse>> (_o->swaps.size(), [](size_t i, _VectorArgs *__va) { return CreateVanillaSwapResponse(*__va->__fbb, __va->__o->swaps[i].get(), __va->__rehasher); }, &_va );
   return quantra::CreatePriceVanillaSwapResponse(
       _fbb,
       _swaps);

--- a/flatbuffers/cpp/year_on_year_inflation_swap_response_generated.h
+++ b/flatbuffers/cpp/year_on_year_inflation_swap_response_generated.h
@@ -221,7 +221,7 @@ struct PriceYearOnYearInflationSwapResponse FLATBUFFERS_FINAL_CLASS : private ::
   }
   bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyOffset(verifier, VT_SWAPS) &&
+           VerifyOffsetRequired(verifier, VT_SWAPS) &&
            verifier.VerifyVector(swaps()) &&
            verifier.VerifyVectorOfTables(swaps()) &&
            verifier.EndTable();
@@ -245,6 +245,7 @@ struct PriceYearOnYearInflationSwapResponseBuilder {
   ::flatbuffers::Offset<PriceYearOnYearInflationSwapResponse> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = ::flatbuffers::Offset<PriceYearOnYearInflationSwapResponse>(end);
+    fbb_.Required(o, PriceYearOnYearInflationSwapResponse::VT_SWAPS);
     return o;
   }
 };
@@ -375,7 +376,7 @@ inline ::flatbuffers::Offset<PriceYearOnYearInflationSwapResponse> CreatePriceYe
   (void)_rehasher;
   (void)_o;
   struct _VectorArgs { ::flatbuffers::FlatBufferBuilder *__fbb; const PriceYearOnYearInflationSwapResponseT* __o; const ::flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
-  auto _swaps = _o->swaps.size() ? _fbb.CreateVector<::flatbuffers::Offset<quantra::YearOnYearInflationSwapResponse>> (_o->swaps.size(), [](size_t i, _VectorArgs *__va) { return CreateYearOnYearInflationSwapResponse(*__va->__fbb, __va->__o->swaps[i].get(), __va->__rehasher); }, &_va ) : 0;
+  auto _swaps = _fbb.CreateVector<::flatbuffers::Offset<quantra::YearOnYearInflationSwapResponse>> (_o->swaps.size(), [](size_t i, _VectorArgs *__va) { return CreateYearOnYearInflationSwapResponse(*__va->__fbb, __va->__o->swaps[i].get(), __va->__rehasher); }, &_va );
   return quantra::CreatePriceYearOnYearInflationSwapResponse(
       _fbb,
       _swaps);

--- a/flatbuffers/cpp/zero_coupon_inflation_swap_response_generated.h
+++ b/flatbuffers/cpp/zero_coupon_inflation_swap_response_generated.h
@@ -195,7 +195,7 @@ struct PriceZeroCouponInflationSwapResponse FLATBUFFERS_FINAL_CLASS : private ::
   }
   bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyOffset(verifier, VT_SWAPS) &&
+           VerifyOffsetRequired(verifier, VT_SWAPS) &&
            verifier.VerifyVector(swaps()) &&
            verifier.VerifyVectorOfTables(swaps()) &&
            verifier.EndTable();
@@ -219,6 +219,7 @@ struct PriceZeroCouponInflationSwapResponseBuilder {
   ::flatbuffers::Offset<PriceZeroCouponInflationSwapResponse> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = ::flatbuffers::Offset<PriceZeroCouponInflationSwapResponse>(end);
+    fbb_.Required(o, PriceZeroCouponInflationSwapResponse::VT_SWAPS);
     return o;
   }
 };
@@ -339,7 +340,7 @@ inline ::flatbuffers::Offset<PriceZeroCouponInflationSwapResponse> CreatePriceZe
   (void)_rehasher;
   (void)_o;
   struct _VectorArgs { ::flatbuffers::FlatBufferBuilder *__fbb; const PriceZeroCouponInflationSwapResponseT* __o; const ::flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
-  auto _swaps = _o->swaps.size() ? _fbb.CreateVector<::flatbuffers::Offset<quantra::ZeroCouponInflationSwapResponse>> (_o->swaps.size(), [](size_t i, _VectorArgs *__va) { return CreateZeroCouponInflationSwapResponse(*__va->__fbb, __va->__o->swaps[i].get(), __va->__rehasher); }, &_va ) : 0;
+  auto _swaps = _fbb.CreateVector<::flatbuffers::Offset<quantra::ZeroCouponInflationSwapResponse>> (_o->swaps.size(), [](size_t i, _VectorArgs *__va) { return CreateZeroCouponInflationSwapResponse(*__va->__fbb, __va->__o->swaps[i].get(), __va->__rehasher); }, &_va );
   return quantra::CreatePriceZeroCouponInflationSwapResponse(
       _fbb,
       _swaps);

--- a/flatbuffers/fbs/basis_swap_response.fbs
+++ b/flatbuffers/fbs/basis_swap_response.fbs
@@ -19,7 +19,7 @@ table BasisSwapResponse {
 
 /// Response wrapper for multiple basis swaps.
 table PriceBasisSwapResponse {
-    swaps:[BasisSwapResponse];
+    swaps:[BasisSwapResponse] (required);
 }
 
 root_type PriceBasisSwapResponse;

--- a/flatbuffers/fbs/cap_floor_response.fbs
+++ b/flatbuffers/fbs/cap_floor_response.fbs
@@ -25,7 +25,7 @@ table CapFloorResponse {
 
 /// Response wrapper for multiple caps/floors.
 table PriceCapFloorResponse {
-    cap_floors:[CapFloorResponse];
+    cap_floors:[CapFloorResponse] (required);
 }
 
 root_type PriceCapFloorResponse;

--- a/flatbuffers/fbs/cds_response.fbs
+++ b/flatbuffers/fbs/cds_response.fbs
@@ -19,7 +19,7 @@ table CDSValues {
 
 /// Batch CDS pricing response.
 table PriceCDSResponse {
-    cds_list:[CDSValues];
+    cds_list:[CDSValues] (required);
 }
 
 root_type PriceCDSResponse;

--- a/flatbuffers/fbs/equity_option_response.fbs
+++ b/flatbuffers/fbs/equity_option_response.fbs
@@ -19,7 +19,7 @@ table EquityOptionResponse {
 
 /// Response wrapper for equity option pricing.
 table PriceEquityOptionResponse {
-    options:[EquityOptionResponse];
+    options:[EquityOptionResponse] (required);
 }
 
 root_type PriceEquityOptionResponse;

--- a/flatbuffers/fbs/fixed_rate_bond_response.fbs
+++ b/flatbuffers/fbs/fixed_rate_bond_response.fbs
@@ -19,7 +19,7 @@ table FixedRateBondResponse {
 
 /// Response wrapper for multiple fixed-rate bonds.
 table PriceFixedRateBondResponse {
-    bonds:[FixedRateBondResponse];
+    bonds:[FixedRateBondResponse] (required);
 }
 
 root_type PriceFixedRateBondResponse;

--- a/flatbuffers/fbs/floating_rate_bond_response.fbs
+++ b/flatbuffers/fbs/floating_rate_bond_response.fbs
@@ -19,7 +19,7 @@ table FloatingRateBondResponse {
 
 /// Response wrapper for multiple floating-rate bonds.
 table PriceFloatingRateBondResponse {
-    bonds:[FloatingRateBondResponse];
+    bonds:[FloatingRateBondResponse] (required);
 }
 
 root_type PriceFloatingRateBondResponse;

--- a/flatbuffers/fbs/fra_response.fbs
+++ b/flatbuffers/fbs/fra_response.fbs
@@ -13,7 +13,7 @@ table FRAResponse {
 
 /// Response wrapper for multiple FRAs.
 table PriceFRAResponse {
-    fras:[FRAResponse];
+    fras:[FRAResponse] (required);
 }
 
 root_type PriceFRAResponse;

--- a/flatbuffers/fbs/ois_swap_response.fbs
+++ b/flatbuffers/fbs/ois_swap_response.fbs
@@ -17,7 +17,7 @@ table OisSwapResponse {
 
 /// Response wrapper for multiple OIS swaps.
 table PriceOisSwapResponse {
-    swaps:[OisSwapResponse];
+    swaps:[OisSwapResponse] (required);
 }
 
 root_type PriceOisSwapResponse;

--- a/flatbuffers/fbs/swaption_response.fbs
+++ b/flatbuffers/fbs/swaption_response.fbs
@@ -61,7 +61,7 @@ table SwaptionResponse {
 
 /// Response wrapper for multiple swaptions.
 table PriceSwaptionResponse {
-    swaptions:[SwaptionResponse];
+    swaptions:[SwaptionResponse] (required);
     /// Per-surface diagnostics, one entry per unique SABR-kind vol surface
     /// referenced by the priced swaptions. Populated only when the request
     /// sets `include_diagnostics=true`. Empty/absent otherwise.

--- a/flatbuffers/fbs/vanilla_swap_response.fbs
+++ b/flatbuffers/fbs/vanilla_swap_response.fbs
@@ -65,7 +65,7 @@ table VanillaSwapResponse {
 
 /// Response wrapper for multiple vanilla swaps.
 table PriceVanillaSwapResponse {
-    swaps:[VanillaSwapResponse];
+    swaps:[VanillaSwapResponse] (required);
 }
 
 root_type PriceVanillaSwapResponse;

--- a/flatbuffers/fbs/year_on_year_inflation_swap_response.fbs
+++ b/flatbuffers/fbs/year_on_year_inflation_swap_response.fbs
@@ -17,7 +17,7 @@ table YearOnYearInflationSwapResponse {
 
 /// Response wrapper for multiple YYIIS trades.
 table PriceYearOnYearInflationSwapResponse {
-    swaps:[YearOnYearInflationSwapResponse];
+    swaps:[YearOnYearInflationSwapResponse] (required);
 }
 
 root_type PriceYearOnYearInflationSwapResponse;

--- a/flatbuffers/fbs/zero_coupon_inflation_swap_response.fbs
+++ b/flatbuffers/fbs/zero_coupon_inflation_swap_response.fbs
@@ -15,7 +15,7 @@ table ZeroCouponInflationSwapResponse {
 
 /// Response wrapper for multiple ZCIIS trades.
 table PriceZeroCouponInflationSwapResponse {
-    swaps:[ZeroCouponInflationSwapResponse];
+    swaps:[ZeroCouponInflationSwapResponse] (required);
 }
 
 root_type PriceZeroCouponInflationSwapResponse;

--- a/flatbuffers/json/basis_swap_response.schema.json
+++ b/flatbuffers/json/basis_swap_response.schema.json
@@ -433,6 +433,7 @@
                 "type" : "array", "items" : {"$ref" : "#/definitions/quantra_VanillaSwapResponse"}
               }
       },
+      "required" : ["swaps"],
       "additionalProperties" : false
     },
     "quantra_BasisSwapResponse" : {
@@ -479,6 +480,7 @@
                 "type" : "array", "items" : {"$ref" : "#/definitions/quantra_BasisSwapResponse"}
               }
       },
+      "required" : ["swaps"],
       "additionalProperties" : false
     }
   },

--- a/flatbuffers/json/cap_floor_response.schema.json
+++ b/flatbuffers/json/cap_floor_response.schema.json
@@ -62,6 +62,7 @@
                 "type" : "array", "items" : {"$ref" : "#/definitions/quantra_CapFloorResponse"}
               }
       },
+      "required" : ["cap_floors"],
       "additionalProperties" : false
     }
   },

--- a/flatbuffers/json/cds_response.schema.json
+++ b/flatbuffers/json/cds_response.schema.json
@@ -327,6 +327,7 @@
                 "type" : "array", "items" : {"$ref" : "#/definitions/quantra_CDSValues"}
               }
       },
+      "required" : ["cds_list"],
       "additionalProperties" : false
     }
   },

--- a/flatbuffers/json/equity_option_response.schema.json
+++ b/flatbuffers/json/equity_option_response.schema.json
@@ -213,6 +213,7 @@
                 "type" : "array", "items" : {"$ref" : "#/definitions/quantra_EquityOptionResponse"}
               }
       },
+      "required" : ["options"],
       "additionalProperties" : false
     }
   },

--- a/flatbuffers/json/fixed_rate_bond_response.schema.json
+++ b/flatbuffers/json/fixed_rate_bond_response.schema.json
@@ -338,6 +338,7 @@
                 "type" : "array", "items" : {"$ref" : "#/definitions/quantra_FixedRateBondResponse"}
               }
       },
+      "required" : ["bonds"],
       "additionalProperties" : false
     }
   },

--- a/flatbuffers/json/floating_rate_bond_response.schema.json
+++ b/flatbuffers/json/floating_rate_bond_response.schema.json
@@ -338,6 +338,7 @@
                 "type" : "array", "items" : {"$ref" : "#/definitions/quantra_FloatingRateBondResponse"}
               }
       },
+      "required" : ["bonds"],
       "additionalProperties" : false
     }
   },

--- a/flatbuffers/json/fra_response.schema.json
+++ b/flatbuffers/json/fra_response.schema.json
@@ -31,6 +31,7 @@
                 "type" : "array", "items" : {"$ref" : "#/definitions/quantra_FRAResponse"}
               }
       },
+      "required" : ["fras"],
       "additionalProperties" : false
     }
   },

--- a/flatbuffers/json/ois_swap_response.schema.json
+++ b/flatbuffers/json/ois_swap_response.schema.json
@@ -433,6 +433,7 @@
                 "type" : "array", "items" : {"$ref" : "#/definitions/quantra_VanillaSwapResponse"}
               }
       },
+      "required" : ["swaps"],
       "additionalProperties" : false
     },
     "quantra_OisSwapResponse" : {
@@ -477,6 +478,7 @@
                 "type" : "array", "items" : {"$ref" : "#/definitions/quantra_OisSwapResponse"}
               }
       },
+      "required" : ["swaps"],
       "additionalProperties" : false
     }
   },

--- a/flatbuffers/json/swaption_response.schema.json
+++ b/flatbuffers/json/swaption_response.schema.json
@@ -510,6 +510,7 @@
                 "description" : "Per-surface diagnostics, one entry per unique SABR-kind vol surface\nreferenced by the priced swaptions. Populated only when the request\nsets `include_diagnostics=true`. Empty/absent otherwise."
               }
       },
+      "required" : ["swaptions"],
       "additionalProperties" : false
     }
   },

--- a/flatbuffers/json/vanilla_swap_response.schema.json
+++ b/flatbuffers/json/vanilla_swap_response.schema.json
@@ -433,6 +433,7 @@
                 "type" : "array", "items" : {"$ref" : "#/definitions/quantra_VanillaSwapResponse"}
               }
       },
+      "required" : ["swaps"],
       "additionalProperties" : false
     }
   },

--- a/flatbuffers/json/year_on_year_inflation_swap_response.schema.json
+++ b/flatbuffers/json/year_on_year_inflation_swap_response.schema.json
@@ -433,6 +433,7 @@
                 "type" : "array", "items" : {"$ref" : "#/definitions/quantra_VanillaSwapResponse"}
               }
       },
+      "required" : ["swaps"],
       "additionalProperties" : false
     },
     "quantra_YearOnYearInflationSwapResponse" : {
@@ -477,6 +478,7 @@
                 "type" : "array", "items" : {"$ref" : "#/definitions/quantra_YearOnYearInflationSwapResponse"}
               }
       },
+      "required" : ["swaps"],
       "additionalProperties" : false
     }
   },

--- a/flatbuffers/json/zero_coupon_inflation_swap_response.schema.json
+++ b/flatbuffers/json/zero_coupon_inflation_swap_response.schema.json
@@ -433,6 +433,7 @@
                 "type" : "array", "items" : {"$ref" : "#/definitions/quantra_VanillaSwapResponse"}
               }
       },
+      "required" : ["swaps"],
       "additionalProperties" : false
     },
     "quantra_ZeroCouponInflationSwapResponse" : {
@@ -471,6 +472,7 @@
                 "type" : "array", "items" : {"$ref" : "#/definitions/quantra_ZeroCouponInflationSwapResponse"}
               }
       },
+      "required" : ["swaps"],
       "additionalProperties" : false
     }
   },

--- a/jsonserver/openapi/openapi3.json
+++ b/jsonserver/openapi/openapi3.json
@@ -2391,6 +2391,9 @@
             }
           }
         },
+        "required": [
+          "swaps"
+        ],
         "additionalProperties": false
       },
       "quantra_BasisSwapResponse": {
@@ -2446,6 +2449,9 @@
             }
           }
         },
+        "required": [
+          "swaps"
+        ],
         "additionalProperties": false
       },
       "quantra_Point": {
@@ -5537,6 +5543,9 @@
             }
           }
         },
+        "required": [
+          "cap_floors"
+        ],
         "additionalProperties": false
       },
       "quantra_CDS": {
@@ -5635,6 +5644,9 @@
             }
           }
         },
+        "required": [
+          "cds_list"
+        ],
         "additionalProperties": false
       },
       "quantra_EquityOptionResponse": {
@@ -5688,6 +5700,9 @@
             }
           }
         },
+        "required": [
+          "options"
+        ],
         "additionalProperties": false
       },
       "quantra_FixedRateBond": {
@@ -5777,6 +5792,9 @@
             }
           }
         },
+        "required": [
+          "bonds"
+        ],
         "additionalProperties": false
       },
       "quantra_FloatingRateBond": {
@@ -5880,6 +5898,9 @@
             }
           }
         },
+        "required": [
+          "bonds"
+        ],
         "additionalProperties": false
       },
       "quantra_FRA": {
@@ -5955,6 +5976,9 @@
             }
           }
         },
+        "required": [
+          "fras"
+        ],
         "additionalProperties": false
       },
       "quantra_OisSwapResponse": {
@@ -6008,6 +6032,9 @@
             }
           }
         },
+        "required": [
+          "swaps"
+        ],
         "additionalProperties": false
       },
       "quantra_PriceBasisSwap": {
@@ -7103,6 +7130,9 @@
             }
           }
         },
+        "required": [
+          "swaptions"
+        ],
         "additionalProperties": false
       },
       "quantra_YearOnYearInflationSwapResponse": {
@@ -7156,6 +7186,9 @@
             }
           }
         },
+        "required": [
+          "swaps"
+        ],
         "additionalProperties": false
       },
       "quantra_ZeroCouponInflationSwapResponse": {
@@ -7203,6 +7236,9 @@
             }
           }
         },
+        "required": [
+          "swaps"
+        ],
         "additionalProperties": false
       }
     }

--- a/jsonserver/openapi/openapi3.yaml
+++ b/jsonserver/openapi/openapi3.yaml
@@ -1662,6 +1662,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/quantra_VanillaSwapResponse'
+      required:
+      - swaps
       additionalProperties: false
     quantra_BasisSwapResponse:
       type: object
@@ -1700,6 +1702,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/quantra_BasisSwapResponse'
+      required:
+      - swaps
       additionalProperties: false
     quantra_Point:
       type: string
@@ -3977,6 +3981,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/quantra_CapFloorResponse'
+      required:
+      - cap_floors
       additionalProperties: false
     quantra_CDS:
       type: object
@@ -4055,6 +4061,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/quantra_CDSValues'
+      required:
+      - cds_list
       additionalProperties: false
     quantra_EquityOptionResponse:
       type: object
@@ -4091,6 +4099,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/quantra_EquityOptionResponse'
+      required:
+      - options
       additionalProperties: false
     quantra_FixedRateBond:
       type: object
@@ -4152,6 +4162,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/quantra_FixedRateBondResponse'
+      required:
+      - bonds
       additionalProperties: false
     quantra_FloatingRateBond:
       type: object
@@ -4223,6 +4235,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/quantra_FloatingRateBondResponse'
+      required:
+      - bonds
       additionalProperties: false
     quantra_FRA:
       type: object
@@ -4276,6 +4290,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/quantra_FRAResponse'
+      required:
+      - fras
       additionalProperties: false
     quantra_OisSwapResponse:
       type: object
@@ -4312,6 +4328,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/quantra_OisSwapResponse'
+      required:
+      - swaps
       additionalProperties: false
     quantra_PriceBasisSwap:
       type: object
@@ -5133,6 +5151,8 @@ components:
             sets `include_diagnostics=true`. Empty/absent otherwise.'
           items:
             $ref: '#/components/schemas/quantra_SwaptionVolDiagnostics'
+      required:
+      - swaptions
       additionalProperties: false
     quantra_YearOnYearInflationSwapResponse:
       type: object
@@ -5169,6 +5189,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/quantra_YearOnYearInflationSwapResponse'
+      required:
+      - swaps
       additionalProperties: false
     quantra_ZeroCouponInflationSwapResponse:
       type: object
@@ -5201,4 +5223,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/quantra_ZeroCouponInflationSwapResponse'
+      required:
+      - swaps
       additionalProperties: false

--- a/src/parsers/term_structure_point_parser.cpp
+++ b/src/parsers/term_structure_point_parser.cpp
@@ -300,6 +300,9 @@ std::shared_ptr<RateHelper> TermStructurePointParser::parse(
 
         auto q = resolveQuote(px, point->quote_id(), quotes, quantra::QuoteType_Curve, bump);
 
+        if (!point->schedule()) {
+            QUANTRA_INVALID_ARGUMENT("BondHelper.schedule is required");
+        }
         if (!point->issue_date()) {
             QUANTRA_INVALID_ARGUMENT("BondHelper.issue_date is required");
         }

--- a/tests/contract/error_contract_test.py
+++ b/tests/contract/error_contract_test.py
@@ -362,6 +362,21 @@ SCENARIOS = [
      "fixed_rate_bond_request.json", 400, _ec_del_curve_point_field("BondHelper", "issue_date")),
     ("ec:400 fixed_rate_bond curve FutureHelper missing future_start_date", "fixed_rate_bond",
      "fixed_rate_bond_request.json", 400, _ec_future_helper_missing_start_date()),
+    # ---- 400 INVALID_ARGUMENT: identity / structural field presence ----
+    # Structural sub-tables and identity strings a product cannot be built
+    # without must fail loudly with a named message, never be silently omitted.
+    ("ec:400 fixed_rate_bond curve BondHelper missing schedule", "fixed_rate_bond",
+     "fixed_rate_bond_request.json", 400,
+     _ec_del_curve_point_field("BondHelper", "schedule"),
+     _ec_body_contains("BondHelper.schedule is required")),
+    ("ec:400 vanilla_swap missing discounting_curve reference", "vanilla_swap",
+     "vanilla_swap_request.json", 400,
+     _ec_del_field("swaps", "discounting_curve"),
+     _ec_body_contains("PriceVanillaSwap.discounting_curve is required")),
+    ("ec:400 cds missing credit_curve_id reference", "cds",
+     "cds_request.json", 400,
+     _ec_del_field("cds_list", "credit_curve_id"),
+     _ec_body_contains("PriceCDS entry requires credit_curve_id")),
     # ---- 400 INVALID_ARGUMENT: unbounded schedule generation guard ----
     ("ec:400 fixed_rate_bond 300y daily schedule rejected", "fixed_rate_bond",
      "fixed_rate_bond_request.json", 400, _ec_abusive_schedule("bonds", "fixed_rate_bond")),


### PR DESCRIPTION
**Schema v3, step 4: required identity & structural fields.** Two changes plus a verification pass:

- New named guard: `BondHelper.schedule` missing now returns 400 `BondHelper.schedule is required` (previously fell through to a generic schedule error).
- The result vector of all 12 pricing responses (`swaps`/`bonds`/`fras`/`cap_floors`/`cds_list`/`options`/`swaptions`) is now `(required)` in the schema, matching `BootstrapCurvesResponse.results` — every mapper already populates it unconditionally.
- Inventory confirmed every identity string (curve/index/model ids, discounting/forwarding curves) and product schedule already carries an explicit runtime guard; fields already rejected at the JSON-parse layer were deliberately left (a runtime guard would be dead code).

+3 error-contract scenarios. Regenerated FlatBuffers/OpenAPI included. Full suite green (509 cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
