### PR TITLE
Reject inert inflation observation-date flag; fix YoY payer doc; align legacy calendar helper

### DIFF
--- a/flatbuffers/cpp/year_on_year_inflation_swap_generated.h
+++ b/flatbuffers/cpp/year_on_year_inflation_swap_generated.h
@@ -63,7 +63,8 @@ struct YearOnYearInflationSwap FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::
     VT_PAYMENT_CALENDAR = 26,
     VT_PAYMENT_CONVENTION = 28
   };
-  /// "Payer" / "Receiver" refers to the YoY inflation leg.
+  /// "Payer" pays the fixed leg and receives the YoY inflation leg;
+  /// "Receiver" is the reverse (receives fixed, pays YoY inflation).
   quantra::enums::SwapType swap_type() const {
     return static_cast<quantra::enums::SwapType>(GetField<int8_t>(VT_SWAP_TYPE, 0));
   }

--- a/flatbuffers/cpp/zero_coupon_inflation_swap_generated.h
+++ b/flatbuffers/cpp/zero_coupon_inflation_swap_generated.h
@@ -100,6 +100,10 @@ struct ZeroCouponInflationSwap FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::
   quantra::enums::CPIInterpolationType observation_interpolation() const {
     return static_cast<quantra::enums::CPIInterpolationType>(GetField<int8_t>(VT_OBSERVATION_INTERPOLATION, 0));
   }
+  /// Must stay false. In the pinned QuantLib this flag does not change the
+  /// priced observation dates for a zero-coupon inflation swap, so setting it
+  /// true would be a silent no-op; the server rejects true with an error
+  /// rather than accept a flag it cannot honour.
   bool adjust_observation_dates() const {
     return GetField<uint8_t>(VT_ADJUST_OBSERVATION_DATES, 0) != 0;
   }

