### PR TITLE
Enable the Hull-White calibration cache in the shipped image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -278,13 +278,15 @@ ENV QUANTRA_STATE_DIR=/app/.quantra
 ENV QUANTRA_ENVOY_ADMIN=http://127.0.0.1:9901
 ENV QUANTRA_FBS_DIR=/app/flatbuffers/fbs
 ENV QUANTRA_FBS_INCLUDE_DIR=/app/flatbuffers/fbs
-# Enable the pricing-engine result caches in the shipped image (audit G1).
-# Safe now the freeze paths are value-exact for every curve type (B1-B3, B7):
-# a cache hit is byte-identical to a miss, so identical requests skip
-# re-bootstrapping. Production stage ONLY — the test gate runs in the deps/dev
-# image and starts its own cache-OFF/cache-ON server pairs explicitly.
+# Enable the pricing-engine result caches in the shipped image. Every cache is
+# gated by the transparency suite, which proves a hit is byte-identical to a
+# miss for every curve type, so identical requests skip re-bootstrapping,
+# re-calibrating a volatility cube, or re-calibrating a short-rate model.
+# Production stage ONLY — the test gate runs in the deps/dev image and starts
+# its own cache-OFF/cache-ON server pairs explicitly.
 ENV QUANTRA_CURVE_CACHE_ENABLED=1
 ENV QUANTRA_SABR_CACHE_ENABLED=1
+ENV QUANTRA_HW_CACHE_ENABLED=1
 # Per-request server-side compute budget. Set slightly above the Envoy route
 # timeout (30s) so a worker frees itself even if Envoy has already returned 504
 # to the client, preventing a slow request from pinning a single-threaded worker.


### PR DESCRIPTION
**The Hull-White calibration cache has been shipping disabled.** Only the curve and volatility-cube caches were enabled in the production image stage, so every container request re-ran the Levenberg-Marquardt fit even for identical inputs — the measured speedup (~150ms → ~47ms on repeat calibrations) never reached anyone running the published image.

Enabling it is safe on exactly the same basis as the other two caches: the transparency suite proves a cache hit is byte-identical to a miss, and an engaged probe prevents that check from passing vacuously.

Also removes internal tracking references that had been left in the surrounding comment, and states the invariant the caches actually depend on.

Full suite green (628 cases).

Note: the published 0.3.0 release notes claim this cache was already on in the shipped container. That claim was wrong; it becomes true from the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
