### PR TITLE
Size the worker fleet from cores and health-check it over gRPC

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -246,7 +246,15 @@ RUN chmod +x /usr/local/bin/quantra
 RUN printf '%s\n' \
     '#!/bin/sh' \
     'set -eu' \
-    ': "${QUANTRA_WORKERS:=4}"' \
+    '# Default worker count to the number of CPUs, capped at 8. An operator can' \
+    '# still pin it explicitly by passing QUANTRA_WORKERS; only compute a default' \
+    '# when it is unset or empty.' \
+    'if [ -z "${QUANTRA_WORKERS:-}" ]; then' \
+    '    _cores=$(nproc 2>/dev/null || echo 1)' \
+    '    if [ "$_cores" -gt 8 ]; then _cores=8; fi' \
+    '    if [ "$_cores" -lt 1 ]; then _cores=1; fi' \
+    '    QUANTRA_WORKERS=$_cores' \
+    'fi' \
     ': "${QUANTRA_GRPC_TARGET:=127.0.0.1:50051}"' \
     ': "${QUANTRA_HTTP_PORT:=8080}"' \
     ': "${QUANTRA_STARTUP_WAIT:=3}"' \

--- a/README.md
+++ b/README.md
@@ -99,7 +99,9 @@ curl http://localhost:8080/health
 curl http://localhost:8080/meta
 ```
 
-Change the worker count with `QUANTRA_WORKERS`:
+By default the container runs one worker per CPU core (capped at 8). Each worker
+is a single-threaded pricing process, so sizing workers to cores is what gives
+you parallel throughput. Override the count with `QUANTRA_WORKERS`:
 
 ```bash
 docker run --rm \
@@ -108,6 +110,9 @@ docker run --rm \
   -p 50051:50051 \
   ghcr.io/joseprupi/quantra-server:0.1.1
 ```
+
+See `docs/process-manager.md` for the full scaling model (load balancing, health
+checks, and per-worker caches).
 
 The public API reference is available at <https://quantra.io/docs/api>.
 

--- a/docs/process-manager.md
+++ b/docs/process-manager.md
@@ -8,6 +8,38 @@ Quantra uses multiple `sync_server` processes to work around QuantLib's process-
 client -> Envoy (:50051) -> sync_server workers (:50055+)
 ```
 
+## Scaling Model
+
+Each `sync_server` worker handles one pricing request at a time. QuantLib here is
+built without session support, so a worker is effectively single-threaded for
+compute: while it prices a request, it does no other pricing work. Throughput
+comes from running several worker processes side by side, not from threads inside
+one process.
+
+Size the worker count roughly to the number of CPU cores. The production
+container defaults `QUANTRA_WORKERS` to the detected core count, capped at 8 and
+floored at 1; set `QUANTRA_WORKERS` explicitly to override. More workers than
+cores mostly adds memory pressure without adding parallel compute.
+
+Envoy balances with `LEAST_REQUEST`, so a new request is sent to the worker with
+the fewest in-flight requests. Because a busy worker keeps an in-flight count of
+at least one, incoming work naturally routes around it to an idle worker instead
+of queueing behind a slow computation.
+
+Envoy probes each worker with a gRPC health check against the standard
+`grpc.health.v1.Health` service (empty service name, i.e. overall serving
+status). The health service runs on gRPC's own thread pool, so a worker that is
+busy on a long calculation still answers as healthy. The check therefore
+distinguishes a *dead* worker (ejected from the pool) from a *busy* one (kept in
+the pool and simply avoided by `LEAST_REQUEST` until it frees up).
+
+Each worker has its own in-process result caches (curve bootstrapping, SABR and
+Hull-White calibration). These caches are independent per process: total cache
+memory scales with the number of workers, and every worker starts cold and warms
+up separately, so the same request may be recomputed once per worker. Sharing a
+cache across workers (for example an out-of-process L2/Redis tier) is a known
+future option, not implemented today.
+
 ## In-Repo CLI
 
 For local development inside the repository, use:

--- a/envoy/quantra_template.yaml
+++ b/envoy/quantra_template.yaml
@@ -58,9 +58,7 @@ static_resources:
         unhealthy_threshold : 1
         healthy_threshold: 1
         interval: 1s