--- a/flatbuffers/fbs/year_on_year_inflation_swap.fbs
+++ b/flatbuffers/fbs/year_on_year_inflation_swap.fbs
@@ -6,7 +6,8 @@ namespace quantra;
 
 /// Standard year-on-year inflation swap (YYIIS).
 table YearOnYearInflationSwap {
-    /// "Payer" / "Receiver" refers to the YoY inflation leg.
+    /// "Payer" pays the fixed leg and receives the YoY inflation leg;
+    /// "Receiver" is the reverse (receives fixed, pays YoY inflation).
     swap_type:enums.SwapType;
     notional:double;
     fixed_schedule:Schedule (required);

--- a/flatbuffers/fbs/zero_coupon_inflation_swap.fbs
+++ b/flatbuffers/fbs/zero_coupon_inflation_swap.fbs
@@ -19,6 +19,10 @@ table ZeroCouponInflationSwap {
     inflation_index_id:string (required);
     observation_lag:Period (required);
     observation_interpolation:enums.CPIInterpolationType = AsIndex;
+    /// Must stay false. In the pinned QuantLib this flag does not change the
+    /// priced observation dates for a zero-coupon inflation swap, so setting it
+    /// true would be a silent no-op; the server rejects true with an error
+    /// rather than accept a flag it cannot honour.
     adjust_observation_dates:bool = false;
     inflation_calendar:enums.Calendar = NullCalendar;
     inflation_convention:enums.BusinessDayConvention = Following;

--- a/flatbuffers/json/price_year_on_year_inflation_swap_request.schema.json
+++ b/flatbuffers/json/price_year_on_year_inflation_swap_request.schema.json
@@ -2215,7 +2215,7 @@
       "properties" : {
         "swap_type" : {
                 "$ref" : "#/definitions/quantra_enums_SwapType",
-                "description" : "\"Payer\" / \"Receiver\" refers to the YoY inflation leg."
+                "description" : "\"Payer\" pays the fixed leg and receives the YoY inflation leg;\n\"Receiver\" is the reverse (receives fixed, pays YoY inflation)."
               },
         "notional" : {
                 "type" : "number"

--- a/flatbuffers/json/price_zero_coupon_inflation_swap_request.schema.json
+++ b/flatbuffers/json/price_zero_coupon_inflation_swap_request.schema.json
@@ -2250,7 +2250,8 @@
                 "$ref" : "#/definitions/quantra_enums_CPIInterpolationType"
               },
         "adjust_observation_dates" : {
-                "type" : "boolean"
+                "type" : "boolean",
+                "description" : "Must stay false. In the pinned QuantLib this flag does not change the\npriced observation dates for a zero-coupon inflation swap, so setting it\ntrue would be a silent no-op; the server rejects true with an error\nrather than accept a flag it cannot honour."
               },
         "inflation_calendar" : {
                 "$ref" : "#/definitions/quantra_enums_Calendar"

--- a/flatbuffers/json/year_on_year_inflation_swap.schema.json
+++ b/flatbuffers/json/year_on_year_inflation_swap.schema.json
@@ -615,7 +615,7 @@
       "properties" : {
         "swap_type" : {
                 "$ref" : "#/definitions/quantra_enums_SwapType",
-                "description" : "\"Payer\" / \"Receiver\" refers to the YoY inflation leg."
+                "description" : "\"Payer\" pays the fixed leg and receives the YoY inflation leg;\n\"Receiver\" is the reverse (receives fixed, pays YoY inflation)."
               },
         "notional" : {
                 "type" : "number"

--- a/flatbuffers/json/zero_coupon_inflation_swap.schema.json
+++ b/flatbuffers/json/zero_coupon_inflation_swap.schema.json
@@ -650,7 +650,8 @@
                 "$ref" : "#/definitions/quantra_enums_CPIInterpolationType"
               },
         "adjust_observation_dates" : {
-                "type" : "boolean"
+                "type" : "boolean",
+                "description" : "Must stay false. In the pinned QuantLib this flag does not change the\npriced observation dates for a zero-coupon inflation swap, so setting it\ntrue would be a silent no-op; the server rejects true with an error\nrather than accept a flag it cannot honour."
               },
         "inflation_calendar" : {
                 "$ref" : "#/definitions/quantra_enums_Calendar"

--- a/flatbuffers/python/quantra/YearOnYearInflationSwap.py
+++ b/flatbuffers/python/quantra/YearOnYearInflationSwap.py
@@ -25,7 +25,8 @@ class YearOnYearInflationSwap(object):
     def Init(self, buf, pos):
         self._tab = flatbuffers.table.Table(buf, pos)
 
-    # "Payer" / "Receiver" refers to the YoY inflation leg.
+    # "Payer" pays the fixed leg and receives the YoY inflation leg;
+    # "Receiver" is the reverse (receives fixed, pays YoY inflation).
     # YearOnYearInflationSwap
     def SwapType(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))

--- a/flatbuffers/python/quantra/ZeroCouponInflationSwap.py
+++ b/flatbuffers/python/quantra/ZeroCouponInflationSwap.py
@@ -109,6 +109,10 @@ class ZeroCouponInflationSwap(object):
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
         return 0
 
+    # Must stay false. In the pinned QuantLib this flag does not change the
+    # priced observation dates for a zero-coupon inflation swap, so setting it
+    # true would be a silent no-op; the server rejects true with an error
+    # rather than accept a flag it cannot honour.
     # ZeroCouponInflationSwap
     def AdjustObservationDates(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(26))

--- a/jsonserver/openapi/openapi3.json
+++ b/jsonserver/openapi/openapi3.json
@@ -6671,7 +6671,8 @@
             "$ref": "#/components/schemas/quantra_enums_CPIInterpolationType"
           },
           "adjust_observation_dates": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Must stay false. In the pinned QuantLib this flag does not change the\npriced observation dates for a zero-coupon inflation swap, so setting it\ntrue would be a silent no-op; the server rejects true with an error\nrather than accept a flag it cannot honour."
           },
           "inflation_calendar": {
             "$ref": "#/components/schemas/quantra_enums_Calendar"

--- a/jsonserver/openapi/openapi3.yaml
+++ b/jsonserver/openapi/openapi3.yaml
@@ -4790,6 +4790,15 @@ components:
           $ref: '#/components/schemas/quantra_enums_CPIInterpolationType'
         adjust_observation_dates:
           type: boolean
+          description: 'Must stay false. In the pinned QuantLib this flag does not
+            change the
+
+            priced observation dates for a zero-coupon inflation swap, so setting
+            it
+
+            true would be a silent no-op; the server rejects true with an error
+
+            rather than accept a flag it cannot honour.'
         inflation_calendar:
           $ref: '#/components/schemas/quantra_enums_Calendar'
         inflation_convention:

--- a/src/mappers/zero_coupon_inflation_swap_mapper.cpp
+++ b/src/mappers/zero_coupon_inflation_swap_mapper.cpp
@@ -54,6 +54,13 @@ ZeroCouponInflationSwapTrade extractTrade(const quantra::PriceZeroCouponInflatio
         swap->observation_lag()->n(),
         TimeUnitToQL(swap->observation_lag()->unit()));
     trade.observationInterpolation = CPIInterpolationToQL(swap->observation_interpolation());
+    if (swap->adjust_observation_dates()) {
+        QUANTRA_INVALID_ARGUMENT(
+            "ZeroCouponInflationSwap adjust_observation_dates=true is not supported: "
+            "in the pinned QuantLib it does not change the priced observation dates "
+            "for this instrument, so honouring it would be a silent no-op. Omit the "
+            "field or set it to false.");
+    }
     trade.adjustObservationDates = swap->adjust_observation_dates();
     trade.inflationCalendar = CalendarToQL(swap->inflation_calendar());
     trade.inflationConvention = ConventionToQL(swap->inflation_convention());

--- a/src/parsers/zero_coupon_inflation_swap_parser.cpp
+++ b/src/parsers/zero_coupon_inflation_swap_parser.cpp
@@ -42,6 +42,13 @@ std::shared_ptr<QuantLib::ZeroCouponInflationSwap> ZeroCouponInflationSwapParser
     if (!inflationIndex) {
         QUANTRA_NOT_FOUND("ZeroCouponInflationSwap inflation index not available");
     }
+    if (swap->adjust_observation_dates()) {
+        QUANTRA_INVALID_ARGUMENT(
+            "ZeroCouponInflationSwap adjust_observation_dates=true is not supported: "
+            "in the pinned QuantLib it does not change the priced observation dates "
+            "for this instrument, so honouring it would be a silent no-op. Omit the "
+            "field or set it to false.");
+    }
 
     QuantLib::ZeroCouponInflationSwap::Type swapType;
     switch (swap->swap_type()) {

--- a/tests/contract/ql_reference.py
+++ b/tests/contract/ql_reference.py
@@ -173,7 +173,10 @@ def get_calendar(name: str):
         # Mirrors the server's CalendarToQL: QuantLib::UnitedKingdom()
         # (default Settlement market).
         "UnitedKingdom": ql.UnitedKingdom(),
-        "UnitedStates": ql.UnitedStates(ql.UnitedStates.NYSE),
+        # Mirrors the server's CalendarToQL: the plain "UnitedStates" enum maps
+        # to the Settlement market (not NYSE).
+        "UnitedStates": ql.UnitedStates(ql.UnitedStates.Settlement),
+        "UnitedStatesSettlement": ql.UnitedStates(ql.UnitedStates.Settlement),
         "UnitedStatesNYSE": ql.UnitedStates(ql.UnitedStates.NYSE),
         "UnitedStatesGovernmentBond": ql.UnitedStates(ql.UnitedStates.GovernmentBond),
     }

--- a/tests/functional/README.md
+++ b/tests/functional/README.md
@@ -572,11 +572,13 @@ pin nothing measurable); they are deliberately not half-implemented:
   QuantLib Python bindings only expose the maturity-date helper
   constructors, so the reference rejects `start_date` instead of
   approximating it. End-date-only helpers are covered.
-* **`adjust_observation_dates` / inflation calendar on ZCIIS** — on the
-  wire and passed to QuantLib by both sides, but numerically inert in this
+* **`adjust_observation_dates` on ZCIIS** — numerically inert in this
   QuantLib version (the CPI flow amount is computed from the maturity and
-  observation lag regardless of the adjusted observation date), so no NPV
-  case can pin it.
+  observation lag regardless of the adjusted observation date; an exhaustive
+  sweep of maturities, inflation calendars and CPI interpolations never moves
+  the NPV when it is toggled). Because it cannot be honoured, the server now
+  rejects `adjust_observation_dates=true` with an invalid-argument error
+  rather than accept a silent no-op; only the default `false` is priced.
 * **Quote-referenced inflation helpers (`quote_id`)** — resolved against
   `pricing.quotes` by both the server and the reference, but no catalog
   case exercises the indirection yet.

--- a/tests/parity/zero_coupon_inflation_swap_test.cpp
+++ b/tests/parity/zero_coupon_inflation_swap_test.cpp
@@ -5,6 +5,8 @@
 // test_quantra_vs_quantlib gtest binary.
 #include "parity_fixture.h"
 
+#include "error.h"
+
 namespace quantra { namespace testing {
 
 TEST_F(QuantraComparisonTest, PriceZeroCouponInflationSwap_MatchesQuantLib) {
@@ -380,6 +382,49 @@ TEST_F(QuantraComparisonTest, PriceZeroCouponInflationSwap_Receiver_Flat) {
     EXPECT_NEAR(priced->fair_rate(), expected->fairRate(), 1e-10);
     EXPECT_NEAR(priced->fixed_leg_npv(), expected->fixedLegNPV(), 1e-8);
     EXPECT_NEAR(priced->inflation_leg_npv(), expected->inflationLegNPV(), 1e-8);
+}
+
+// adjust_observation_dates has no numerical effect on a zero-coupon inflation
+// swap in the pinned QuantLib (an exhaustive sweep of maturities, calendars and
+// interpolations leaves the NPV unchanged when it is toggled). Rather than
+// silently accept a flag it cannot honour, the server rejects the true value.
+TEST_F(QuantraComparisonTest, PriceZeroCouponInflationSwap_RejectsAdjustObservationDates) {
+    flatbuffers::grpc::MessageBuilder b;
+
+    auto startDate = b.CreateString("2025-01-15");
+    auto maturityDate = b.CreateString("2028-01-15");
+    auto idxId = b.CreateString("EUHICP");
+    auto discCurveId = b.CreateString("DISC");
+    auto curveId = b.CreateString("HICP_ZC");
+    auto observationLag = buildPeriod(b, 3, quantra::enums::TimeUnit_Months);
+
+    quantra::ZeroCouponInflationSwapBuilder zcib(b);
+    zcib.add_swap_type(quantra::enums::SwapType_Receiver);
+    zcib.add_notional(1000000.0);
+    zcib.add_start_date(startDate);
+    zcib.add_maturity_date(maturityDate);
+    zcib.add_fixed_rate(0.02);
+    zcib.add_inflation_index_id(idxId);
+    zcib.add_observation_lag(observationLag);
+    zcib.add_adjust_observation_dates(true);  // unsupported -> must be rejected
+    auto zciis = zcib.Finish();
+
+    quantra::PriceZeroCouponInflationSwapBuilder pzb(b);
+    pzb.add_zero_coupon_inflation_swap(zciis);
+    pzb.add_discounting_curve(discCurveId);
+    pzb.add_inflation_curve(curveId);
+    auto trades = b.CreateVector(
+        std::vector<flatbuffers::Offset<quantra::PriceZeroCouponInflationSwap>>{pzb.Finish()});
+
+    quantra::PriceZeroCouponInflationSwapRequestBuilder reqb(b);
+    reqb.add_swaps(trades);
+    reqb.add_include_flows(false);
+    b.Finish(reqb.Finish());
+
+    auto req = flatbuffers::GetRoot<quantra::PriceZeroCouponInflationSwapRequest>(b.GetBufferPointer());
+    ZeroCouponInflationSwapPricingRequest handler;
+    auto outBuilder = std::make_shared<flatbuffers::grpc::MessageBuilder>();
+    EXPECT_THROW(handler.request(outBuilder, req), QuantraInvalidArgument);
 }
 
 }} // namespace quantra::testing


### PR DESCRIPTION
Three small correctness/documentation fixes:

- **ZCIIS `adjust_observation_dates` rejected as unsupported.** The flag is numerically inert in the pinned QuantLib — proven by an exhaustive sweep (730 maturity × interpolation × calendar combinations plus weekend variants; NPV never moved, because the CPI flow amount is derived at monthly granularity and discards the adjusted date). Setting it `true` now returns a 400 explaining this instead of silently doing nothing; the schema comment documents it.
- **YoY inflation swap `swap_type` comment corrected.** It claimed Payer refers to the inflation leg; empirically Payer pays the **fixed** leg and receives YoY inflation (fixedLegNPV −98280.6 / yoyLegNPV +100566.2 on the 5Y example). Doc-only.
- **Legacy test-reference `get_calendar("UnitedStates")` aligned** from NYSE to Settlement, matching the server enum (dormant path; nothing relied on it).

+1 rejection test. Full suite green (520 cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
