### PR TITLE
Require an explicit swap direction

### DIFF
--- a/flatbuffers/cpp/basis_swap_generated.h
+++ b/flatbuffers/cpp/basis_swap_generated.h
@@ -24,7 +24,7 @@ struct BasisSwapT;
 
 struct BasisSwapT : public ::flatbuffers::NativeTable {
   typedef BasisSwap TableType;
-  quantra::enums::SwapType swap_type = quantra::enums::SwapType_Payer;
+  ::flatbuffers::Optional<quantra::enums::SwapType> swap_type = ::flatbuffers::nullopt;
   std::unique_ptr<quantra::SwapFloatingLegT> leg1{};
   std::unique_ptr<quantra::SwapFloatingLegT> leg2{};
   BasisSwapT() = default;
@@ -42,8 +42,10 @@ struct BasisSwap FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
     VT_LEG1 = 6,
     VT_LEG2 = 8
   };
-  quantra::enums::SwapType swap_type() const {
-    return static_cast<quantra::enums::SwapType>(GetField<int8_t>(VT_SWAP_TYPE, 0));
+  /// Payer/receiver refer to leg1. Presence-required: an omitted type is a
+  /// 400, never the alphabetical-0 default (Payer).
+  ::flatbuffers::Optional<quantra::enums::SwapType> swap_type() const {
+    return GetOptional<int8_t, quantra::enums::SwapType>(VT_SWAP_TYPE);
   }
   const quantra::SwapFloatingLeg *leg1() const {
     return GetPointer<const quantra::SwapFloatingLeg *>(VT_LEG1);
@@ -70,7 +72,7 @@ struct BasisSwapBuilder {
   ::flatbuffers::FlatBufferBuilder &fbb_;
   ::flatbuffers::uoffset_t start_;
   void add_swap_type(quantra::enums::SwapType swap_type) {
-    fbb_.AddElement<int8_t>(BasisSwap::VT_SWAP_TYPE, static_cast<int8_t>(swap_type), 0);
+    fbb_.AddElement<int8_t>(BasisSwap::VT_SWAP_TYPE, static_cast<int8_t>(swap_type));
   }
   void add_leg1(::flatbuffers::Offset<quantra::SwapFloatingLeg> leg1) {
     fbb_.AddOffset(BasisSwap::VT_LEG1, leg1);
@@ -91,13 +93,13 @@ struct BasisSwapBuilder {
 
 inline ::flatbuffers::Offset<BasisSwap> CreateBasisSwap(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    quantra::enums::SwapType swap_type = quantra::enums::SwapType_Payer,
+    ::flatbuffers::Optional<quantra::enums::SwapType> swap_type = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::SwapFloatingLeg> leg1 = 0,
     ::flatbuffers::Offset<quantra::SwapFloatingLeg> leg2 = 0) {
   BasisSwapBuilder builder_(_fbb);
   builder_.add_leg2(leg2);
   builder_.add_leg1(leg1);
-  builder_.add_swap_type(swap_type);
+  if(swap_type) { builder_.add_swap_type(*swap_type); }
   return builder_.Finish();
 }
 

--- a/flatbuffers/cpp/ois_swap_generated.h
+++ b/flatbuffers/cpp/ois_swap_generated.h
@@ -225,7 +225,7 @@ inline ::flatbuffers::Offset<OisFloatingLeg> CreateOisFloatingLeg(
 
 struct OisSwapT : public ::flatbuffers::NativeTable {
   typedef OisSwap TableType;
-  quantra::enums::SwapType swap_type = quantra::enums::SwapType_Payer;
+  ::flatbuffers::Optional<quantra::enums::SwapType> swap_type = ::flatbuffers::nullopt;
   std::unique_ptr<quantra::SwapFixedLegT> fixed_leg{};
   std::unique_ptr<quantra::OisFloatingLegT> overnight_leg{};
   OisSwapT() = default;
@@ -243,8 +243,10 @@ struct OisSwap FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
     VT_FIXED_LEG = 6,
     VT_OVERNIGHT_LEG = 8
   };
-  quantra::enums::SwapType swap_type() const {
-    return static_cast<quantra::enums::SwapType>(GetField<int8_t>(VT_SWAP_TYPE, 0));
+  /// Payer/receiver refer to the fixed leg. Presence-required: an omitted
+  /// type is a 400, never the alphabetical-0 default (Payer).
+  ::flatbuffers::Optional<quantra::enums::SwapType> swap_type() const {
+    return GetOptional<int8_t, quantra::enums::SwapType>(VT_SWAP_TYPE);
   }
   const quantra::SwapFixedLeg *fixed_leg() const {
     return GetPointer<const quantra::SwapFixedLeg *>(VT_FIXED_LEG);
@@ -271,7 +273,7 @@ struct OisSwapBuilder {
   ::flatbuffers::FlatBufferBuilder &fbb_;
   ::flatbuffers::uoffset_t start_;
   void add_swap_type(quantra::enums::SwapType swap_type) {
-    fbb_.AddElement<int8_t>(OisSwap::VT_SWAP_TYPE, static_cast<int8_t>(swap_type), 0);
+    fbb_.AddElement<int8_t>(OisSwap::VT_SWAP_TYPE, static_cast<int8_t>(swap_type));
   }
   void add_fixed_leg(::flatbuffers::Offset<quantra::SwapFixedLeg> fixed_leg) {
     fbb_.AddOffset(OisSwap::VT_FIXED_LEG, fixed_leg);
@@ -292,13 +294,13 @@ struct OisSwapBuilder {
 
 inline ::flatbuffers::Offset<OisSwap> CreateOisSwap(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    quantra::enums::SwapType swap_type = quantra::enums::SwapType_Payer,
+    ::flatbuffers::Optional<quantra::enums::SwapType> swap_type = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::SwapFixedLeg> fixed_leg = 0,
     ::flatbuffers::Offset<quantra::OisFloatingLeg> overnight_leg = 0) {
   OisSwapBuilder builder_(_fbb);
   builder_.add_overnight_leg(overnight_leg);
   builder_.add_fixed_leg(fixed_leg);
-  builder_.add_swap_type(swap_type);
+  if(swap_type) { builder_.add_swap_type(*swap_type); }
   return builder_.Finish();
 }
 

--- a/flatbuffers/cpp/vanilla_swap_generated.h
+++ b/flatbuffers/cpp/vanilla_swap_generated.h
@@ -734,7 +734,7 @@ inline ::flatbuffers::Offset<SwapCmsLeg> CreateSwapCmsLegDirect(
 
 struct VanillaSwapT : public ::flatbuffers::NativeTable {
   typedef VanillaSwap TableType;
-  quantra::enums::SwapType swap_type = quantra::enums::SwapType_Payer;
+  ::flatbuffers::Optional<quantra::enums::SwapType> swap_type = ::flatbuffers::nullopt;
   std::unique_ptr<quantra::SwapFixedLegT> fixed_leg{};
   std::unique_ptr<quantra::SwapFloatingLegT> floating_leg{};
   std::unique_ptr<quantra::SwapCmsLegT> cms_leg{};
@@ -754,8 +754,10 @@ struct VanillaSwap FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
     VT_FLOATING_LEG = 8,
     VT_CMS_LEG = 10
   };
-  quantra::enums::SwapType swap_type() const {
-    return static_cast<quantra::enums::SwapType>(GetField<int8_t>(VT_SWAP_TYPE, 0));
+  /// Payer/receiver refer to the fixed leg. Presence-required: an omitted
+  /// type is a 400, never the alphabetical-0 default (Payer).
+  ::flatbuffers::Optional<quantra::enums::SwapType> swap_type() const {
+    return GetOptional<int8_t, quantra::enums::SwapType>(VT_SWAP_TYPE);
   }
   const quantra::SwapFixedLeg *fixed_leg() const {
     return GetPointer<const quantra::SwapFixedLeg *>(VT_FIXED_LEG);
@@ -790,7 +792,7 @@ struct VanillaSwapBuilder {
   ::flatbuffers::FlatBufferBuilder &fbb_;
   ::flatbuffers::uoffset_t start_;
   void add_swap_type(quantra::enums::SwapType swap_type) {
-    fbb_.AddElement<int8_t>(VanillaSwap::VT_SWAP_TYPE, static_cast<int8_t>(swap_type), 0);
+    fbb_.AddElement<int8_t>(VanillaSwap::VT_SWAP_TYPE, static_cast<int8_t>(swap_type));
   }
   void add_fixed_leg(::flatbuffers::Offset<quantra::SwapFixedLeg> fixed_leg) {
     fbb_.AddOffset(VanillaSwap::VT_FIXED_LEG, fixed_leg);
@@ -814,7 +816,7 @@ struct VanillaSwapBuilder {
 
 inline ::flatbuffers::Offset<VanillaSwap> CreateVanillaSwap(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    quantra::enums::SwapType swap_type = quantra::enums::SwapType_Payer,
+    ::flatbuffers::Optional<quantra::enums::SwapType> swap_type = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::SwapFixedLeg> fixed_leg = 0,
     ::flatbuffers::Offset<quantra::SwapFloatingLeg> floating_leg = 0,
     ::flatbuffers::Offset<quantra::SwapCmsLeg> cms_leg = 0) {
@@ -822,7 +824,7 @@ inline ::flatbuffers::Offset<VanillaSwap> CreateVanillaSwap(
   builder_.add_cms_leg(cms_leg);
   builder_.add_floating_leg(floating_leg);
   builder_.add_fixed_leg(fixed_leg);
-  builder_.add_swap_type(swap_type);
+  if(swap_type) { builder_.add_swap_type(*swap_type); }
   return builder_.Finish();
 }
 

--- a/flatbuffers/cpp/year_on_year_inflation_swap_generated.h
+++ b/flatbuffers/cpp/year_on_year_inflation_swap_generated.h
@@ -25,7 +25,7 @@ struct YearOnYearInflationSwapT;
 
 struct YearOnYearInflationSwapT : public ::flatbuffers::NativeTable {
   typedef YearOnYearInflationSwap TableType;
-  quantra::enums::SwapType swap_type = quantra::enums::SwapType_Payer;
+  ::flatbuffers::Optional<quantra::enums::SwapType> swap_type = ::flatbuffers::nullopt;
   double notional = 0.0;
   std::unique_ptr<quantra::ScheduleT> fixed_schedule{};
   double fixed_rate = 0.0;
@@ -65,8 +65,10 @@ struct YearOnYearInflationSwap FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::
   };
   /// "Payer" pays the fixed leg and receives the YoY inflation leg;
   /// "Receiver" is the reverse (receives fixed, pays YoY inflation).
-  quantra::enums::SwapType swap_type() const {
-    return static_cast<quantra::enums::SwapType>(GetField<int8_t>(VT_SWAP_TYPE, 0));
+  /// Presence-required: an omitted type is a 400, never the alphabetical-0
+  /// default (Payer).
+  ::flatbuffers::Optional<quantra::enums::SwapType> swap_type() const {
+    return GetOptional<int8_t, quantra::enums::SwapType>(VT_SWAP_TYPE);
   }
   double notional() const {
     return GetField<double>(VT_NOTIONAL, 0.0);
@@ -136,7 +138,7 @@ struct YearOnYearInflationSwapBuilder {
   ::flatbuffers::FlatBufferBuilder &fbb_;
   ::flatbuffers::uoffset_t start_;
   void add_swap_type(quantra::enums::SwapType swap_type) {
-    fbb_.AddElement<int8_t>(YearOnYearInflationSwap::VT_SWAP_TYPE, static_cast<int8_t>(swap_type), 0);
+    fbb_.AddElement<int8_t>(YearOnYearInflationSwap::VT_SWAP_TYPE, static_cast<int8_t>(swap_type));
   }
   void add_notional(double notional) {
     fbb_.AddElement<double>(YearOnYearInflationSwap::VT_NOTIONAL, notional, 0.0);
@@ -191,7 +193,7 @@ struct YearOnYearInflationSwapBuilder {
 
 inline ::flatbuffers::Offset<YearOnYearInflationSwap> CreateYearOnYearInflationSwap(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    quantra::enums::SwapType swap_type = quantra::enums::SwapType_Payer,
+    ::flatbuffers::Optional<quantra::enums::SwapType> swap_type = ::flatbuffers::nullopt,
     double notional = 0.0,
     ::flatbuffers::Offset<quantra::Schedule> fixed_schedule = 0,
     double fixed_rate = 0.0,
@@ -217,13 +219,13 @@ inline ::flatbuffers::Offset<YearOnYearInflationSwap> CreateYearOnYearInflationS
   builder_.add_yoy_day_counter(yoy_day_counter);
   builder_.add_observation_interpolation(observation_interpolation);
   builder_.add_fixed_day_counter(fixed_day_counter);
-  builder_.add_swap_type(swap_type);
+  if(swap_type) { builder_.add_swap_type(*swap_type); }
   return builder_.Finish();
 }
 
 inline ::flatbuffers::Offset<YearOnYearInflationSwap> CreateYearOnYearInflationSwapDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    quantra::enums::SwapType swap_type = quantra::enums::SwapType_Payer,
+    ::flatbuffers::Optional<quantra::enums::SwapType> swap_type = ::flatbuffers::nullopt,
     double notional = 0.0,
     ::flatbuffers::Offset<quantra::Schedule> fixed_schedule = 0,
     double fixed_rate = 0.0,

--- a/flatbuffers/cpp/zero_coupon_inflation_swap_generated.h
+++ b/flatbuffers/cpp/zero_coupon_inflation_swap_generated.h
@@ -24,7 +24,7 @@ struct ZeroCouponInflationSwapT;
 
 struct ZeroCouponInflationSwapT : public ::flatbuffers::NativeTable {
   typedef ZeroCouponInflationSwap TableType;
-  quantra::enums::SwapType swap_type = quantra::enums::SwapType_Payer;
+  ::flatbuffers::Optional<quantra::enums::SwapType> swap_type = ::flatbuffers::nullopt;
   double notional = 0.0;
   std::string start_date{};
   std::string maturity_date{};
@@ -64,9 +64,10 @@ struct ZeroCouponInflationSwap FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::
     VT_INFLATION_CALENDAR = 28,
     VT_INFLATION_CONVENTION = 30
   };
-  /// "Payer" / "Receiver" refers to the inflation leg.
-  quantra::enums::SwapType swap_type() const {
-    return static_cast<quantra::enums::SwapType>(GetField<int8_t>(VT_SWAP_TYPE, 0));
+  /// "Payer" / "Receiver" refers to the inflation leg. Presence-required: an
+  /// omitted type is a 400, never the alphabetical-0 default (Payer).
+  ::flatbuffers::Optional<quantra::enums::SwapType> swap_type() const {
+    return GetOptional<int8_t, quantra::enums::SwapType>(VT_SWAP_TYPE);
   }
   double notional() const {
     return GetField<double>(VT_NOTIONAL, 0.0);
@@ -145,7 +146,7 @@ struct ZeroCouponInflationSwapBuilder {
   ::flatbuffers::FlatBufferBuilder &fbb_;
   ::flatbuffers::uoffset_t start_;
   void add_swap_type(quantra::enums::SwapType swap_type) {
-    fbb_.AddElement<int8_t>(ZeroCouponInflationSwap::VT_SWAP_TYPE, static_cast<int8_t>(swap_type), 0);
+    fbb_.AddElement<int8_t>(ZeroCouponInflationSwap::VT_SWAP_TYPE, static_cast<int8_t>(swap_type));
   }
   void add_notional(double notional) {
     fbb_.AddElement<double>(ZeroCouponInflationSwap::VT_NOTIONAL, notional, 0.0);
@@ -203,7 +204,7 @@ struct ZeroCouponInflationSwapBuilder {
 
 inline ::flatbuffers::Offset<ZeroCouponInflationSwap> CreateZeroCouponInflationSwap(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    quantra::enums::SwapType swap_type = quantra::enums::SwapType_Payer,
+    ::flatbuffers::Optional<quantra::enums::SwapType> swap_type = ::flatbuffers::nullopt,
     double notional = 0.0,
     ::flatbuffers::Offset<::flatbuffers::String> start_date = 0,
     ::flatbuffers::Offset<::flatbuffers::String> maturity_date = 0,
@@ -231,13 +232,13 @@ inline ::flatbuffers::Offset<ZeroCouponInflationSwap> CreateZeroCouponInflationS
   builder_.add_day_counter(day_counter);
   builder_.add_fixed_convention(fixed_convention);
   builder_.add_fixed_calendar(fixed_calendar);
-  builder_.add_swap_type(swap_type);
+  if(swap_type) { builder_.add_swap_type(*swap_type); }
   return builder_.Finish();
 }
 
 inline ::flatbuffers::Offset<ZeroCouponInflationSwap> CreateZeroCouponInflationSwapDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    quantra::enums::SwapType swap_type = quantra::enums::SwapType_Payer,
+    ::flatbuffers::Optional<quantra::enums::SwapType> swap_type = ::flatbuffers::nullopt,
     double notional = 0.0,
     const char *start_date = nullptr,
     const char *maturity_date = nullptr,

--- a/flatbuffers/fbs/basis_swap.fbs
+++ b/flatbuffers/fbs/basis_swap.fbs
@@ -5,7 +5,9 @@ namespace quantra;
 
 /// Basis swap with two floating legs (e.g., 3M vs 6M).
 table BasisSwap {
-    swap_type:enums.SwapType;
+    /// Payer/receiver refer to leg1. Presence-required: an omitted type is a
+    /// 400, never the alphabetical-0 default (Payer).
+    swap_type:enums.SwapType = null;
     leg1:SwapFloatingLeg;
     leg2:SwapFloatingLeg;
 }

--- a/flatbuffers/fbs/ois_swap.fbs
+++ b/flatbuffers/fbs/ois_swap.fbs
@@ -27,7 +27,9 @@ table OisFloatingLeg {
 
 /// Overnight indexed swap: fixed vs compounded overnight.
 table OisSwap {
-    swap_type:enums.SwapType;
+    /// Payer/receiver refer to the fixed leg. Presence-required: an omitted
+    /// type is a 400, never the alphabetical-0 default (Payer).
+    swap_type:enums.SwapType = null;
     fixed_leg:SwapFixedLeg;
     overnight_leg:OisFloatingLeg;
 }

--- a/flatbuffers/fbs/vanilla_swap.fbs
+++ b/flatbuffers/fbs/vanilla_swap.fbs
@@ -93,7 +93,9 @@ table SwapCmsLeg {
 
 /// Vanilla interest rate swap (fixed vs floating).
 table VanillaSwap {
-    swap_type:enums.SwapType;
+    /// Payer/receiver refer to the fixed leg. Presence-required: an omitted
+    /// type is a 400, never the alphabetical-0 default (Payer).
+    swap_type:enums.SwapType = null;
     fixed_leg:SwapFixedLeg;
     /// Standard IBOR floating leg path.
     floating_leg:SwapFloatingLeg;

--- a/flatbuffers/fbs/year_on_year_inflation_swap.fbs
+++ b/flatbuffers/fbs/year_on_year_inflation_swap.fbs
@@ -8,7 +8,9 @@ namespace quantra;
 table YearOnYearInflationSwap {
     /// "Payer" pays the fixed leg and receives the YoY inflation leg;
     /// "Receiver" is the reverse (receives fixed, pays YoY inflation).
-    swap_type:enums.SwapType;
+    /// Presence-required: an omitted type is a 400, never the alphabetical-0
+    /// default (Payer).
+    swap_type:enums.SwapType = null;
     notional:double;
     fixed_schedule:Schedule (required);
     fixed_rate:double;

--- a/flatbuffers/fbs/zero_coupon_inflation_swap.fbs
+++ b/flatbuffers/fbs/zero_coupon_inflation_swap.fbs
@@ -5,8 +5,9 @@ namespace quantra;
 
 /// Standard zero-coupon inflation swap (ZCIIS).
 table ZeroCouponInflationSwap {
-    /// "Payer" / "Receiver" refers to the inflation leg.
-    swap_type:enums.SwapType;
+    /// "Payer" / "Receiver" refers to the inflation leg. Presence-required: an
+    /// omitted type is a 400, never the alphabetical-0 default (Payer).
+    swap_type:enums.SwapType = null;
     notional:double;
     start_date:string (required);
     /// Contract maturity date before any internal observation adjustment.

--- a/flatbuffers/json/basis_swap.schema.json
+++ b/flatbuffers/json/basis_swap.schema.json
@@ -581,7 +581,8 @@
       "description" : "Vanilla interest rate swap (fixed vs floating).",
       "properties" : {
         "swap_type" : {
-                "$ref" : "#/definitions/quantra_enums_SwapType"
+                "$ref" : "#/definitions/quantra_enums_SwapType",
+                "description" : "Payer/receiver refer to the fixed leg. Presence-required: an omitted\ntype is a 400, never the alphabetical-0 default (Payer)."
               },
         "fixed_leg" : {
                 "$ref" : "#/definitions/quantra_SwapFixedLeg"
@@ -602,7 +603,8 @@
       "description" : "Basis swap with two floating legs (e.g., 3M vs 6M).",
       "properties" : {
         "swap_type" : {
-                "$ref" : "#/definitions/quantra_enums_SwapType"
+                "$ref" : "#/definitions/quantra_enums_SwapType",
+                "description" : "Payer/receiver refer to leg1. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (Payer)."
               },
         "leg1" : {
                 "$ref" : "#/definitions/quantra_SwapFloatingLeg"

--- a/flatbuffers/json/price_basis_swap_request.schema.json
+++ b/flatbuffers/json/price_basis_swap_request.schema.json
@@ -2420,7 +2420,8 @@
       "description" : "Vanilla interest rate swap (fixed vs floating).",
       "properties" : {
         "swap_type" : {
-                "$ref" : "#/definitions/quantra_enums_SwapType"
+                "$ref" : "#/definitions/quantra_enums_SwapType",
+                "description" : "Payer/receiver refer to the fixed leg. Presence-required: an omitted\ntype is a 400, never the alphabetical-0 default (Payer)."
               },
         "fixed_leg" : {
                 "$ref" : "#/definitions/quantra_SwapFixedLeg"
@@ -2441,7 +2442,8 @@
       "description" : "Basis swap with two floating legs (e.g., 3M vs 6M).",
       "properties" : {
         "swap_type" : {
-                "$ref" : "#/definitions/quantra_enums_SwapType"
+                "$ref" : "#/definitions/quantra_enums_SwapType",
+                "description" : "Payer/receiver refer to leg1. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (Payer)."
               },
         "leg1" : {
                 "$ref" : "#/definitions/quantra_SwapFloatingLeg"

--- a/flatbuffers/json/price_ois_swap_request.schema.json
+++ b/flatbuffers/json/price_ois_swap_request.schema.json
@@ -2420,7 +2420,8 @@
       "description" : "Vanilla interest rate swap (fixed vs floating).",
       "properties" : {
         "swap_type" : {
-                "$ref" : "#/definitions/quantra_enums_SwapType"
+                "$ref" : "#/definitions/quantra_enums_SwapType",
+                "description" : "Payer/receiver refer to the fixed leg. Presence-required: an omitted\ntype is a 400, never the alphabetical-0 default (Payer)."
               },
         "fixed_leg" : {
                 "$ref" : "#/definitions/quantra_SwapFixedLeg"
@@ -2491,7 +2492,8 @@
       "description" : "Overnight indexed swap: fixed vs compounded overnight.",
       "properties" : {
         "swap_type" : {
-                "$ref" : "#/definitions/quantra_enums_SwapType"
+                "$ref" : "#/definitions/quantra_enums_SwapType",
+                "description" : "Payer/receiver refer to the fixed leg. Presence-required: an omitted\ntype is a 400, never the alphabetical-0 default (Payer)."
               },
         "fixed_leg" : {
                 "$ref" : "#/definitions/quantra_SwapFixedLeg"

--- a/flatbuffers/json/price_swaption_request.schema.json
+++ b/flatbuffers/json/price_swaption_request.schema.json
@@ -2424,7 +2424,8 @@
       "description" : "Vanilla interest rate swap (fixed vs floating).",
       "properties" : {
         "swap_type" : {
-                "$ref" : "#/definitions/quantra_enums_SwapType"
+                "$ref" : "#/definitions/quantra_enums_SwapType",
+                "description" : "Payer/receiver refer to the fixed leg. Presence-required: an omitted\ntype is a 400, never the alphabetical-0 default (Payer)."
               },
         "fixed_leg" : {
                 "$ref" : "#/definitions/quantra_SwapFixedLeg"
@@ -2495,7 +2496,8 @@
       "description" : "Overnight indexed swap: fixed vs compounded overnight.",
       "properties" : {
         "swap_type" : {
-                "$ref" : "#/definitions/quantra_enums_SwapType"
+                "$ref" : "#/definitions/quantra_enums_SwapType",
+                "description" : "Payer/receiver refer to the fixed leg. Presence-required: an omitted\ntype is a 400, never the alphabetical-0 default (Payer)."
               },
         "fixed_leg" : {
                 "$ref" : "#/definitions/quantra_SwapFixedLeg"

--- a/flatbuffers/json/price_vanilla_swap_request.schema.json
+++ b/flatbuffers/json/price_vanilla_swap_request.schema.json
@@ -2420,7 +2420,8 @@
       "description" : "Vanilla interest rate swap (fixed vs floating).",
       "properties" : {
         "swap_type" : {
-                "$ref" : "#/definitions/quantra_enums_SwapType"
+                "$ref" : "#/definitions/quantra_enums_SwapType",
+                "description" : "Payer/receiver refer to the fixed leg. Presence-required: an omitted\ntype is a 400, never the alphabetical-0 default (Payer)."
               },
         "fixed_leg" : {
                 "$ref" : "#/definitions/quantra_SwapFixedLeg"

--- a/flatbuffers/json/price_year_on_year_inflation_swap_request.schema.json
+++ b/flatbuffers/json/price_year_on_year_inflation_swap_request.schema.json
@@ -2263,7 +2263,7 @@
       "properties" : {
         "swap_type" : {
                 "$ref" : "#/definitions/quantra_enums_SwapType",
-                "description" : "\"Payer\" pays the fixed leg and receives the YoY inflation leg;\n\"Receiver\" is the reverse (receives fixed, pays YoY inflation)."
+                "description" : "\"Payer\" pays the fixed leg and receives the YoY inflation leg;\n\"Receiver\" is the reverse (receives fixed, pays YoY inflation).\nPresence-required: an omitted type is a 400, never the alphabetical-0\ndefault (Payer)."
               },
         "notional" : {
                 "type" : "number"

--- a/flatbuffers/json/price_zero_coupon_inflation_swap_request.schema.json
+++ b/flatbuffers/json/price_zero_coupon_inflation_swap_request.schema.json
@@ -2263,7 +2263,7 @@
       "properties" : {
         "swap_type" : {
                 "$ref" : "#/definitions/quantra_enums_SwapType",
-                "description" : "\"Payer\" / \"Receiver\" refers to the inflation leg."
+                "description" : "\"Payer\" / \"Receiver\" refers to the inflation leg. Presence-required: an\nomitted type is a 400, never the alphabetical-0 default (Payer)."
               },
         "notional" : {
                 "type" : "number"

--- a/flatbuffers/json/swaption.schema.json
+++ b/flatbuffers/json/swaption.schema.json
@@ -585,7 +585,8 @@
       "description" : "Vanilla interest rate swap (fixed vs floating).",
       "properties" : {
         "swap_type" : {
-                "$ref" : "#/definitions/quantra_enums_SwapType"
+                "$ref" : "#/definitions/quantra_enums_SwapType",
+                "description" : "Payer/receiver refer to the fixed leg. Presence-required: an omitted\ntype is a 400, never the alphabetical-0 default (Payer)."
               },
         "fixed_leg" : {
                 "$ref" : "#/definitions/quantra_SwapFixedLeg"
@@ -656,7 +657,8 @@
       "description" : "Overnight indexed swap: fixed vs compounded overnight.",
       "properties" : {
         "swap_type" : {
-                "$ref" : "#/definitions/quantra_enums_SwapType"
+                "$ref" : "#/definitions/quantra_enums_SwapType",
+                "description" : "Payer/receiver refer to the fixed leg. Presence-required: an omitted\ntype is a 400, never the alphabetical-0 default (Payer)."
               },
         "fixed_leg" : {
                 "$ref" : "#/definitions/quantra_SwapFixedLeg"

--- a/flatbuffers/json/vanilla_swap.schema.json
+++ b/flatbuffers/json/vanilla_swap.schema.json
@@ -581,7 +581,8 @@
       "description" : "Vanilla interest rate swap (fixed vs floating).",
       "properties" : {
         "swap_type" : {
-                "$ref" : "#/definitions/quantra_enums_SwapType"
+                "$ref" : "#/definitions/quantra_enums_SwapType",
+                "description" : "Payer/receiver refer to the fixed leg. Presence-required: an omitted\ntype is a 400, never the alphabetical-0 default (Payer)."
               },
         "fixed_leg" : {
                 "$ref" : "#/definitions/quantra_SwapFixedLeg"

--- a/flatbuffers/json/year_on_year_inflation_swap.schema.json
+++ b/flatbuffers/json/year_on_year_inflation_swap.schema.json
@@ -631,7 +631,7 @@
       "properties" : {
         "swap_type" : {
                 "$ref" : "#/definitions/quantra_enums_SwapType",
-                "description" : "\"Payer\" pays the fixed leg and receives the YoY inflation leg;\n\"Receiver\" is the reverse (receives fixed, pays YoY inflation)."
+                "description" : "\"Payer\" pays the fixed leg and receives the YoY inflation leg;\n\"Receiver\" is the reverse (receives fixed, pays YoY inflation).\nPresence-required: an omitted type is a 400, never the alphabetical-0\ndefault (Payer)."
               },
         "notional" : {
                 "type" : "number"

--- a/flatbuffers/json/zero_coupon_inflation_swap.schema.json
+++ b/flatbuffers/json/zero_coupon_inflation_swap.schema.json
@@ -631,7 +631,7 @@
       "properties" : {
         "swap_type" : {
                 "$ref" : "#/definitions/quantra_enums_SwapType",
-                "description" : "\"Payer\" / \"Receiver\" refers to the inflation leg."
+                "description" : "\"Payer\" / \"Receiver\" refers to the inflation leg. Presence-required: an\nomitted type is a 400, never the alphabetical-0 default (Payer)."
               },
         "notional" : {
                 "type" : "number"

--- a/flatbuffers/python/quantra/BasisSwap.py
+++ b/flatbuffers/python/quantra/BasisSwap.py
@@ -25,12 +25,14 @@ class BasisSwap(object):
     def Init(self, buf, pos):
         self._tab = flatbuffers.table.Table(buf, pos)
 
+    # Payer/receiver refer to leg1. Presence-required: an omitted type is a
+    # 400, never the alphabetical-0 default (Payer).
     # BasisSwap
     def SwapType(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # BasisSwap
     def Leg1(self):
@@ -60,7 +62,7 @@ def Start(builder):
     BasisSwapStart(builder)
 
 def BasisSwapAddSwapType(builder, swapType):
-    builder.PrependInt8Slot(0, swapType, 0)
+    builder.PrependInt8Slot(0, swapType, None)
 
 def AddSwapType(builder, swapType):
     BasisSwapAddSwapType(builder, swapType)
@@ -92,7 +94,7 @@ class BasisSwapT(object):
 
     # BasisSwapT
     def __init__(self):
-        self.swapType = 0  # type: int
+        self.swapType = None  # type: Optional[int]
         self.leg1 = None  # type: Optional[SwapFloatingLegT]
         self.leg2 = None  # type: Optional[SwapFloatingLegT]
 

--- a/flatbuffers/python/quantra/OisSwap.py
+++ b/flatbuffers/python/quantra/OisSwap.py
@@ -25,12 +25,14 @@ class OisSwap(object):
     def Init(self, buf, pos):
         self._tab = flatbuffers.table.Table(buf, pos)
 
+    # Payer/receiver refer to the fixed leg. Presence-required: an omitted
+    # type is a 400, never the alphabetical-0 default (Payer).
     # OisSwap
     def SwapType(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # OisSwap
     def FixedLeg(self):
@@ -61,7 +63,7 @@ def Start(builder):
     OisSwapStart(builder)
 
 def OisSwapAddSwapType(builder, swapType):
-    builder.PrependInt8Slot(0, swapType, 0)
+    builder.PrependInt8Slot(0, swapType, None)
 
 def AddSwapType(builder, swapType):
     OisSwapAddSwapType(builder, swapType)
@@ -93,7 +95,7 @@ class OisSwapT(object):
 
     # OisSwapT
     def __init__(self):
-        self.swapType = 0  # type: int
+        self.swapType = None  # type: Optional[int]
         self.fixedLeg = None  # type: Optional[SwapFixedLegT]
         self.overnightLeg = None  # type: Optional[OisFloatingLegT]
 

--- a/flatbuffers/python/quantra/VanillaSwap.py
+++ b/flatbuffers/python/quantra/VanillaSwap.py
@@ -25,12 +25,14 @@ class VanillaSwap(object):
     def Init(self, buf, pos):
         self._tab = flatbuffers.table.Table(buf, pos)
 
+    # Payer/receiver refer to the fixed leg. Presence-required: an omitted
+    # type is a 400, never the alphabetical-0 default (Payer).
     # VanillaSwap
     def SwapType(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # VanillaSwap
     def FixedLeg(self):
@@ -75,7 +77,7 @@ def Start(builder):
     VanillaSwapStart(builder)
 
 def VanillaSwapAddSwapType(builder, swapType):
-    builder.PrependInt8Slot(0, swapType, 0)
+    builder.PrependInt8Slot(0, swapType, None)
 
 def AddSwapType(builder, swapType):
     VanillaSwapAddSwapType(builder, swapType)
@@ -113,7 +115,7 @@ class VanillaSwapT(object):
 
     # VanillaSwapT
     def __init__(self):
-        self.swapType = 0  # type: int
+        self.swapType = None  # type: Optional[int]
         self.fixedLeg = None  # type: Optional[SwapFixedLegT]
         self.floatingLeg = None  # type: Optional[SwapFloatingLegT]
         self.cmsLeg = None  # type: Optional[SwapCmsLegT]

--- a/flatbuffers/python/quantra/YearOnYearInflationSwap.py
+++ b/flatbuffers/python/quantra/YearOnYearInflationSwap.py
@@ -27,12 +27,14 @@ class YearOnYearInflationSwap(object):
 
     # "Payer" pays the fixed leg and receives the YoY inflation leg;
     # "Receiver" is the reverse (receives fixed, pays YoY inflation).
+    # Presence-required: an omitted type is a 400, never the alphabetical-0
+    # default (Payer).
     # YearOnYearInflationSwap
     def SwapType(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # YearOnYearInflationSwap
     def Notional(self):
@@ -137,7 +139,7 @@ def Start(builder):
     YearOnYearInflationSwapStart(builder)
 
 def YearOnYearInflationSwapAddSwapType(builder, swapType):
-    builder.PrependInt8Slot(0, swapType, 0)
+    builder.PrependInt8Slot(0, swapType, None)
 
 def AddSwapType(builder, swapType):
     YearOnYearInflationSwapAddSwapType(builder, swapType)
@@ -229,7 +231,7 @@ class YearOnYearInflationSwapT(object):
 
     # YearOnYearInflationSwapT
     def __init__(self):
-        self.swapType = 0  # type: int
+        self.swapType = None  # type: Optional[int]
         self.notional = 0.0  # type: float
         self.fixedSchedule = None  # type: Optional[ScheduleT]
         self.fixedRate = 0.0  # type: float

--- a/flatbuffers/python/quantra/ZeroCouponInflationSwap.py
+++ b/flatbuffers/python/quantra/ZeroCouponInflationSwap.py
@@ -25,13 +25,14 @@ class ZeroCouponInflationSwap(object):
     def Init(self, buf, pos):
         self._tab = flatbuffers.table.Table(buf, pos)
 
-    # "Payer" / "Receiver" refers to the inflation leg.
+    # "Payer" / "Receiver" refers to the inflation leg. Presence-required: an
+    # omitted type is a 400, never the alphabetical-0 default (Payer).
     # ZeroCouponInflationSwap
     def SwapType(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # ZeroCouponInflationSwap
     def Notional(self):
@@ -141,7 +142,7 @@ def Start(builder):
     ZeroCouponInflationSwapStart(builder)
 
 def ZeroCouponInflationSwapAddSwapType(builder, swapType):
-    builder.PrependInt8Slot(0, swapType, 0)
+    builder.PrependInt8Slot(0, swapType, None)
 
 def AddSwapType(builder, swapType):
     ZeroCouponInflationSwapAddSwapType(builder, swapType)
@@ -239,7 +240,7 @@ class ZeroCouponInflationSwapT(object):
 
     # ZeroCouponInflationSwapT
     def __init__(self):
-        self.swapType = 0  # type: int
+        self.swapType = None  # type: Optional[int]
         self.notional = 0.0  # type: float
         self.startDate = None  # type: str
         self.maturityDate = None  # type: str

--- a/src/common/enum_convert.cpp
+++ b/src/common/enum_convert.cpp
@@ -344,7 +344,7 @@ QuantLib::VanillaSwap::Type SwapTypeToQL(const quantra::enums::SwapType swapType
         return QuantLib::VanillaSwap::Receiver;
     }
 
-    QUANTRA_ERROR("Swap type not found");
+    QUANTRA_ERROR("swap_type is not a known swap type: " + std::to_string(static_cast<int>(swapType)));
 }
 
 QuantLib::OvernightIndexedSwap::Type OvernightIndexedSwapTypeToQL(
@@ -358,7 +358,7 @@ QuantLib::OvernightIndexedSwap::Type OvernightIndexedSwapTypeToQL(
         return QuantLib::OvernightIndexedSwap::Receiver;
     }
 
-    QUANTRA_ERROR("Overnight indexed swap type not found");
+    QUANTRA_ERROR("swap_type is not a known overnight indexed swap type: " + std::to_string(static_cast<int>(swapType)));
 }
 
 QuantLib::ZeroCouponSwap::Type ZeroCouponSwapTypeToQL(
@@ -372,7 +372,7 @@ QuantLib::ZeroCouponSwap::Type ZeroCouponSwapTypeToQL(
         return QuantLib::ZeroCouponSwap::Receiver;
     }
 
-    QUANTRA_ERROR("Zero coupon swap type not found");
+    QUANTRA_ERROR("swap_type is not a known zero coupon swap type: " + std::to_string(static_cast<int>(swapType)));
 }
 
 QuantLib::ZeroCouponInflationSwap::Type ZeroCouponInflationSwapTypeToQL(
@@ -386,7 +386,7 @@ QuantLib::ZeroCouponInflationSwap::Type ZeroCouponInflationSwapTypeToQL(
         return QuantLib::ZeroCouponInflationSwap::Receiver;
     }
 
-    QUANTRA_ERROR("Zero coupon inflation swap type not found");
+    QUANTRA_ERROR("swap_type is not a known zero coupon inflation swap type: " + std::to_string(static_cast<int>(swapType)));
 }
 
 QuantLib::YearOnYearInflationSwap::Type YearOnYearInflationSwapTypeToQL(
@@ -400,7 +400,7 @@ QuantLib::YearOnYearInflationSwap::Type YearOnYearInflationSwapTypeToQL(
         return QuantLib::YearOnYearInflationSwap::Receiver;
     }
 
-    QUANTRA_ERROR("Year-on-year inflation swap type not found");
+    QUANTRA_ERROR("swap_type is not a known year-on-year inflation swap type: " + std::to_string(static_cast<int>(swapType)));
 }
 
 QuantLib::CPI::InterpolationType CPIInterpolationToQL(

--- a/src/mappers/basis_swap_mapper.cpp
+++ b/src/mappers/basis_swap_mapper.cpp
@@ -55,6 +55,9 @@ BasisSwapTrade extractTrade(const quantra::PriceBasisSwap* pricing) {
     }
 
     const auto* swap = pricing->basis_swap();
+    if (!swap->swap_type().has_value()) {
+        QUANTRA_INVALID_ARGUMENT("BasisSwap.swap_type is required");
+    }
     if (!swap->leg1()) {
         QUANTRA_INVALID_ARGUMENT("BasisSwap.leg1 is required");
     }
@@ -81,7 +84,7 @@ BasisSwapTrade extractTrade(const quantra::PriceBasisSwap* pricing) {
     ScheduleParser scheduleParser;
 
     BasisSwapTrade trade;
-    trade.swapType = SwapTypeToQL(swap->swap_type());
+    trade.swapType = SwapTypeToQL(swap->swap_type().value());
     trade.discountingCurveId = pricing->discounting_curve()->str();
     trade.forwardingCurveLeg1Id = pricing->forwarding_curve_leg1()->str();
     trade.forwardingCurveLeg2Id = pricing->forwarding_curve_leg2()->str();

--- a/src/mappers/ois_swap_mapper.cpp
+++ b/src/mappers/ois_swap_mapper.cpp
@@ -26,6 +26,9 @@ OisSwapTrade extractTrade(const quantra::PriceOisSwap* pricing) {
     }
 
     const auto* swap = pricing->ois_swap();
+    if (!swap->swap_type().has_value()) {
+        QUANTRA_INVALID_ARGUMENT("OisSwap.swap_type is required");
+    }
     if (!swap->fixed_leg()) {
         QUANTRA_INVALID_ARGUMENT("OisSwap.fixed_leg is required");
     }
@@ -54,7 +57,7 @@ OisSwapTrade extractTrade(const quantra::PriceOisSwap* pricing) {
     ScheduleParser scheduleParser;
 
     OisSwapTrade trade;
-    trade.swapType = OvernightIndexedSwapTypeToQL(swap->swap_type());
+    trade.swapType = OvernightIndexedSwapTypeToQL(swap->swap_type().value());
     trade.discountingCurveId = pricing->discounting_curve()->str();
     trade.forwardingCurveId = pricing->forwarding_curve()->str();
 

--- a/src/mappers/swaption_mapper.cpp
+++ b/src/mappers/swaption_mapper.cpp
@@ -79,9 +79,12 @@ VanillaSwapTrade extractVanillaUnderlying(const quantra::VanillaSwap* swap) {
     if (swap->floating_leg() == nullptr)
         QUANTRA_INVALID_ARGUMENT("VanillaSwap floating_leg not found");
 
+    if (!swap->swap_type().has_value())
+        QUANTRA_INVALID_ARGUMENT("VanillaSwap.swap_type is required");
+
     VanillaSwapTrade trade;
     trade.branch = VanillaSwapTrade::Branch::Ibor;
-    switch (swap->swap_type()) {
+    switch (swap->swap_type().value()) {
         case quantra::enums::SwapType_Payer:
             trade.swapType = QuantLib::VanillaSwap::Payer;
             break;
@@ -89,7 +92,9 @@ VanillaSwapTrade extractVanillaUnderlying(const quantra::VanillaSwap* swap) {
             trade.swapType = QuantLib::VanillaSwap::Receiver;
             break;
         default:
-            QUANTRA_INVALID_ARGUMENT("Invalid swap type");
+            QUANTRA_INVALID_ARGUMENT(
+                "VanillaSwap.swap_type is not a known swap type: " +
+                std::to_string(static_cast<int>(swap->swap_type().value())));
     }
 
     ScheduleParser scheduleParser;
@@ -134,8 +139,11 @@ OisSwapTrade extractOisUnderlying(const quantra::OisSwap* swap) {
     if (swap->overnight_leg() == nullptr)
         QUANTRA_INVALID_ARGUMENT("OisSwap overnight_leg not found");
 
+    if (!swap->swap_type().has_value())
+        QUANTRA_INVALID_ARGUMENT("OisSwap.swap_type is required");
+
     OisSwapTrade trade;
-    switch (swap->swap_type()) {
+    switch (swap->swap_type().value()) {
         case quantra::enums::SwapType_Payer:
             trade.swapType = QuantLib::OvernightIndexedSwap::Payer;
             break;
@@ -143,7 +151,9 @@ OisSwapTrade extractOisUnderlying(const quantra::OisSwap* swap) {
             trade.swapType = QuantLib::OvernightIndexedSwap::Receiver;
             break;
         default:
-            QUANTRA_INVALID_ARGUMENT("Invalid swap type");
+            QUANTRA_INVALID_ARGUMENT(
+                "OisSwap.swap_type is not a known swap type: " +
+                std::to_string(static_cast<int>(swap->swap_type().value())));
     }
 
     ScheduleParser scheduleParser;

--- a/src/mappers/vanilla_swap_mapper.cpp
+++ b/src/mappers/vanilla_swap_mapper.cpp
@@ -42,6 +42,9 @@ VanillaSwapTrade extractTrade(const quantra::PriceVanillaSwap* pricing) {
     }
 
     const auto* swap = pricing->vanilla_swap();
+    if (!swap->swap_type().has_value()) {
+        QUANTRA_INVALID_ARGUMENT("VanillaSwap.swap_type is required");
+    }
     if (!swap->fixed_leg()) {
         QUANTRA_INVALID_ARGUMENT("VanillaSwap.fixed_leg is required");
     }
@@ -66,7 +69,7 @@ VanillaSwapTrade extractTrade(const quantra::PriceVanillaSwap* pricing) {
     ScheduleParser scheduleParser;
 
     VanillaSwapTrade trade;
-    trade.swapType = SwapTypeToQL(swap->swap_type());
+    trade.swapType = SwapTypeToQL(swap->swap_type().value());
     trade.discountingCurveId = pricing->discounting_curve()->str();
     trade.forwardingCurveId = pricing->forwarding_curve()->str();
 

--- a/src/mappers/year_on_year_inflation_swap_mapper.cpp
+++ b/src/mappers/year_on_year_inflation_swap_mapper.cpp
@@ -29,6 +29,9 @@ YearOnYearInflationSwapTrade extractTrade(const quantra::PriceYearOnYearInflatio
     }
 
     const auto* swap = pricing->year_on_year_inflation_swap();
+    if (!swap->swap_type().has_value()) {
+        QUANTRA_INVALID_ARGUMENT("YearOnYearInflationSwap.swap_type is required");
+    }
     if (!swap->fixed_schedule()) {
         QUANTRA_INVALID_ARGUMENT("YearOnYearInflationSwap fixed_schedule not found");
     }
@@ -48,7 +51,7 @@ YearOnYearInflationSwapTrade extractTrade(const quantra::PriceYearOnYearInflatio
     auto yoySchedule = scheduleParser.parse(swap->yoy_schedule());
 
     YearOnYearInflationSwapTrade trade;
-    trade.swapType = YearOnYearInflationSwapTypeToQL(swap->swap_type());
+    trade.swapType = YearOnYearInflationSwapTypeToQL(swap->swap_type().value());
     trade.notional = swap->notional();
     trade.fixedSchedule = *fixedSchedule;
     trade.fixedRate = swap->fixed_rate();

--- a/src/mappers/zero_coupon_inflation_swap_mapper.cpp
+++ b/src/mappers/zero_coupon_inflation_swap_mapper.cpp
@@ -28,6 +28,9 @@ ZeroCouponInflationSwapTrade extractTrade(const quantra::PriceZeroCouponInflatio
     }
 
     const auto* swap = pricing->zero_coupon_inflation_swap();
+    if (!swap->swap_type().has_value()) {
+        QUANTRA_INVALID_ARGUMENT("ZeroCouponInflationSwap.swap_type is required");
+    }
     if (!swap->start_date()) {
         QUANTRA_INVALID_ARGUMENT("ZeroCouponInflationSwap start_date not found");
     }
@@ -43,7 +46,7 @@ ZeroCouponInflationSwapTrade extractTrade(const quantra::PriceZeroCouponInflatio
     }
 
     ZeroCouponInflationSwapTrade trade;
-    trade.swapType = ZeroCouponInflationSwapTypeToQL(swap->swap_type());
+    trade.swapType = ZeroCouponInflationSwapTypeToQL(swap->swap_type().value());
     trade.notional = swap->notional();
     trade.startDate = DateToQL(swap->start_date()->str());
     trade.maturityDate = DateToQL(swap->maturity_date()->str());

--- a/src/parsers/ois_swap_parser.cpp
+++ b/src/parsers/ois_swap_parser.cpp
@@ -12,9 +12,11 @@ std::shared_ptr<QuantLib::OvernightIndexedSwap> OisSwapParser::parse(
 
     if (swap->overnight_leg() == NULL)
         QUANTRA_INVALID_ARGUMENT("OisSwap overnight_leg not found");
+    if (!swap->swap_type().has_value())
+        QUANTRA_INVALID_ARGUMENT("OisSwap.swap_type is required");
 
     QuantLib::OvernightIndexedSwap::Type swapType;
-    switch (swap->swap_type()) {
+    switch (swap->swap_type().value()) {
         case quantra::enums::SwapType_Payer:
             swapType = QuantLib::OvernightIndexedSwap::Payer;
             break;
@@ -22,7 +24,9 @@ std::shared_ptr<QuantLib::OvernightIndexedSwap> OisSwapParser::parse(
             swapType = QuantLib::OvernightIndexedSwap::Receiver;
             break;
         default:
-            QUANTRA_INVALID_ARGUMENT("Invalid swap type");
+            QUANTRA_INVALID_ARGUMENT(
+                "OisSwap.swap_type is not a known swap type: " +
+                std::to_string(static_cast<int>(swap->swap_type().value())));
     }
 
     ScheduleParser scheduleParser;

--- a/src/parsers/vanilla_swap_parser.cpp
+++ b/src/parsers/vanilla_swap_parser.cpp
@@ -12,9 +12,11 @@ std::shared_ptr<QuantLib::VanillaSwap> VanillaSwapParser::parse(
 
     if (swap->floating_leg() == NULL)
         QUANTRA_INVALID_ARGUMENT("VanillaSwap floating_leg not found");
+    if (!swap->swap_type().has_value())
+        QUANTRA_INVALID_ARGUMENT("VanillaSwap.swap_type is required");
 
     QuantLib::VanillaSwap::Type swapType;
-    switch (swap->swap_type()) {
+    switch (swap->swap_type().value()) {
         case quantra::enums::SwapType_Payer:
             swapType = QuantLib::VanillaSwap::Payer;
             break;
@@ -22,7 +24,9 @@ std::shared_ptr<QuantLib::VanillaSwap> VanillaSwapParser::parse(
             swapType = QuantLib::VanillaSwap::Receiver;
             break;
         default:
-            QUANTRA_INVALID_ARGUMENT("Invalid swap type");
+            QUANTRA_INVALID_ARGUMENT(
+                "VanillaSwap.swap_type is not a known swap type: " +
+                std::to_string(static_cast<int>(swap->swap_type().value())));
     }
 
     auto fixedLeg = swap->fixed_leg();

--- a/src/parsers/year_on_year_inflation_swap_parser.cpp
+++ b/src/parsers/year_on_year_inflation_swap_parser.cpp
@@ -43,9 +43,11 @@ std::shared_ptr<QuantLib::YearOnYearInflationSwap> YearOnYearInflationSwapParser
     if (!inflationIndex) {
         QUANTRA_NOT_FOUND("YearOnYearInflationSwap inflation index not available");
     }
+    if (!swap->swap_type().has_value())
+        QUANTRA_INVALID_ARGUMENT("YearOnYearInflationSwap.swap_type is required");
 
     QuantLib::YearOnYearInflationSwap::Type swapType;
-    switch (swap->swap_type()) {
+    switch (swap->swap_type().value()) {
         case quantra::enums::SwapType_Payer:
             swapType = QuantLib::YearOnYearInflationSwap::Payer;
             break;
@@ -53,7 +55,9 @@ std::shared_ptr<QuantLib::YearOnYearInflationSwap> YearOnYearInflationSwapParser
             swapType = QuantLib::YearOnYearInflationSwap::Receiver;
             break;
         default:
-            QUANTRA_INVALID_ARGUMENT("Invalid year-on-year inflation swap type");
+            QUANTRA_INVALID_ARGUMENT(
+                "YearOnYearInflationSwap.swap_type is not a known swap type: " +
+                std::to_string(static_cast<int>(swap->swap_type().value())));
     }
 
     ScheduleParser scheduleParser;

--- a/src/parsers/zero_coupon_inflation_swap_parser.cpp
+++ b/src/parsers/zero_coupon_inflation_swap_parser.cpp
@@ -49,9 +49,11 @@ std::shared_ptr<QuantLib::ZeroCouponInflationSwap> ZeroCouponInflationSwapParser
             "for this instrument, so honouring it would be a silent no-op. Omit the "
             "field or set it to false.");
     }
+    if (!swap->swap_type().has_value())
+        QUANTRA_INVALID_ARGUMENT("ZeroCouponInflationSwap.swap_type is required");
 
     QuantLib::ZeroCouponInflationSwap::Type swapType;
-    switch (swap->swap_type()) {
+    switch (swap->swap_type().value()) {
         case quantra::enums::SwapType_Payer:
             swapType = QuantLib::ZeroCouponInflationSwap::Payer;
             break;
@@ -59,7 +61,9 @@ std::shared_ptr<QuantLib::ZeroCouponInflationSwap> ZeroCouponInflationSwapParser
             swapType = QuantLib::ZeroCouponInflationSwap::Receiver;
             break;
         default:
-            QUANTRA_INVALID_ARGUMENT("Invalid zero coupon inflation swap type");
+            QUANTRA_INVALID_ARGUMENT(
+                "ZeroCouponInflationSwap.swap_type is not a known swap type: " +
+                std::to_string(static_cast<int>(swap->swap_type().value())));
     }
 
     return std::make_shared<QuantLib::ZeroCouponInflationSwap>(

--- a/tests/contract/error_contract_test.py
+++ b/tests/contract/error_contract_test.py
@@ -217,10 +217,10 @@ def _ec_del_swap_leg_field(arr_key, swap_key, leg_key, field):
 
 
 def _ec_del_instrument_field(arr_key, product_key, field):
-    """Drop a convention field from the product instrument block. The FRA,
-    cap/floor and CDS convention enums (day_counter, calendar,
-    business_day_convention) are presence-required: an omitted convention is an
-    error, never an alphabetical-0 default."""
+    """Drop a convention or discriminator field from the product instrument
+    block. The instrument-level enums (day_counter, calendar,
+    business_day_convention, swap_type, ...) are presence-required: an omitted
+    value is an error, never an alphabetical-0 default."""
     def f(req):
         req[arr_key][0][product_key].pop(field, None)
         return req
@@ -679,6 +679,32 @@ SCENARIOS = [
      "cds_request.json", 400,
      _ec_del_instrument_field("cds_list", "cds", "side"),
      _ec_body_contains("CDS.side is required")),
+    # ---- 400 INVALID_ARGUMENT: swap-direction discriminator presence ----
+    # swap_type decides which way round the trade is booked. An omitted value is
+    # indistinguishable from the alphabetical-0 default (Payer), so it must be
+    # rejected rather than silently pricing the trade in the wrong direction.
+    ("ec:400 vanilla_swap missing swap_type", "vanilla_swap",
+     "vanilla_swap_request.json", 400,
+     _ec_del_instrument_field("swaps", "vanilla_swap", "swap_type"),
+     _ec_body_contains("VanillaSwap.swap_type is required")),
+    ("ec:400 ois_swap missing swap_type", "ois_swap",
+     "ois_swap_request.json", 400,
+     _ec_del_instrument_field("swaps", "ois_swap", "swap_type"),
+     _ec_body_contains("OisSwap.swap_type is required")),
+    ("ec:400 basis_swap missing swap_type", "basis_swap",
+     "basis_swap_request.json", 400,
+     _ec_del_instrument_field("swaps", "basis_swap", "swap_type"),
+     _ec_body_contains("BasisSwap.swap_type is required")),
+    ("ec:400 zero_coupon_inflation_swap missing swap_type",
+     "zero_coupon_inflation_swap",
+     "inflation/zciis_eur_5y_payer_linear_obs.json", 400,
+     _ec_del_instrument_field("swaps", "zero_coupon_inflation_swap", "swap_type"),
+     _ec_body_contains("ZeroCouponInflationSwap.swap_type is required")),
+    ("ec:400 year_on_year_inflation_swap missing swap_type",
+     "year_on_year_inflation_swap",
+     "inflation/yyiis_eur_5y_payer_annual.json", 400,
+     _ec_del_instrument_field("swaps", "year_on_year_inflation_swap", "swap_type"),
+     _ec_body_contains("YearOnYearInflationSwap.swap_type is required")),
     # ---- 400 INVALID_ARGUMENT: coupon-pricer optionlet-vol convention presence ----
     # A ConstantOptionletVolatility convention enum omitted from a coupon pricer
     # must be rejected, not silently defaulted to the alphabetical-0 value.


### PR DESCRIPTION
**First step of the schema completion batch: swap direction can no longer be implicit.**

An omitted `swap_type` was indistinguishable from the first enum value, so a swap sent without one was silently priced as a **Payer** — the same direction-flip class as the CDS `side` fix. It is now optional-with-presence on vanilla, OIS, basis and both inflation swaps; omission returns a 400 naming table and field, on the standalone products **and** on the swaption underlyings. Out-of-range wire values still fail closed, now with a message naming the field and the offending value.

**No migration needed**: an audit of every request JSON and C++ builder in the tree found all 54 swap objects already state their direction — so no catalog input changed and no priced result moved. The bug was latent, which is precisely why no test caught it.

Also documented a semantic subtlety the audit surfaced: `BasisSwap.swap_type` refers to **leg1**, not "the fixed leg".

Five error-contract scenarios (one per product). Full suite green (633 cases). Wire-breaking; lands in the upcoming 0.5.0 with its migration guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