-        tcp_health_check: 
-          send:
-          receive: []
+        grpc_health_check: {}
     load_assignment:
       cluster_name: cluster_0
       endpoints:

--- a/scripts/envoy_config.py
+++ b/scripts/envoy_config.py
@@ -154,7 +154,12 @@ def generate_envoy_config(
                     "interval": health_check_interval,
                     "unhealthy_threshold": 2,
                     "healthy_threshold": 1,
-                    "tcp_health_check": {}
+                    # gRPC health check against the standard grpc.health.v1.Health
+                    # service the engine serves. An empty service name asks for the
+                    # server's overall serving status. A worker busy on a long
+                    # computation still answers here (health runs on gRPC's own
+                    # threads), so only genuinely dead workers are ejected.
+                    "grpc_health_check": {}
                 }],
                 "load_assignment": {
                     "cluster_name": "quantra_workers",

--- a/tests/bench/throughput_bench.py
+++ b/tests/bench/throughput_bench.py
@@ -13,7 +13,7 @@ Topology started per invocation (inside the quantraserver:test image, which
 ships /usr/local/bin/envoy):
 
     scripts/quantra start --workers N --foreground   (run in the background)
-        -> N sync_server workers on base_port=50055.. + an Envoy ROUND_ROBIN
+        -> N sync_server workers on base_port=50055.. + an Envoy LEAST_REQUEST
            front on port 50051. --foreground keeps the manager alive so Envoy
            stays up for the whole run.
     json_server localhost:50051 8080

--- a/tests/contract/envoy_config_test.py
+++ b/tests/contract/envoy_config_test.py
@@ -58,6 +58,16 @@ def test_lb_policy_is_least_request():
     assert cluster["lb_policy"] == "LEAST_REQUEST"
 
 
+def test_health_check_is_grpc():
+    # The engine serves the standard grpc.health.v1.Health service, so Envoy
+    # must probe it over gRPC (not a bare TCP connect). A gRPC probe reflects
+    # actual serving status rather than just an open socket.
+    cluster = _cluster(_generate())
+    health_check = cluster["health_checks"][0]
+    assert "grpc_health_check" in health_check
+    assert "tcp_health_check" not in health_check
+
+
 def test_request_timeout_override_changes_route_timeout():
     route = _route(_generate("--request-timeout", "12s"))
     assert route["timeout"] == "12s"

--- a/tools/quantra-manager/quantra
+++ b/tools/quantra-manager/quantra
@@ -238,7 +238,12 @@ def generate_envoy_config(port: int, base_port: int, workers: int, admin_port: i
                     "interval": "1s",
                     "unhealthy_threshold": 2,
                     "healthy_threshold": 1,
-                    "tcp_health_check": {},
+                    # gRPC health check against the standard grpc.health.v1.Health
+                    # service the engine serves. Empty service name = overall
+                    # serving status. A worker busy on a computation still answers
+                    # (health runs on gRPC's own threads), so only dead workers are
+                    # ejected.
+                    "grpc_health_check": {},
                 }],
                 "load_assignment": {
                     "cluster_name": "quantra_workers",


### PR DESCRIPTION
**Operational hardening of the multi-process scaling model** — the final step of the concurrency sequence.

- **Worker count from cores:** the container entrypoint defaults `QUANTRA_WORKERS` to `min(nproc, 8)` (floored at 1) computed at start; an explicit env override still wins. Was hard-coded 4.
- **Envoy health checks TCP → gRPC:** the engine serves standard `grpc.health.v1.Health` now, so all three config sources (generator, the manager's inline copy, the static template) use `grpc_health_check`. TCP only detected dead processes; gRPC health answers on gRPC's own threads, so it distinguishes a dead worker from a compute-busy one.
- **"Scaling Model" doc** (docs/process-manager.md): single-threaded worker processes sized ≈ cores; least-request routing around busy workers; independent per-process caches (N× memory, cold per worker); cross-worker cache sharing noted as future work, not promised.
- Stale ROUND_ROBIN / TCP-health mentions updated. +1 config-gen test asserting the gRPC health check.

Full suite green (537 cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
