### PR TITLE
Fix two reachable crashes and NaN-in-JSON output

### DIFF
--- a/src/mappers/basis_swap_mapper.cpp
+++ b/src/mappers/basis_swap_mapper.cpp
@@ -1,5 +1,7 @@
 #include "basis_swap_mapper.h"
 
+#include <cmath>
+
 #include "schedule_parser.h"
 #include "enum_convert.h"
 #include "error.h"
@@ -110,7 +112,7 @@ flatbuffers::Offset<quantra::SwapLegFlow> serializeFlow(
     fb.add_rate(f.rate);
     if (f.isFloating) {
         fb.add_fixing_date(fixingDate);
-        fb.add_index_fixing(f.indexFixing);
+        if (std::isfinite(f.indexFixing)) fb.add_index_fixing(f.indexFixing);
         fb.add_spread(f.spread);
     }
     return fb.Finish();
@@ -170,8 +172,10 @@ flatbuffers::Offset<quantra::PriceBasisSwapResponse> BasisSwapMapper::toResponse
         rb.add_leg2_bps(swap.leg2Bps);
         rb.add_leg1_npv(swap.leg1Npv);
         rb.add_leg2_npv(swap.leg2Npv);
-        rb.add_fair_spread_leg1(swap.fairSpreadLeg1);
-        rb.add_fair_spread_leg2(swap.fairSpreadLeg2);
+        // A zero-BPS leg (e.g. notional 0) makes the fair spread NaN, which is
+        // not representable in JSON. Omit it rather than emit a bare `nan`.
+        if (std::isfinite(swap.fairSpreadLeg1)) rb.add_fair_spread_leg1(swap.fairSpreadLeg1);
+        if (std::isfinite(swap.fairSpreadLeg2)) rb.add_fair_spread_leg2(swap.fairSpreadLeg2);
         if (swap.includeFlows) {
             rb.add_leg1_flows(leg1Flows);
             rb.add_leg2_flows(leg2Flows);

--- a/src/mappers/cds_mapper.cpp
+++ b/src/mappers/cds_mapper.cpp
@@ -1,5 +1,7 @@
 #include "cds_mapper.h"
 
+#include <cmath>
+
 #include "date_convert.h"
 #include "schedule_parser.h"
 #include "enum_convert.h"
@@ -107,7 +109,7 @@ flatbuffers::Offset<quantra::PriceCDSResponse> CdsMapper::toResponse(
     for (const auto& v : result.values) {
         quantra::CDSValuesBuilder vb(builder);
         vb.add_npv(v.npv);
-        if (v.fairSpread) {
+        if (v.fairSpread && std::isfinite(*v.fairSpread)) {
             vb.add_fair_spread(*v.fairSpread);
         }
         vb.add_fair_upfront(v.fairUpfront);

--- a/src/mappers/ois_swap_mapper.cpp
+++ b/src/mappers/ois_swap_mapper.cpp
@@ -1,5 +1,7 @@
 #include "ois_swap_mapper.h"
 
+#include <cmath>
+
 #include "schedule_parser.h"
 #include "enum_convert.h"
 #include "error.h"
@@ -100,7 +102,7 @@ flatbuffers::Offset<quantra::SwapLegFlow> serializeFlow(
     fb.add_rate(f.rate);
     if (f.isFloating) {
         fb.add_fixing_date(fixingDate);
-        fb.add_index_fixing(f.indexFixing);
+        if (std::isfinite(f.indexFixing)) fb.add_index_fixing(f.indexFixing);
         fb.add_spread(f.spread);
     }
     return fb.Finish();
@@ -156,8 +158,10 @@ flatbuffers::Offset<quantra::PriceOisSwapResponse> OisSwapMapper::toResponse(
 
         quantra::OisSwapResponseBuilder rb(builder);
         rb.add_npv(swap.npv);
-        rb.add_fair_rate(swap.fairRate);
-        rb.add_fair_spread(swap.fairSpread);
+        // fairRate/fairSpread divide by leg BPS; a zero-BPS leg (e.g. notional 0)
+        // yields NaN/inf, which is not valid JSON. Omit rather than emit `nan`.
+        if (std::isfinite(swap.fairRate)) rb.add_fair_rate(swap.fairRate);
+        if (std::isfinite(swap.fairSpread)) rb.add_fair_spread(swap.fairSpread);
         rb.add_fixed_leg_bps(swap.fixedLegBps);
         rb.add_overnight_leg_bps(swap.overnightLegBps);
         rb.add_fixed_leg_npv(swap.fixedLegNpv);

--- a/src/mappers/swap_leg_flow_builder.cpp
+++ b/src/mappers/swap_leg_flow_builder.cpp
@@ -1,5 +1,7 @@
 #include "swap_leg_flow_builder.h"
 
+#include <cmath>
+
 #include <ql/cashflows/coupon.hpp>
 #include <ql/cashflows/floatingratecoupon.hpp>
 #include <ql/utilities/dataformatters.hpp>
@@ -63,7 +65,7 @@ flatbuffers::Offset<SwapLegFlow> buildSwapLegFlow(
     fb.add_rate(rate);
     if (frc) {
         fb.add_fixing_date(fixingDate);
-        fb.add_index_fixing(indexFixing);
+        if (std::isfinite(indexFixing)) fb.add_index_fixing(indexFixing);
         fb.add_spread(spread);
     }
     return fb.Finish();

--- a/src/mappers/swaption_mapper.cpp
+++ b/src/mappers/swaption_mapper.cpp
@@ -303,6 +303,14 @@ SwaptionInputs SwaptionMapper::toInputs(const quantra::PriceSwaptionRequest* req
         if (!pricing->as_of_date()) {
             QUANTRA_INVALID_ARGUMENT("as_of_date is required");
         }
+        // toInputs runs BEFORE the registry build (which owns the usual
+        // rates-presence guard), so the rebump snapshots must validate the
+        // market data themselves. Without this a request that omits
+        // pricing.rates would segfault on the derefs below.
+        if (!pricing->rates() || !pricing->rates()->curves()) {
+            QUANTRA_INVALID_ARGUMENT(
+                "Swaption rebump pricing requires pricing.rates.curves (at least one curve needed)");
+        }
         const QuantLib::Date asOf = DateToQL(pricing->as_of_date()->str());
         const auto& cfg = kSwaptionRebumpConfig;
 

--- a/src/mappers/vanilla_swap_flow_builder.cpp
+++ b/src/mappers/vanilla_swap_flow_builder.cpp
@@ -1,5 +1,6 @@
 #include "vanilla_swap_flow_builder.h"
 
+#include <cmath>
 #include <limits>
 
 #include <ql/cashflows/cmscoupon.hpp>
@@ -87,9 +88,11 @@ VanillaSwapFlowsBuildResult buildVanillaSwapFlows(
             } catch (...) {
             }
 
-            fb.add_index_fixing(fixing);
+            // indexFixing() can fail (missing historical fixing); we caught the
+            // throw and left `fixing` as NaN. NaN is not valid JSON, so omit it.
+            if (std::isfinite(fixing)) fb.add_index_fixing(fixing);
             fb.add_has_cms_swap_rate(hasCmsSwapRate);
-            if (hasCmsSwapRate) {
+            if (hasCmsSwapRate && std::isfinite(cmsSwapRate)) {
                 fb.add_cms_swap_rate(cmsSwapRate);
             }
             fb.add_spread(coupon->spread());

--- a/src/mappers/vanilla_swap_mapper.cpp
+++ b/src/mappers/vanilla_swap_mapper.cpp
@@ -192,9 +192,9 @@ flatbuffers::Offset<quantra::SwapLegFlow> serializeFlow(
     fb.add_rate(f.rate);
     if (f.isFloating) {
         fb.add_fixing_date(fixingDate);
-        fb.add_index_fixing(f.indexFixing);
+        if (std::isfinite(f.indexFixing)) fb.add_index_fixing(f.indexFixing);
         fb.add_has_cms_swap_rate(f.hasCmsSwapRate);
-        if (f.hasCmsSwapRate) {
+        if (f.hasCmsSwapRate && std::isfinite(f.cmsSwapRate)) {
             fb.add_cms_swap_rate(f.cmsSwapRate);
         }
         fb.add_spread(f.spread);
@@ -249,8 +249,10 @@ flatbuffers::Offset<quantra::PriceVanillaSwapResponse> VanillaSwapMapper::toResp
 
         quantra::VanillaSwapResponseBuilder rb(builder);
         rb.add_npv(swap.npv);
-        rb.add_fair_rate(swap.fairRate);
-        rb.add_fair_spread(swap.fairSpread);
+        // fairRate/fairSpread divide by leg BPS; a zero-BPS leg (e.g. notional 0)
+        // yields NaN/inf, which is not valid JSON. Omit rather than emit `nan`.
+        if (std::isfinite(swap.fairRate)) rb.add_fair_rate(swap.fairRate);
+        if (std::isfinite(swap.fairSpread)) rb.add_fair_spread(swap.fairSpread);
         rb.add_fixed_leg_bps(swap.fixedLegBps);
         rb.add_floating_leg_bps(swap.floatingLegBps);
         rb.add_fixed_leg_npv(swap.fixedLegNpv);

--- a/src/mappers/year_on_year_inflation_swap_mapper.cpp
+++ b/src/mappers/year_on_year_inflation_swap_mapper.cpp
@@ -1,5 +1,7 @@
 #include "year_on_year_inflation_swap_mapper.h"
 
+#include <cmath>
+
 #include "date_convert.h"
 #include "schedule_parser.h"
 #include "enum_convert.h"
@@ -102,7 +104,7 @@ flatbuffers::Offset<quantra::SwapLegFlow> serializeFlow(
     fb.add_rate(f.rate);
     if (f.isFloating) {
         fb.add_fixing_date(fixingDate);
-        fb.add_index_fixing(f.indexFixing);
+        if (std::isfinite(f.indexFixing)) fb.add_index_fixing(f.indexFixing);
         fb.add_spread(f.spread);
     }
     return fb.Finish();
@@ -156,8 +158,10 @@ YearOnYearInflationSwapMapper::toResponse(
 
         quantra::YearOnYearInflationSwapResponseBuilder rb(builder);
         rb.add_npv(swap.npv);
-        rb.add_fair_rate(swap.fairRate);
-        rb.add_fair_spread(swap.fairSpread);
+        // fairRate/fairSpread divide by leg BPS; a zero-BPS leg (e.g. notional 0)
+        // yields NaN/inf, which is not valid JSON. Omit rather than emit `nan`.
+        if (std::isfinite(swap.fairRate)) rb.add_fair_rate(swap.fairRate);
+        if (std::isfinite(swap.fairSpread)) rb.add_fair_spread(swap.fairSpread);
         rb.add_fixed_leg_bps(swap.fixedLegBps);
         rb.add_yoy_leg_bps(swap.yoyLegBps);
         rb.add_fixed_leg_npv(swap.fixedLegNpv);

--- a/src/mappers/zero_coupon_inflation_swap_mapper.cpp
+++ b/src/mappers/zero_coupon_inflation_swap_mapper.cpp
@@ -1,5 +1,7 @@
 #include "zero_coupon_inflation_swap_mapper.h"
 
+#include <cmath>
+
 #include "date_convert.h"
 #include "enum_convert.h"
 #include "error.h"
@@ -105,7 +107,7 @@ flatbuffers::Offset<quantra::SwapLegFlow> serializeFlow(
     fb.add_rate(f.rate);
     if (f.isFloating) {
         fb.add_fixing_date(fixingDate);
-        fb.add_index_fixing(f.indexFixing);
+        if (std::isfinite(f.indexFixing)) fb.add_index_fixing(f.indexFixing);
         fb.add_spread(f.spread);
     }
     return fb.Finish();
@@ -159,7 +161,9 @@ ZeroCouponInflationSwapMapper::toResponse(
 
         quantra::ZeroCouponInflationSwapResponseBuilder rb(builder);
         rb.add_npv(swap.npv);
-        rb.add_fair_rate(swap.fairRate);
+        // fairRate divides by leg BPS; a zero-BPS leg (e.g. notional 0) yields
+        // NaN/inf, which is not valid JSON. Omit rather than emit `nan`.
+        if (std::isfinite(swap.fairRate)) rb.add_fair_rate(swap.fairRate);
         rb.add_fixed_leg_bps(swap.fixedLegBps);
         rb.add_fixed_leg_npv(swap.fixedLegNpv);
         rb.add_inflation_leg_npv(swap.inflationLegNpv);

--- a/src/market/curve_bootstrapper.cpp
+++ b/src/market/curve_bootstrapper.cpp
@@ -85,6 +85,14 @@ void CurveBootstrapper::collectDeps(
         auto wrapper = ts->points()->Get(i);
         auto ptype = wrapper->point_type();
 
+        // A union whose type byte is set but whose value offset is absent
+        // passes FlatBuffers verification, then the static_casts below would
+        // dereference a null table. Reject it as a bad request instead.
+        if (ptype != quantra::Point_NONE && wrapper->point() == nullptr) {
+            QUANTRA_INVALID_ARGUMENT(
+                "Curve point union type is set but its value is missing");
+        }
+
         // Swap/OIS helpers: discount-curve only.
         // QuantLib's SwapRateHelper/OISRateHelper override projection via
         // index->clone(termStructureHandle_), so projection_curve deps are

--- a/src/market/curve_cache_key.cpp
+++ b/src/market/curve_cache_key.cpp
@@ -158,6 +158,15 @@ std::vector<uint8_t> CurveKeyBuilder::serializePoint(
     auto ptype = pw->point_type();
     buf.writeU8(static_cast<uint8_t>(ptype));
 
+    // Point_NONE carries no payload, so its type byte alone is the full content
+    // and stays keyable. Any other type with an absent value offset is a crafted
+    // buffer that passed verification; the point_as_*() casts below would return
+    // null and crash, so reject it as a bad request.
+    if (ptype != quantra::Point_NONE && pw->point() == nullptr) {
+        QUANTRA_INVALID_ARGUMENT(
+            "Curve point union type is set but its value is missing");
+    }
+
     // The convention enums are presence-required (an omitted convention is a
     // request error, never a default). Serialize a presence byte plus the value
     // so a present field never collides with an absent one in the cache key.

--- a/src/market/pricing_registry.cpp
+++ b/src/market/pricing_registry.cpp
@@ -210,6 +210,13 @@ PricingRegistry PricingRegistryBuilder::build(const quantra::Pricing* pricing,
             if (spec->payload_type() == quantra::ModelPayload_NONE) {
                 QUANTRA_INVALID_ARGUMENT("ModelSpec.payload is required for model id: " + id);
             }
+            // A union whose type byte is set but whose value offset is absent
+            // passes verification; the payload_as_*() casts below would then
+            // return null and crash on deref. Reject the crafted buffer.
+            if (spec->payload() == nullptr) {
+                QUANTRA_INVALID_ARGUMENT(
+                    "ModelSpec.payload type is set but its value is missing for model id: " + id);
+            }
 
             // Plain-domain mirror. Mirror enums are bit-compatible with the
             // FB enums by construction (see parser/model_domain.h); QL types

--- a/src/parsers/inflation_curve_parsers.cpp
+++ b/src/parsers/inflation_curve_parsers.cpp
@@ -413,6 +413,10 @@ std::map<std::string, InflationCurveEntry> buildInflationCurves(
                     QUANTRA_INVALID_ARGUMENT("Zero inflation curves require only ZeroCouponInflationSwapHelper points for curve id: " + id);
                 }
                 const auto* helper = point->point_as_ZeroCouponInflationSwapHelper();
+                if (!helper) {
+                    QUANTRA_INVALID_ARGUMENT(
+                        "Inflation point union type is set but its value is missing for curve id: " + id);
+                }
                 const std::string label = "ZeroCouponInflationSwapHelper";
                 const double quoteValue = resolveQuoteOrInline(helper, quotes, id, label);
                 if (!std::isfinite(quoteValue)) {
@@ -498,6 +502,10 @@ std::map<std::string, InflationCurveEntry> buildInflationCurves(
                     QUANTRA_INVALID_ARGUMENT("YoY inflation curves require only YearOnYearInflationSwapHelper points for curve id: " + id);
                 }
                 const auto* helper = point->point_as_YearOnYearInflationSwapHelper();
+                if (!helper) {
+                    QUANTRA_INVALID_ARGUMENT(
+                        "Inflation point union type is set but its value is missing for curve id: " + id);
+                }
                 const std::string label = "YearOnYearInflationSwapHelper";
                 const double quoteValue = resolveQuoteOrInline(helper, quotes, id, label);
                 if (!std::isfinite(quoteValue)) {

--- a/src/parsers/term_structure_point_parser.cpp
+++ b/src/parsers/term_structure_point_parser.cpp
@@ -65,6 +65,14 @@ std::shared_ptr<RateHelper> TermStructurePointParser::parse(
     double bump
 ) const {
 
+    // A union whose type byte names a helper but whose value offset is absent
+    // survives FlatBuffers verification; the static_casts in each branch below
+    // would then dereference a null table and crash. Reject it up front.
+    if (point_type != quantra::Point_NONE && data == nullptr) {
+        QUANTRA_INVALID_ARGUMENT(
+            "Term structure point union type is set but its value is missing");
+    }
+
     // ------------------------------------------------------------------
     // Deposit
     // ------------------------------------------------------------------

--- a/tests/contract/error_contract_test.py
+++ b/tests/contract/error_contract_test.py
@@ -419,6 +419,54 @@ def _ec_body_contains(substr):
     return check
 
 
+def _ec_swaption_rebump_without_rates():
+    """Ask for rebump greeks while omitting pricing.rates entirely.
+
+    The rebump snapshots are built in the mapper, which runs before the pricing
+    registry (owner of the usual rates-presence guard). Pre-guard this
+    dereferenced a null pricing.rates and SIGSEGV'd the worker; it must now be a
+    clean INVALID_ARGUMENT that names the requirement."""
+    def f(req):
+        req["pricing"]["options"] = {"swaption_pricing_rebump": True}
+        req["pricing"].pop("rates", None)
+        return req
+    return f
+
+
+def _ec_basis_swap_zero_notional():
+    """Zero both basis-swap leg notionals so each leg BPS collapses to 0.
+
+    The fair spread is npv - spread/BPS; a zero BPS makes it NaN. NaN has no
+    JSON representation, so the response mapper must omit the field, keeping the
+    HTTP-200 body valid JSON rather than emitting a bare `nan` token."""
+    def f(req):
+        bs = req["swaps"][0]["basis_swap"]
+        bs["leg1"]["notional"] = 0.0
+        bs["leg2"]["notional"] = 0.0
+        return req
+    return f
+
+
+def _ec_body_valid_json_without(*absent_keys):
+    """Body validator: the 200 body must parse as JSON, carry no bare `nan`
+    token, and none of the swaps may carry any of `absent_keys` (the fields
+    that would have serialized a non-finite double)."""
+    def check(body_text):
+        if "nan" in body_text.lower():
+            return f"response body carries a non-finite token: {body_text[:200]}"
+        try:
+            body = json.loads(body_text)
+        except Exception as e:
+            return f"response body is not valid JSON: {e} :: {body_text[:200]}"
+        for swap in body.get("swaps", []) or []:
+            for k in absent_keys:
+                if k in swap:
+                    return (f"expected field {k!r} to be omitted (non-finite), "
+                            f"but it is present: {json.dumps(swap)[:200]}")
+        return None
+    return check
+
+
 def _ec_unimplemented_curve_point():
     # Replace the first curve's first point with a schema-ready-but-unbuilt
     # helper (FxSwapHelper). The point parses into a valid FlatBuffer, then the
@@ -707,6 +755,20 @@ SCENARIOS = [
          _ec_equity_set_payoff("EquityCashOrNothingPayoff",
                                {"option_type": "Call", "strike": 100.0, "cash": 10.0})(req)),
      _ec_body_contains("Bermudan exercise is not supported for digital")),
+    # ---- 400 INVALID_ARGUMENT: swaption rebump requires market data ----
+    # Rebump snapshots are built in the mapper (before the registry's usual
+    # rates-presence guard); omitting pricing.rates used to crash the worker.
+    ("ec:400 swaption rebump without pricing.rates", "swaption",
+     "swaption_request.json", 400,
+     _ec_swaption_rebump_without_rates(),
+     _ec_body_contains("Swaption rebump pricing requires pricing.rates.curves")),
+    # ---- 200 OK: non-finite outputs are omitted, never serialized as `nan` ----
+    # A zero-notional basis swap collapses each leg BPS to 0, making the fair
+    # spread NaN. The response must stay valid JSON with the field omitted.
+    ("ec:200 basis_swap zero notional omits non-finite fair spread", "basis_swap",
+     "basis_swap_request.json", 200,
+     _ec_basis_swap_zero_notional(),
+     _ec_body_valid_json_without("fair_spread_leg1", "fair_spread_leg2")),
     # ---- 501 UNIMPLEMENTED: valid request, feature not built yet ----
     ("ec:501 swaption curve uses unimplemented helper", "swaption",
      "swaption_request.json", 501, _ec_unimplemented_curve_point()),

--- a/tests/parity/union_absent_value_test.cpp
+++ b/tests/parity/union_absent_value_test.cpp
@@ -1,0 +1,78 @@
+// Crafted FlatBuffers union with the type byte set but the value offset absent.
+//
+// FlatBuffers' verifier accepts a union whose type byte names a real member but
+// whose value offset is missing (the point:Point, point:InflationPoint and
+// payload:ModelPayload fields are not `(required)`). Downstream code then
+// dereferences the null table returned by the `*_as_*()` accessors and
+// SIGSEGVs the worker. These are hand-crafted buffers the JSON gateway cannot
+// produce, so they are exercised here directly at the C++ boundary: the code
+// must throw a QuantraError (mapped to a clean 400), never crash.
+#include <gtest/gtest.h>
+
+#include "curve_bootstrapper.h"
+#include "curve_cache_key.h"
+#include "error.h"
+
+namespace quantra {
+namespace testing {
+namespace {
+
+// Build a TermStructure whose single point carries a real helper TYPE byte
+// (DepositHelper) but a value offset of 0 (absent). Structurally this is what
+// the FlatBuffers verifier lets through.
+const quantra::TermStructure* buildTypeSetValueAbsentCurve(
+    flatbuffers::FlatBufferBuilder& fbb)
+{
+    auto pw = quantra::CreatePointsWrapper(
+        fbb, quantra::Point_DepositHelper, /*value offset absent*/ 0);
+    std::vector<flatbuffers::Offset<quantra::PointsWrapper>> pts{pw};
+    auto ts = quantra::CreateTermStructureDirect(
+        fbb, "curve-absent-union",
+        quantra::enums::DayCounter_Actual360,
+        quantra::enums::Interpolator_LogLinear,
+        quantra::enums::BootstrapTrait_Discount,
+        &pts, "2026-06-11");
+    fbb.Finish(ts);
+    return flatbuffers::GetRoot<quantra::TermStructure>(fbb.GetBufferPointer());
+}
+
+// The cache-key builder walks every point; serializePoint used to cast the
+// absent union value and crash. It must now throw instead.
+TEST(UnionAbsentValue, CurveCacheKeyRejectsAbsentUnionValue) {
+    flatbuffers::FlatBufferBuilder fbb;
+    const auto* ts = buildTypeSetValueAbsentCurve(fbb);
+
+    KeyContext ctx;
+    EXPECT_THROW(CurveKeyBuilder::compute("2026-06-11", ts, ctx, {}),
+                 QuantraError);
+}
+
+// The dependency collector (hit before the cache key on the bootstrap path)
+// static_casts the absent union value; it must throw instead of dereferencing
+// a null table.
+TEST(UnionAbsentValue, CurveBootstrapperRejectsAbsentUnionValue) {
+    flatbuffers::FlatBufferBuilder fbb;
+    // Use SwapHelper: collectDeps dereferences its ->deps() unconditionally.
+    auto pw = quantra::CreatePointsWrapper(
+        fbb, quantra::Point_SwapHelper, /*value offset absent*/ 0);
+    std::vector<flatbuffers::Offset<quantra::PointsWrapper>> pts{pw};
+    auto ts = quantra::CreateTermStructureDirect(
+        fbb, "curve-absent-swap",
+        quantra::enums::DayCounter_Actual360,
+        quantra::enums::Interpolator_LogLinear,
+        quantra::enums::BootstrapTrait_Discount,
+        &pts, "2026-06-11");
+    std::vector<flatbuffers::Offset<quantra::TermStructure>> curves{ts};
+    auto curvesVec = fbb.CreateVector(curves);
+    fbb.Finish(curvesVec);
+    const auto* curvesPtr =
+        flatbuffers::GetRoot<flatbuffers::Vector<
+            flatbuffers::Offset<quantra::TermStructure>>>(fbb.GetBufferPointer());
+
+    CurveBootstrapper bootstrapper;
+    EXPECT_THROW(bootstrapper.bootstrapAll(curvesPtr), QuantraError);
+}
+
+} // namespace
+} // namespace testing
+} // namespace quantra


### PR DESCRIPTION
**Three wire-reachable correctness defects** found by the code audit.

- **`/price-swaption` segfault**: requesting rebump greeks with no `pricing.rates` dereferenced the market data in the mapper before the registry guard ran. Now a 400 naming the requirement. (Same class as the previously-fixed omitted-date crash.)
- **Crafted-union null-deref**: a FlatBuffers buffer with a union type byte set but its value offset absent passed the verifier, then null-dereferenced in curve/inflation/model parsing (crash vector on the unauthenticated gRPC port). Every deref site now checks the absent value and raises a named error. The legitimate `Point_NONE` keyable state (type set, no payload) is preserved — guarded in code rather than forcing `(required)`, which would have broken that contract.
- **NaN in JSON**: fair rates/spreads and floating-leg fixings could be NaN (zero-notional swap, missing past fixing) and serialized as the bare token `nan` — invalid JSON on a 200. Non-finite response scalars are now omitted, matching the equity-greeks fix, propagated across **all** swap + CDS response mappers (not just the two that crash).

New crafted-union parity test (asserts throw, not segfault) + two error-contract scenarios (rebump-without-rates → 400; zero-notional basis swap → valid JSON with the field omitted). Full suite green (628 cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
