### PR TITLE
Require explicit volatility, model and swaption exercise types

### DIFF
--- a/examples/data/swaption_atm_matrix_request.json
+++ b/examples/data/swaption_atm_matrix_request.json
@@ -187,6 +187,7 @@
           }
         },
         "exercise_date": "2026-01-15",
+        "exercise_type": "European",
         "settlement_type": "Physical",
         "settlement_method": "PhysicalOTC"
       },

--- a/examples/data/swaption_sabr_calibrate_request.json
+++ b/examples/data/swaption_sabr_calibrate_request.json
@@ -254,6 +254,7 @@
           }
         },
         "exercise_date": "2026-01-15",
+        "exercise_type": "European",
         "settlement_type": "Physical",
         "settlement_method": "PhysicalOTC"
       },

--- a/examples/data/swaption_smile_cube_request.json
+++ b/examples/data/swaption_smile_cube_request.json
@@ -252,6 +252,7 @@
           }
         },
         "exercise_date": "2026-01-15",
+        "exercise_type": "European",
         "settlement_type": "Physical",
         "settlement_method": "PhysicalOTC"
       },

--- a/flatbuffers/cpp/model_generated.h
+++ b/flatbuffers/cpp/model_generated.h
@@ -191,7 +191,7 @@ bool VerifyModelPayloadVector(::flatbuffers::Verifier &verifier, const ::flatbuf
 
 struct CapFloorModelSpecT : public ::flatbuffers::NativeTable {
   typedef CapFloorModelSpec TableType;
-  quantra::enums::IrModelType model_type = quantra::enums::IrModelType_Black;
+  ::flatbuffers::Optional<quantra::enums::IrModelType> model_type = ::flatbuffers::nullopt;
 };
 
 /// Cap/Floor pricing model specification.
@@ -201,8 +201,10 @@ struct CapFloorModelSpec FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table 
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_MODEL_TYPE = 4
   };
-  quantra::enums::IrModelType model_type() const {
-    return static_cast<quantra::enums::IrModelType>(GetField<int8_t>(VT_MODEL_TYPE, 0));
+  /// Pricing model / engine selector. Presence-required: an omitted type is a
+  /// 400, never the alphabetical-0 default (Black).
+  ::flatbuffers::Optional<quantra::enums::IrModelType> model_type() const {
+    return GetOptional<int8_t, quantra::enums::IrModelType>(VT_MODEL_TYPE);
   }
   bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -219,7 +221,7 @@ struct CapFloorModelSpecBuilder {
   ::flatbuffers::FlatBufferBuilder &fbb_;
   ::flatbuffers::uoffset_t start_;
   void add_model_type(quantra::enums::IrModelType model_type) {
-    fbb_.AddElement<int8_t>(CapFloorModelSpec::VT_MODEL_TYPE, static_cast<int8_t>(model_type), 0);
+    fbb_.AddElement<int8_t>(CapFloorModelSpec::VT_MODEL_TYPE, static_cast<int8_t>(model_type));
   }
   explicit CapFloorModelSpecBuilder(::flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
@@ -234,9 +236,9 @@ struct CapFloorModelSpecBuilder {
 
 inline ::flatbuffers::Offset<CapFloorModelSpec> CreateCapFloorModelSpec(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    quantra::enums::IrModelType model_type = quantra::enums::IrModelType_Black) {
+    ::flatbuffers::Optional<quantra::enums::IrModelType> model_type = ::flatbuffers::nullopt) {
   CapFloorModelSpecBuilder builder_(_fbb);
-  builder_.add_model_type(model_type);
+  if(model_type) { builder_.add_model_type(*model_type); }
   return builder_.Finish();
 }
 
@@ -496,7 +498,7 @@ inline ::flatbuffers::Offset<SwaptionHwCalibrationSpec> CreateSwaptionHwCalibrat
 
 struct SwaptionModelSpecT : public ::flatbuffers::NativeTable {
   typedef SwaptionModelSpec TableType;
-  quantra::enums::IrModelType model_type = quantra::enums::IrModelType_Black;
+  ::flatbuffers::Optional<quantra::enums::IrModelType> model_type = ::flatbuffers::nullopt;
   double hw_a = 0.03;
   double hw_sigma = 0.01;
   int32_t lattice_steps = 50;
@@ -520,9 +522,10 @@ struct SwaptionModelSpec FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table 
     VT_PARAM_MODE = 12,
     VT_HW_CALIBRATION = 14
   };
-  /// Swaption pricing model type.
-  quantra::enums::IrModelType model_type() const {
-    return static_cast<quantra::enums::IrModelType>(GetField<int8_t>(VT_MODEL_TYPE, 0));
+  /// Swaption pricing model type. Presence-required: an omitted type is a
+  /// 400, never the alphabetical-0 default (Black).
+  ::flatbuffers::Optional<quantra::enums::IrModelType> model_type() const {
+    return GetOptional<int8_t, quantra::enums::IrModelType>(VT_MODEL_TYPE);
   }
   /// Explicit Hull-White "a" used when param_mode=Explicit.
   double hw_a() const {
@@ -565,7 +568,7 @@ struct SwaptionModelSpecBuilder {
   ::flatbuffers::FlatBufferBuilder &fbb_;
   ::flatbuffers::uoffset_t start_;
   void add_model_type(quantra::enums::IrModelType model_type) {
-    fbb_.AddElement<int8_t>(SwaptionModelSpec::VT_MODEL_TYPE, static_cast<int8_t>(model_type), 0);
+    fbb_.AddElement<int8_t>(SwaptionModelSpec::VT_MODEL_TYPE, static_cast<int8_t>(model_type));
   }
   void add_hw_a(double hw_a) {
     fbb_.AddElement<double>(SwaptionModelSpec::VT_HW_A, hw_a, 0.03);
@@ -595,7 +598,7 @@ struct SwaptionModelSpecBuilder {
 
 inline ::flatbuffers::Offset<SwaptionModelSpec> CreateSwaptionModelSpec(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    quantra::enums::IrModelType model_type = quantra::enums::IrModelType_Black,
+    ::flatbuffers::Optional<quantra::enums::IrModelType> model_type = ::flatbuffers::nullopt,
     double hw_a = 0.03,
     double hw_sigma = 0.01,
     int32_t lattice_steps = 50,
@@ -607,7 +610,7 @@ inline ::flatbuffers::Offset<SwaptionModelSpec> CreateSwaptionModelSpec(
   builder_.add_hw_calibration(hw_calibration);
   builder_.add_lattice_steps(lattice_steps);
   builder_.add_param_mode(param_mode);
-  builder_.add_model_type(model_type);
+  if(model_type) { builder_.add_model_type(*model_type); }
   return builder_.Finish();
 }
 
@@ -712,7 +715,7 @@ inline ::flatbuffers::Offset<CdsModelSpec> CreateCdsModelSpec(
 
 struct EquityVanillaModelSpecT : public ::flatbuffers::NativeTable {
   typedef EquityVanillaModelSpec TableType;
-  quantra::enums::EquityModelType model_type = quantra::enums::EquityModelType_BlackScholesAnalytic;
+  ::flatbuffers::Optional<quantra::enums::EquityModelType> model_type = ::flatbuffers::nullopt;
   int32_t binomial_steps = 500;
 };
 
@@ -724,8 +727,10 @@ struct EquityVanillaModelSpec FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::T
     VT_MODEL_TYPE = 4,
     VT_BINOMIAL_STEPS = 6
   };
-  quantra::enums::EquityModelType model_type() const {
-    return static_cast<quantra::enums::EquityModelType>(GetField<int8_t>(VT_MODEL_TYPE, 0));
+  /// Pricing model / engine selector. Presence-required: an omitted type is a
+  /// 400, never the alphabetical-0 default (BlackScholesAnalytic).
+  ::flatbuffers::Optional<quantra::enums::EquityModelType> model_type() const {
+    return GetOptional<int8_t, quantra::enums::EquityModelType>(VT_MODEL_TYPE);
   }
   int32_t binomial_steps() const {
     return GetField<int32_t>(VT_BINOMIAL_STEPS, 500);
@@ -746,7 +751,7 @@ struct EquityVanillaModelSpecBuilder {
   ::flatbuffers::FlatBufferBuilder &fbb_;
   ::flatbuffers::uoffset_t start_;
   void add_model_type(quantra::enums::EquityModelType model_type) {
-    fbb_.AddElement<int8_t>(EquityVanillaModelSpec::VT_MODEL_TYPE, static_cast<int8_t>(model_type), 0);
+    fbb_.AddElement<int8_t>(EquityVanillaModelSpec::VT_MODEL_TYPE, static_cast<int8_t>(model_type));
   }
   void add_binomial_steps(int32_t binomial_steps) {
     fbb_.AddElement<int32_t>(EquityVanillaModelSpec::VT_BINOMIAL_STEPS, binomial_steps, 500);
@@ -764,11 +769,11 @@ struct EquityVanillaModelSpecBuilder {
 
 inline ::flatbuffers::Offset<EquityVanillaModelSpec> CreateEquityVanillaModelSpec(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    quantra::enums::EquityModelType model_type = quantra::enums::EquityModelType_BlackScholesAnalytic,
+    ::flatbuffers::Optional<quantra::enums::EquityModelType> model_type = ::flatbuffers::nullopt,
     int32_t binomial_steps = 500) {
   EquityVanillaModelSpecBuilder builder_(_fbb);
   builder_.add_binomial_steps(binomial_steps);
-  builder_.add_model_type(model_type);
+  if(model_type) { builder_.add_model_type(*model_type); }
   return builder_.Finish();
 }
 

--- a/flatbuffers/cpp/swaption_generated.h
+++ b/flatbuffers/cpp/swaption_generated.h
@@ -134,8 +134,8 @@ bool VerifySwaptionUnderlyingVector(::flatbuffers::Verifier &verifier, const ::f
 
 struct SwaptionT : public ::flatbuffers::NativeTable {
   typedef Swaption TableType;
-  quantra::enums::ExerciseType exercise_type = quantra::enums::ExerciseType_European;
-  quantra::enums::SettlementType settlement_type = quantra::enums::SettlementType_Physical;
+  ::flatbuffers::Optional<quantra::enums::ExerciseType> exercise_type = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::SettlementType> settlement_type = ::flatbuffers::nullopt;
   quantra::enums::SettlementMethod settlement_method = quantra::enums::SettlementMethod_PhysicalOTC;
   std::string exercise_date{};
   std::vector<std::string> exercise_dates{};
@@ -155,13 +155,15 @@ struct Swaption FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
     VT_UNDERLYING_TYPE = 14,
     VT_UNDERLYING = 16
   };
-  /// Exercise style: European, Bermudan, or American.
-  quantra::enums::ExerciseType exercise_type() const {
-    return static_cast<quantra::enums::ExerciseType>(GetField<int8_t>(VT_EXERCISE_TYPE, 0));
+  /// Exercise style: European, Bermudan, or American. Presence-required: an
+  /// omitted style is a 400, never the alphabetical-0 default (European).
+  ::flatbuffers::Optional<quantra::enums::ExerciseType> exercise_type() const {
+    return GetOptional<int8_t, quantra::enums::ExerciseType>(VT_EXERCISE_TYPE);
   }
-  /// Settlement type for swaption payoff handling.
-  quantra::enums::SettlementType settlement_type() const {
-    return static_cast<quantra::enums::SettlementType>(GetField<int8_t>(VT_SETTLEMENT_TYPE, 0));
+  /// Settlement type for swaption payoff handling. Presence-required: an
+  /// omitted type is a 400, never the alphabetical-0 default (Physical).
+  ::flatbuffers::Optional<quantra::enums::SettlementType> settlement_type() const {
+    return GetOptional<int8_t, quantra::enums::SettlementType>(VT_SETTLEMENT_TYPE);
   }
   /// Settlement method (physical/other) per market convention.
   quantra::enums::SettlementMethod settlement_method() const {
@@ -222,10 +224,10 @@ struct SwaptionBuilder {
   ::flatbuffers::FlatBufferBuilder &fbb_;
   ::flatbuffers::uoffset_t start_;
   void add_exercise_type(quantra::enums::ExerciseType exercise_type) {
-    fbb_.AddElement<int8_t>(Swaption::VT_EXERCISE_TYPE, static_cast<int8_t>(exercise_type), 0);
+    fbb_.AddElement<int8_t>(Swaption::VT_EXERCISE_TYPE, static_cast<int8_t>(exercise_type));
   }
   void add_settlement_type(quantra::enums::SettlementType settlement_type) {
-    fbb_.AddElement<int8_t>(Swaption::VT_SETTLEMENT_TYPE, static_cast<int8_t>(settlement_type), 0);
+    fbb_.AddElement<int8_t>(Swaption::VT_SETTLEMENT_TYPE, static_cast<int8_t>(settlement_type));
   }
   void add_settlement_method(quantra::enums::SettlementMethod settlement_method) {
     fbb_.AddElement<int8_t>(Swaption::VT_SETTLEMENT_METHOD, static_cast<int8_t>(settlement_method), 0);
@@ -255,8 +257,8 @@ struct SwaptionBuilder {
 
 inline ::flatbuffers::Offset<Swaption> CreateSwaption(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    quantra::enums::ExerciseType exercise_type = quantra::enums::ExerciseType_European,
-    quantra::enums::SettlementType settlement_type = quantra::enums::SettlementType_Physical,
+    ::flatbuffers::Optional<quantra::enums::ExerciseType> exercise_type = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::SettlementType> settlement_type = ::flatbuffers::nullopt,
     quantra::enums::SettlementMethod settlement_method = quantra::enums::SettlementMethod_PhysicalOTC,
     ::flatbuffers::Offset<::flatbuffers::String> exercise_date = 0,
     ::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<::flatbuffers::String>>> exercise_dates = 0,
@@ -268,15 +270,15 @@ inline ::flatbuffers::Offset<Swaption> CreateSwaption(
   builder_.add_exercise_date(exercise_date);
   builder_.add_underlying_type(underlying_type);
   builder_.add_settlement_method(settlement_method);
-  builder_.add_settlement_type(settlement_type);
-  builder_.add_exercise_type(exercise_type);
+  if(settlement_type) { builder_.add_settlement_type(*settlement_type); }
+  if(exercise_type) { builder_.add_exercise_type(*exercise_type); }
   return builder_.Finish();
 }
 
 inline ::flatbuffers::Offset<Swaption> CreateSwaptionDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    quantra::enums::ExerciseType exercise_type = quantra::enums::ExerciseType_European,
-    quantra::enums::SettlementType settlement_type = quantra::enums::SettlementType_Physical,
+    ::flatbuffers::Optional<quantra::enums::ExerciseType> exercise_type = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::SettlementType> settlement_type = ::flatbuffers::nullopt,
     quantra::enums::SettlementMethod settlement_method = quantra::enums::SettlementMethod_PhysicalOTC,
     const char *exercise_date = nullptr,
     const std::vector<::flatbuffers::Offset<::flatbuffers::String>> *exercise_dates = nullptr,

--- a/flatbuffers/cpp/volatility_generated.h
+++ b/flatbuffers/cpp/volatility_generated.h
@@ -621,7 +621,7 @@ struct IrVolBaseSpecT : public ::flatbuffers::NativeTable {
   ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt;
   ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt;
   quantra::enums::VolSurfaceShape shape = quantra::enums::VolSurfaceShape_Constant;
-  quantra::enums::VolatilityType volatility_type = quantra::enums::VolatilityType_Normal;
+  ::flatbuffers::Optional<quantra::enums::VolatilityType> volatility_type = ::flatbuffers::nullopt;
   double displacement = 0.0;
   double constant_vol = 0.0;
   std::string quote_id{};
@@ -657,8 +657,11 @@ struct IrVolBaseSpec FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   quantra::enums::VolSurfaceShape shape() const {
     return static_cast<quantra::enums::VolSurfaceShape>(GetField<int8_t>(VT_SHAPE, 0));
   }
-  quantra::enums::VolatilityType volatility_type() const {
-    return static_cast<quantra::enums::VolatilityType>(GetField<int8_t>(VT_VOLATILITY_TYPE, 0));
+  /// Quotation convention of the supplied vols. Presence-required: an omitted
+  /// type is a 400, never the alphabetical-0 default (Normal), which would
+  /// price a lognormal-quoted surface as normal vols.
+  ::flatbuffers::Optional<quantra::enums::VolatilityType> volatility_type() const {
+    return GetOptional<int8_t, quantra::enums::VolatilityType>(VT_VOLATILITY_TYPE);
   }
   /// Only meaningful for ShiftedLognormal.
   double displacement() const {
@@ -711,7 +714,7 @@ struct IrVolBaseSpecBuilder {
     fbb_.AddElement<int8_t>(IrVolBaseSpec::VT_SHAPE, static_cast<int8_t>(shape), 0);
   }
   void add_volatility_type(quantra::enums::VolatilityType volatility_type) {
-    fbb_.AddElement<int8_t>(IrVolBaseSpec::VT_VOLATILITY_TYPE, static_cast<int8_t>(volatility_type), 0);
+    fbb_.AddElement<int8_t>(IrVolBaseSpec::VT_VOLATILITY_TYPE, static_cast<int8_t>(volatility_type));
   }
   void add_displacement(double displacement) {
     fbb_.AddElement<double>(IrVolBaseSpec::VT_DISPLACEMENT, displacement, 0.0);
@@ -740,7 +743,7 @@ inline ::flatbuffers::Offset<IrVolBaseSpec> CreateIrVolBaseSpec(
     ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt,
     ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
     quantra::enums::VolSurfaceShape shape = quantra::enums::VolSurfaceShape_Constant,
-    quantra::enums::VolatilityType volatility_type = quantra::enums::VolatilityType_Normal,
+    ::flatbuffers::Optional<quantra::enums::VolatilityType> volatility_type = ::flatbuffers::nullopt,
     double displacement = 0.0,
     double constant_vol = 0.0,
     ::flatbuffers::Offset<::flatbuffers::String> quote_id = 0) {
@@ -749,7 +752,7 @@ inline ::flatbuffers::Offset<IrVolBaseSpec> CreateIrVolBaseSpec(
   builder_.add_displacement(displacement);
   builder_.add_quote_id(quote_id);
   builder_.add_reference_date(reference_date);
-  builder_.add_volatility_type(volatility_type);
+  if(volatility_type) { builder_.add_volatility_type(*volatility_type); }
   builder_.add_shape(shape);
   if(day_counter) { builder_.add_day_counter(*day_counter); }
   if(business_day_convention) { builder_.add_business_day_convention(*business_day_convention); }
@@ -764,7 +767,7 @@ inline ::flatbuffers::Offset<IrVolBaseSpec> CreateIrVolBaseSpecDirect(
     ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt,
     ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
     quantra::enums::VolSurfaceShape shape = quantra::enums::VolSurfaceShape_Constant,
-    quantra::enums::VolatilityType volatility_type = quantra::enums::VolatilityType_Normal,
+    ::flatbuffers::Optional<quantra::enums::VolatilityType> volatility_type = ::flatbuffers::nullopt,
     double displacement = 0.0,
     double constant_vol = 0.0,
     const char *quote_id = nullptr) {

--- a/flatbuffers/fbs/model.fbs
+++ b/flatbuffers/fbs/model.fbs
@@ -5,7 +5,9 @@ namespace quantra;
 
 /// Cap/Floor pricing model specification.
 table CapFloorModelSpec {
-    model_type:enums.IrModelType;
+    /// Pricing model / engine selector. Presence-required: an omitted type is a
+    /// 400, never the alphabetical-0 default (Black).
+    model_type:enums.IrModelType = null;
 }
 
 /// Swaption Hull-White calibration specification.
@@ -44,8 +46,9 @@ table SwaptionHwCalibrationSpec {
 
 /// Swaption pricing model specification.
 table SwaptionModelSpec {
-    /// Swaption pricing model type.
-    model_type:enums.IrModelType;
+    /// Swaption pricing model type. Presence-required: an omitted type is a
+    /// 400, never the alphabetical-0 default (Black).
+    model_type:enums.IrModelType = null;
     /// Explicit Hull-White "a" used when param_mode=Explicit.
     hw_a:double = 0.03;
     /// Explicit Hull-White "sigma" used when param_mode=Explicit.
@@ -69,7 +72,9 @@ table CdsModelSpec {
 
 /// Equity vanilla option pricing model specification (future).
 table EquityVanillaModelSpec {
-    model_type:enums.EquityModelType;
+    /// Pricing model / engine selector. Presence-required: an omitted type is a
+    /// 400, never the alphabetical-0 default (BlackScholesAnalytic).
+    model_type:enums.EquityModelType = null;
     binomial_steps:int = 500;
 }
 

--- a/flatbuffers/fbs/swaption.fbs
+++ b/flatbuffers/fbs/swaption.fbs
@@ -9,10 +9,12 @@ union SwaptionUnderlying { VanillaSwap, OisSwap }
 
 /// Swaption instrument definition.
 table Swaption {
-    /// Exercise style: European, Bermudan, or American.
-    exercise_type:enums.ExerciseType;
-    /// Settlement type for swaption payoff handling.
-    settlement_type:enums.SettlementType;
+    /// Exercise style: European, Bermudan, or American. Presence-required: an
+    /// omitted style is a 400, never the alphabetical-0 default (European).
+    exercise_type:enums.ExerciseType = null;
+    /// Settlement type for swaption payoff handling. Presence-required: an
+    /// omitted type is a 400, never the alphabetical-0 default (Physical).
+    settlement_type:enums.SettlementType = null;
     /// Settlement method (physical/other) per market convention.
     settlement_method:enums.SettlementMethod = PhysicalOTC;
     /// Single exercise date (ISO date string). Required for European and American.

--- a/flatbuffers/fbs/volatility.fbs
+++ b/flatbuffers/fbs/volatility.fbs
@@ -31,7 +31,10 @@ table IrVolBaseSpec {
     business_day_convention:enums.BusinessDayConvention = null;
     day_counter:enums.DayCounter = null;
     shape:enums.VolSurfaceShape = Constant;
-    volatility_type:enums.VolatilityType;
+    /// Quotation convention of the supplied vols. Presence-required: an omitted
+    /// type is a 400, never the alphabetical-0 default (Normal), which would
+    /// price a lognormal-quoted surface as normal vols.
+    volatility_type:enums.VolatilityType = null;
     /// Only meaningful for ShiftedLognormal.
     displacement:double = 0.0;
     constant_vol:double;

--- a/flatbuffers/json/bootstrap_curves_request.schema.json
+++ b/flatbuffers/json/bootstrap_curves_request.schema.json
@@ -997,7 +997,8 @@
                 "$ref" : "#/definitions/quantra_enums_VolSurfaceShape"
               },
         "volatility_type" : {
-                "$ref" : "#/definitions/quantra_enums_VolatilityType"
+                "$ref" : "#/definitions/quantra_enums_VolatilityType",
+                "description" : "Quotation convention of the supplied vols. Presence-required: an omitted\ntype is a 400, never the alphabetical-0 default (Normal), which would\nprice a lognormal-quoted surface as normal vols."
               },
         "displacement" : {
                 "type" : "number",
@@ -1419,7 +1420,8 @@
       "description" : "Cap/Floor pricing model specification.",
       "properties" : {
         "model_type" : {
-                "$ref" : "#/definitions/quantra_enums_IrModelType"
+                "$ref" : "#/definitions/quantra_enums_IrModelType",
+                "description" : "Pricing model / engine selector. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (Black)."
               }
       },
       "additionalProperties" : false
@@ -1490,7 +1492,7 @@
       "properties" : {
         "model_type" : {
                 "$ref" : "#/definitions/quantra_enums_IrModelType",
-                "description" : "Swaption pricing model type."
+                "description" : "Swaption pricing model type. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (Black)."
               },
         "hw_a" : {
                 "type" : "number",
@@ -1542,7 +1544,8 @@
       "description" : "Equity vanilla option pricing model specification (future).",
       "properties" : {
         "model_type" : {
-                "$ref" : "#/definitions/quantra_enums_EquityModelType"
+                "$ref" : "#/definitions/quantra_enums_EquityModelType",
+                "description" : "Pricing model / engine selector. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (BlackScholesAnalytic)."
               },
         "binomial_steps" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647

--- a/flatbuffers/json/bootstrap_inflation_curves_request.schema.json
+++ b/flatbuffers/json/bootstrap_inflation_curves_request.schema.json
@@ -989,7 +989,8 @@
                 "$ref" : "#/definitions/quantra_enums_VolSurfaceShape"
               },
         "volatility_type" : {
-                "$ref" : "#/definitions/quantra_enums_VolatilityType"
+                "$ref" : "#/definitions/quantra_enums_VolatilityType",
+                "description" : "Quotation convention of the supplied vols. Presence-required: an omitted\ntype is a 400, never the alphabetical-0 default (Normal), which would\nprice a lognormal-quoted surface as normal vols."
               },
         "displacement" : {
                 "type" : "number",
@@ -1411,7 +1412,8 @@
       "description" : "Cap/Floor pricing model specification.",
       "properties" : {
         "model_type" : {
-                "$ref" : "#/definitions/quantra_enums_IrModelType"
+                "$ref" : "#/definitions/quantra_enums_IrModelType",
+                "description" : "Pricing model / engine selector. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (Black)."
               }
       },
       "additionalProperties" : false
@@ -1482,7 +1484,7 @@
       "properties" : {
         "model_type" : {
                 "$ref" : "#/definitions/quantra_enums_IrModelType",
-                "description" : "Swaption pricing model type."
+                "description" : "Swaption pricing model type. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (Black)."
               },
         "hw_a" : {
                 "type" : "number",
@@ -1534,7 +1536,8 @@
       "description" : "Equity vanilla option pricing model specification (future).",
       "properties" : {
         "model_type" : {
-                "$ref" : "#/definitions/quantra_enums_EquityModelType"
+                "$ref" : "#/definitions/quantra_enums_EquityModelType",
+                "description" : "Pricing model / engine selector. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (BlackScholesAnalytic)."
               },
         "binomial_steps" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647

--- a/flatbuffers/json/calibrate_swaption_model_request.schema.json
+++ b/flatbuffers/json/calibrate_swaption_model_request.schema.json
@@ -985,7 +985,8 @@
                 "$ref" : "#/definitions/quantra_enums_VolSurfaceShape"
               },
         "volatility_type" : {
-                "$ref" : "#/definitions/quantra_enums_VolatilityType"
+                "$ref" : "#/definitions/quantra_enums_VolatilityType",
+                "description" : "Quotation convention of the supplied vols. Presence-required: an omitted\ntype is a 400, never the alphabetical-0 default (Normal), which would\nprice a lognormal-quoted surface as normal vols."
               },
         "displacement" : {
                 "type" : "number",
@@ -1407,7 +1408,8 @@
       "description" : "Cap/Floor pricing model specification.",
       "properties" : {
         "model_type" : {
-                "$ref" : "#/definitions/quantra_enums_IrModelType"
+                "$ref" : "#/definitions/quantra_enums_IrModelType",
+                "description" : "Pricing model / engine selector. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (Black)."
               }
       },
       "additionalProperties" : false
@@ -1478,7 +1480,7 @@
       "properties" : {
         "model_type" : {
                 "$ref" : "#/definitions/quantra_enums_IrModelType",
-                "description" : "Swaption pricing model type."
+                "description" : "Swaption pricing model type. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (Black)."
               },
         "hw_a" : {
                 "type" : "number",
@@ -1530,7 +1532,8 @@
       "description" : "Equity vanilla option pricing model specification (future).",
       "properties" : {
         "model_type" : {
-                "$ref" : "#/definitions/quantra_enums_EquityModelType"
+                "$ref" : "#/definitions/quantra_enums_EquityModelType",
+                "description" : "Pricing model / engine selector. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (BlackScholesAnalytic)."
               },
         "binomial_steps" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647

--- a/flatbuffers/json/calibrate_swaption_vol_request.schema.json
+++ b/flatbuffers/json/calibrate_swaption_vol_request.schema.json
@@ -985,7 +985,8 @@
                 "$ref" : "#/definitions/quantra_enums_VolSurfaceShape"
               },
         "volatility_type" : {
-                "$ref" : "#/definitions/quantra_enums_VolatilityType"
+                "$ref" : "#/definitions/quantra_enums_VolatilityType",
+                "description" : "Quotation convention of the supplied vols. Presence-required: an omitted\ntype is a 400, never the alphabetical-0 default (Normal), which would\nprice a lognormal-quoted surface as normal vols."
               },
         "displacement" : {
                 "type" : "number",
@@ -1407,7 +1408,8 @@
       "description" : "Cap/Floor pricing model specification.",
       "properties" : {
         "model_type" : {
-                "$ref" : "#/definitions/quantra_enums_IrModelType"
+                "$ref" : "#/definitions/quantra_enums_IrModelType",
+                "description" : "Pricing model / engine selector. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (Black)."
               }
       },
       "additionalProperties" : false
@@ -1478,7 +1480,7 @@
       "properties" : {
         "model_type" : {
                 "$ref" : "#/definitions/quantra_enums_IrModelType",
-                "description" : "Swaption pricing model type."
+                "description" : "Swaption pricing model type. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (Black)."
               },
         "hw_a" : {
                 "type" : "number",
@@ -1530,7 +1532,8 @@
       "description" : "Equity vanilla option pricing model specification (future).",
       "properties" : {
         "model_type" : {
-                "$ref" : "#/definitions/quantra_enums_EquityModelType"
+                "$ref" : "#/definitions/quantra_enums_EquityModelType",
+                "description" : "Pricing model / engine selector. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (BlackScholesAnalytic)."
               },
         "binomial_steps" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647

--- a/flatbuffers/json/price_basis_swap_request.schema.json
+++ b/flatbuffers/json/price_basis_swap_request.schema.json
@@ -985,7 +985,8 @@
                 "$ref" : "#/definitions/quantra_enums_VolSurfaceShape"
               },
         "volatility_type" : {
-                "$ref" : "#/definitions/quantra_enums_VolatilityType"
+                "$ref" : "#/definitions/quantra_enums_VolatilityType",
+                "description" : "Quotation convention of the supplied vols. Presence-required: an omitted\ntype is a 400, never the alphabetical-0 default (Normal), which would\nprice a lognormal-quoted surface as normal vols."
               },
         "displacement" : {
                 "type" : "number",
@@ -1407,7 +1408,8 @@
       "description" : "Cap/Floor pricing model specification.",
       "properties" : {
         "model_type" : {
-                "$ref" : "#/definitions/quantra_enums_IrModelType"
+                "$ref" : "#/definitions/quantra_enums_IrModelType",
+                "description" : "Pricing model / engine selector. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (Black)."
               }
       },
       "additionalProperties" : false
@@ -1478,7 +1480,7 @@
       "properties" : {
         "model_type" : {
                 "$ref" : "#/definitions/quantra_enums_IrModelType",
-                "description" : "Swaption pricing model type."
+                "description" : "Swaption pricing model type. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (Black)."
               },
         "hw_a" : {
                 "type" : "number",
@@ -1530,7 +1532,8 @@
       "description" : "Equity vanilla option pricing model specification (future).",
       "properties" : {
         "model_type" : {
-                "$ref" : "#/definitions/quantra_enums_EquityModelType"
+                "$ref" : "#/definitions/quantra_enums_EquityModelType",
+                "description" : "Pricing model / engine selector. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (BlackScholesAnalytic)."
               },
         "binomial_steps" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647

--- a/flatbuffers/json/price_callable_fixed_rate_bond_request.schema.json
+++ b/flatbuffers/json/price_callable_fixed_rate_bond_request.schema.json
@@ -985,7 +985,8 @@
                 "$ref" : "#/definitions/quantra_enums_VolSurfaceShape"
               },
         "volatility_type" : {
-                "$ref" : "#/definitions/quantra_enums_VolatilityType"
+                "$ref" : "#/definitions/quantra_enums_VolatilityType",
+                "description" : "Quotation convention of the supplied vols. Presence-required: an omitted\ntype is a 400, never the alphabetical-0 default (Normal), which would\nprice a lognormal-quoted surface as normal vols."
               },
         "displacement" : {
                 "type" : "number",
@@ -1407,7 +1408,8 @@
       "description" : "Cap/Floor pricing model specification.",
       "properties" : {
         "model_type" : {
-                "$ref" : "#/definitions/quantra_enums_IrModelType"
+                "$ref" : "#/definitions/quantra_enums_IrModelType",
+                "description" : "Pricing model / engine selector. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (Black)."
               }
       },
       "additionalProperties" : false
@@ -1478,7 +1480,7 @@
       "properties" : {
         "model_type" : {
                 "$ref" : "#/definitions/quantra_enums_IrModelType",
-                "description" : "Swaption pricing model type."
+                "description" : "Swaption pricing model type. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (Black)."
               },
         "hw_a" : {
                 "type" : "number",
@@ -1530,7 +1532,8 @@
       "description" : "Equity vanilla option pricing model specification (future).",
       "properties" : {
         "model_type" : {
-                "$ref" : "#/definitions/quantra_enums_EquityModelType"
+                "$ref" : "#/definitions/quantra_enums_EquityModelType",
+                "description" : "Pricing model / engine selector. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (BlackScholesAnalytic)."
               },
         "binomial_steps" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647

--- a/flatbuffers/json/price_cap_floor_request.schema.json
+++ b/flatbuffers/json/price_cap_floor_request.schema.json
@@ -985,7 +985,8 @@
                 "$ref" : "#/definitions/quantra_enums_VolSurfaceShape"
               },
         "volatility_type" : {
-                "$ref" : "#/definitions/quantra_enums_VolatilityType"
+                "$ref" : "#/definitions/quantra_enums_VolatilityType",
+                "description" : "Quotation convention of the supplied vols. Presence-required: an omitted\ntype is a 400, never the alphabetical-0 default (Normal), which would\nprice a lognormal-quoted surface as normal vols."
               },
         "displacement" : {
                 "type" : "number",
@@ -1407,7 +1408,8 @@
       "description" : "Cap/Floor pricing model specification.",
       "properties" : {
         "model_type" : {
-                "$ref" : "#/definitions/quantra_enums_IrModelType"
+                "$ref" : "#/definitions/quantra_enums_IrModelType",
+                "description" : "Pricing model / engine selector. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (Black)."
               }
       },
       "additionalProperties" : false
@@ -1478,7 +1480,7 @@
       "properties" : {
         "model_type" : {
                 "$ref" : "#/definitions/quantra_enums_IrModelType",
-                "description" : "Swaption pricing model type."
+                "description" : "Swaption pricing model type. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (Black)."
               },
         "hw_a" : {
                 "type" : "number",
@@ -1530,7 +1532,8 @@
       "description" : "Equity vanilla option pricing model specification (future).",
       "properties" : {
         "model_type" : {
-                "$ref" : "#/definitions/quantra_enums_EquityModelType"
+                "$ref" : "#/definitions/quantra_enums_EquityModelType",
+                "description" : "Pricing model / engine selector. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (BlackScholesAnalytic)."
               },
         "binomial_steps" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647

--- a/flatbuffers/json/price_cds_request.schema.json
+++ b/flatbuffers/json/price_cds_request.schema.json
@@ -985,7 +985,8 @@
                 "$ref" : "#/definitions/quantra_enums_VolSurfaceShape"
               },
         "volatility_type" : {
-                "$ref" : "#/definitions/quantra_enums_VolatilityType"
+                "$ref" : "#/definitions/quantra_enums_VolatilityType",
+                "description" : "Quotation convention of the supplied vols. Presence-required: an omitted\ntype is a 400, never the alphabetical-0 default (Normal), which would\nprice a lognormal-quoted surface as normal vols."
               },
         "displacement" : {
                 "type" : "number",
@@ -1407,7 +1408,8 @@
       "description" : "Cap/Floor pricing model specification.",
       "properties" : {
         "model_type" : {
-                "$ref" : "#/definitions/quantra_enums_IrModelType"
+                "$ref" : "#/definitions/quantra_enums_IrModelType",
+                "description" : "Pricing model / engine selector. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (Black)."
               }
       },
       "additionalProperties" : false
@@ -1478,7 +1480,7 @@
       "properties" : {
         "model_type" : {
                 "$ref" : "#/definitions/quantra_enums_IrModelType",
-                "description" : "Swaption pricing model type."
+                "description" : "Swaption pricing model type. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (Black)."
               },
         "hw_a" : {
                 "type" : "number",
@@ -1530,7 +1532,8 @@
       "description" : "Equity vanilla option pricing model specification (future).",
       "properties" : {
         "model_type" : {
-                "$ref" : "#/definitions/quantra_enums_EquityModelType"
+                "$ref" : "#/definitions/quantra_enums_EquityModelType",
+                "description" : "Pricing model / engine selector. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (BlackScholesAnalytic)."
               },
         "binomial_steps" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647

--- a/flatbuffers/json/price_equity_option_request.schema.json
+++ b/flatbuffers/json/price_equity_option_request.schema.json
@@ -985,7 +985,8 @@
                 "$ref" : "#/definitions/quantra_enums_VolSurfaceShape"
               },
         "volatility_type" : {
-                "$ref" : "#/definitions/quantra_enums_VolatilityType"
+                "$ref" : "#/definitions/quantra_enums_VolatilityType",
+                "description" : "Quotation convention of the supplied vols. Presence-required: an omitted\ntype is a 400, never the alphabetical-0 default (Normal), which would\nprice a lognormal-quoted surface as normal vols."
               },
         "displacement" : {
                 "type" : "number",
@@ -1407,7 +1408,8 @@
       "description" : "Cap/Floor pricing model specification.",
       "properties" : {
         "model_type" : {
-                "$ref" : "#/definitions/quantra_enums_IrModelType"
+                "$ref" : "#/definitions/quantra_enums_IrModelType",
+                "description" : "Pricing model / engine selector. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (Black)."
               }
       },
       "additionalProperties" : false
@@ -1478,7 +1480,7 @@
       "properties" : {
         "model_type" : {
                 "$ref" : "#/definitions/quantra_enums_IrModelType",
-                "description" : "Swaption pricing model type."
+                "description" : "Swaption pricing model type. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (Black)."
               },
         "hw_a" : {
                 "type" : "number",
@@ -1530,7 +1532,8 @@
       "description" : "Equity vanilla option pricing model specification (future).",
       "properties" : {
         "model_type" : {
-                "$ref" : "#/definitions/quantra_enums_EquityModelType"
+                "$ref" : "#/definitions/quantra_enums_EquityModelType",
+                "description" : "Pricing model / engine selector. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (BlackScholesAnalytic)."
               },
         "binomial_steps" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647

--- a/flatbuffers/json/price_fixed_rate_bond_request.schema.json
+++ b/flatbuffers/json/price_fixed_rate_bond_request.schema.json
@@ -985,7 +985,8 @@
                 "$ref" : "#/definitions/quantra_enums_VolSurfaceShape"
               },
         "volatility_type" : {
-                "$ref" : "#/definitions/quantra_enums_VolatilityType"
+                "$ref" : "#/definitions/quantra_enums_VolatilityType",
+                "description" : "Quotation convention of the supplied vols. Presence-required: an omitted\ntype is a 400, never the alphabetical-0 default (Normal), which would\nprice a lognormal-quoted surface as normal vols."
               },
         "displacement" : {
                 "type" : "number",
@@ -1407,7 +1408,8 @@
       "description" : "Cap/Floor pricing model specification.",
       "properties" : {
         "model_type" : {
-                "$ref" : "#/definitions/quantra_enums_IrModelType"
+                "$ref" : "#/definitions/quantra_enums_IrModelType",
+                "description" : "Pricing model / engine selector. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (Black)."
               }
       },
       "additionalProperties" : false
@@ -1478,7 +1480,7 @@
       "properties" : {
         "model_type" : {
                 "$ref" : "#/definitions/quantra_enums_IrModelType",
-                "description" : "Swaption pricing model type."
+                "description" : "Swaption pricing model type. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (Black)."
               },
         "hw_a" : {
                 "type" : "number",
@@ -1530,7 +1532,8 @@
       "description" : "Equity vanilla option pricing model specification (future).",
       "properties" : {
         "model_type" : {
-                "$ref" : "#/definitions/quantra_enums_EquityModelType"
+                "$ref" : "#/definitions/quantra_enums_EquityModelType",
+                "description" : "Pricing model / engine selector. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (BlackScholesAnalytic)."
               },
         "binomial_steps" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647

--- a/flatbuffers/json/price_floating_rate_bond_request.schema.json
+++ b/flatbuffers/json/price_floating_rate_bond_request.schema.json
@@ -985,7 +985,8 @@
                 "$ref" : "#/definitions/quantra_enums_VolSurfaceShape"
               },
         "volatility_type" : {
-                "$ref" : "#/definitions/quantra_enums_VolatilityType"
+                "$ref" : "#/definitions/quantra_enums_VolatilityType",
+                "description" : "Quotation convention of the supplied vols. Presence-required: an omitted\ntype is a 400, never the alphabetical-0 default (Normal), which would\nprice a lognormal-quoted surface as normal vols."
               },
         "displacement" : {
                 "type" : "number",
@@ -1407,7 +1408,8 @@
       "description" : "Cap/Floor pricing model specification.",
       "properties" : {
         "model_type" : {
-                "$ref" : "#/definitions/quantra_enums_IrModelType"
+                "$ref" : "#/definitions/quantra_enums_IrModelType",
+                "description" : "Pricing model / engine selector. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (Black)."
               }
       },
       "additionalProperties" : false
@@ -1478,7 +1480,7 @@
       "properties" : {
         "model_type" : {
                 "$ref" : "#/definitions/quantra_enums_IrModelType",
-                "description" : "Swaption pricing model type."
+                "description" : "Swaption pricing model type. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (Black)."
               },
         "hw_a" : {
                 "type" : "number",
@@ -1530,7 +1532,8 @@
       "description" : "Equity vanilla option pricing model specification (future).",
       "properties" : {
         "model_type" : {
-                "$ref" : "#/definitions/quantra_enums_EquityModelType"
+                "$ref" : "#/definitions/quantra_enums_EquityModelType",
+                "description" : "Pricing model / engine selector. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (BlackScholesAnalytic)."
               },
         "binomial_steps" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647

--- a/flatbuffers/json/price_fra_request.schema.json
+++ b/flatbuffers/json/price_fra_request.schema.json
@@ -985,7 +985,8 @@
                 "$ref" : "#/definitions/quantra_enums_VolSurfaceShape"
               },
         "volatility_type" : {
-                "$ref" : "#/definitions/quantra_enums_VolatilityType"
+                "$ref" : "#/definitions/quantra_enums_VolatilityType",
+                "description" : "Quotation convention of the supplied vols. Presence-required: an omitted\ntype is a 400, never the alphabetical-0 default (Normal), which would\nprice a lognormal-quoted surface as normal vols."
               },
         "displacement" : {
                 "type" : "number",
@@ -1407,7 +1408,8 @@
       "description" : "Cap/Floor pricing model specification.",
       "properties" : {
         "model_type" : {
-                "$ref" : "#/definitions/quantra_enums_IrModelType"
+                "$ref" : "#/definitions/quantra_enums_IrModelType",
+                "description" : "Pricing model / engine selector. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (Black)."
               }
       },
       "additionalProperties" : false
@@ -1478,7 +1480,7 @@
       "properties" : {
         "model_type" : {
                 "$ref" : "#/definitions/quantra_enums_IrModelType",
-                "description" : "Swaption pricing model type."
+                "description" : "Swaption pricing model type. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (Black)."
               },
         "hw_a" : {
                 "type" : "number",
@@ -1530,7 +1532,8 @@
       "description" : "Equity vanilla option pricing model specification (future).",
       "properties" : {
         "model_type" : {
-                "$ref" : "#/definitions/quantra_enums_EquityModelType"
+                "$ref" : "#/definitions/quantra_enums_EquityModelType",
+                "description" : "Pricing model / engine selector. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (BlackScholesAnalytic)."
               },
         "binomial_steps" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647

--- a/flatbuffers/json/price_ois_swap_request.schema.json
+++ b/flatbuffers/json/price_ois_swap_request.schema.json
@@ -985,7 +985,8 @@
                 "$ref" : "#/definitions/quantra_enums_VolSurfaceShape"
               },
         "volatility_type" : {
-                "$ref" : "#/definitions/quantra_enums_VolatilityType"
+                "$ref" : "#/definitions/quantra_enums_VolatilityType",
+                "description" : "Quotation convention of the supplied vols. Presence-required: an omitted\ntype is a 400, never the alphabetical-0 default (Normal), which would\nprice a lognormal-quoted surface as normal vols."
               },
         "displacement" : {
                 "type" : "number",
@@ -1407,7 +1408,8 @@
       "description" : "Cap/Floor pricing model specification.",
       "properties" : {
         "model_type" : {
-                "$ref" : "#/definitions/quantra_enums_IrModelType"
+                "$ref" : "#/definitions/quantra_enums_IrModelType",
+                "description" : "Pricing model / engine selector. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (Black)."
               }
       },
       "additionalProperties" : false
@@ -1478,7 +1480,7 @@
       "properties" : {
         "model_type" : {
                 "$ref" : "#/definitions/quantra_enums_IrModelType",
-                "description" : "Swaption pricing model type."
+                "description" : "Swaption pricing model type. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (Black)."
               },
         "hw_a" : {
                 "type" : "number",
@@ -1530,7 +1532,8 @@
       "description" : "Equity vanilla option pricing model specification (future).",
       "properties" : {
         "model_type" : {
-                "$ref" : "#/definitions/quantra_enums_EquityModelType"
+                "$ref" : "#/definitions/quantra_enums_EquityModelType",
+                "description" : "Pricing model / engine selector. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (BlackScholesAnalytic)."
               },
         "binomial_steps" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647

--- a/flatbuffers/json/price_swaption_request.schema.json
+++ b/flatbuffers/json/price_swaption_request.schema.json
@@ -989,7 +989,8 @@
                 "$ref" : "#/definitions/quantra_enums_VolSurfaceShape"
               },
         "volatility_type" : {
-                "$ref" : "#/definitions/quantra_enums_VolatilityType"
+                "$ref" : "#/definitions/quantra_enums_VolatilityType",
+                "description" : "Quotation convention of the supplied vols. Presence-required: an omitted\ntype is a 400, never the alphabetical-0 default (Normal), which would\nprice a lognormal-quoted surface as normal vols."
               },
         "displacement" : {
                 "type" : "number",
@@ -1411,7 +1412,8 @@
       "description" : "Cap/Floor pricing model specification.",
       "properties" : {
         "model_type" : {
-                "$ref" : "#/definitions/quantra_enums_IrModelType"
+                "$ref" : "#/definitions/quantra_enums_IrModelType",
+                "description" : "Pricing model / engine selector. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (Black)."
               }
       },
       "additionalProperties" : false
@@ -1482,7 +1484,7 @@
       "properties" : {
         "model_type" : {
                 "$ref" : "#/definitions/quantra_enums_IrModelType",
-                "description" : "Swaption pricing model type."
+                "description" : "Swaption pricing model type. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (Black)."
               },
         "hw_a" : {
                 "type" : "number",
@@ -1534,7 +1536,8 @@
       "description" : "Equity vanilla option pricing model specification (future).",
       "properties" : {
         "model_type" : {
-                "$ref" : "#/definitions/quantra_enums_EquityModelType"
+                "$ref" : "#/definitions/quantra_enums_EquityModelType",
+                "description" : "Pricing model / engine selector. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (BlackScholesAnalytic)."
               },
         "binomial_steps" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -2514,11 +2517,11 @@
       "properties" : {
         "exercise_type" : {
                 "$ref" : "#/definitions/quantra_enums_ExerciseType",
-                "description" : "Exercise style: European, Bermudan, or American."
+                "description" : "Exercise style: European, Bermudan, or American. Presence-required: an\nomitted style is a 400, never the alphabetical-0 default (European)."
               },
         "settlement_type" : {
                 "$ref" : "#/definitions/quantra_enums_SettlementType",
-                "description" : "Settlement type for swaption payoff handling."
+                "description" : "Settlement type for swaption payoff handling. Presence-required: an\nomitted type is a 400, never the alphabetical-0 default (Physical)."
               },
         "settlement_method" : {
                 "$ref" : "#/definitions/quantra_enums_SettlementMethod",

--- a/flatbuffers/json/price_vanilla_swap_request.schema.json
+++ b/flatbuffers/json/price_vanilla_swap_request.schema.json
@@ -985,7 +985,8 @@
                 "$ref" : "#/definitions/quantra_enums_VolSurfaceShape"
               },
         "volatility_type" : {
-                "$ref" : "#/definitions/quantra_enums_VolatilityType"
+                "$ref" : "#/definitions/quantra_enums_VolatilityType",
+                "description" : "Quotation convention of the supplied vols. Presence-required: an omitted\ntype is a 400, never the alphabetical-0 default (Normal), which would\nprice a lognormal-quoted surface as normal vols."
               },
         "displacement" : {
                 "type" : "number",
@@ -1407,7 +1408,8 @@
       "description" : "Cap/Floor pricing model specification.",
       "properties" : {
         "model_type" : {
-                "$ref" : "#/definitions/quantra_enums_IrModelType"
+                "$ref" : "#/definitions/quantra_enums_IrModelType",
+                "description" : "Pricing model / engine selector. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (Black)."
               }
       },
       "additionalProperties" : false
@@ -1478,7 +1480,7 @@
       "properties" : {
         "model_type" : {
                 "$ref" : "#/definitions/quantra_enums_IrModelType",
-                "description" : "Swaption pricing model type."
+                "description" : "Swaption pricing model type. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (Black)."
               },
         "hw_a" : {
                 "type" : "number",
@@ -1530,7 +1532,8 @@
       "description" : "Equity vanilla option pricing model specification (future).",
       "properties" : {
         "model_type" : {
-                "$ref" : "#/definitions/quantra_enums_EquityModelType"
+                "$ref" : "#/definitions/quantra_enums_EquityModelType",
+                "description" : "Pricing model / engine selector. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (BlackScholesAnalytic)."
               },
         "binomial_steps" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647

--- a/flatbuffers/json/price_year_on_year_inflation_cap_floor_request.schema.json
+++ b/flatbuffers/json/price_year_on_year_inflation_cap_floor_request.schema.json
@@ -985,7 +985,8 @@
                 "$ref" : "#/definitions/quantra_enums_VolSurfaceShape"
               },
         "volatility_type" : {
-                "$ref" : "#/definitions/quantra_enums_VolatilityType"
+                "$ref" : "#/definitions/quantra_enums_VolatilityType",
+                "description" : "Quotation convention of the supplied vols. Presence-required: an omitted\ntype is a 400, never the alphabetical-0 default (Normal), which would\nprice a lognormal-quoted surface as normal vols."
               },
         "displacement" : {
                 "type" : "number",
@@ -1407,7 +1408,8 @@
       "description" : "Cap/Floor pricing model specification.",
       "properties" : {
         "model_type" : {
-                "$ref" : "#/definitions/quantra_enums_IrModelType"
+                "$ref" : "#/definitions/quantra_enums_IrModelType",
+                "description" : "Pricing model / engine selector. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (Black)."
               }
       },
       "additionalProperties" : false
@@ -1478,7 +1480,7 @@
       "properties" : {
         "model_type" : {
                 "$ref" : "#/definitions/quantra_enums_IrModelType",
-                "description" : "Swaption pricing model type."
+                "description" : "Swaption pricing model type. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (Black)."
               },
         "hw_a" : {
                 "type" : "number",
@@ -1530,7 +1532,8 @@
       "description" : "Equity vanilla option pricing model specification (future).",
       "properties" : {
         "model_type" : {
-                "$ref" : "#/definitions/quantra_enums_EquityModelType"
+                "$ref" : "#/definitions/quantra_enums_EquityModelType",
+                "description" : "Pricing model / engine selector. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (BlackScholesAnalytic)."
               },
         "binomial_steps" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647

--- a/flatbuffers/json/price_year_on_year_inflation_swap_request.schema.json
+++ b/flatbuffers/json/price_year_on_year_inflation_swap_request.schema.json
@@ -985,7 +985,8 @@
                 "$ref" : "#/definitions/quantra_enums_VolSurfaceShape"
               },
         "volatility_type" : {
-                "$ref" : "#/definitions/quantra_enums_VolatilityType"
+                "$ref" : "#/definitions/quantra_enums_VolatilityType",
+                "description" : "Quotation convention of the supplied vols. Presence-required: an omitted\ntype is a 400, never the alphabetical-0 default (Normal), which would\nprice a lognormal-quoted surface as normal vols."
               },
         "displacement" : {
                 "type" : "number",
@@ -1407,7 +1408,8 @@
       "description" : "Cap/Floor pricing model specification.",
       "properties" : {
         "model_type" : {
-                "$ref" : "#/definitions/quantra_enums_IrModelType"
+                "$ref" : "#/definitions/quantra_enums_IrModelType",
+                "description" : "Pricing model / engine selector. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (Black)."
               }
       },
       "additionalProperties" : false
@@ -1478,7 +1480,7 @@
       "properties" : {
         "model_type" : {
                 "$ref" : "#/definitions/quantra_enums_IrModelType",
-                "description" : "Swaption pricing model type."
+                "description" : "Swaption pricing model type. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (Black)."
               },
         "hw_a" : {
                 "type" : "number",
@@ -1530,7 +1532,8 @@
       "description" : "Equity vanilla option pricing model specification (future).",
       "properties" : {
         "model_type" : {
-                "$ref" : "#/definitions/quantra_enums_EquityModelType"
+                "$ref" : "#/definitions/quantra_enums_EquityModelType",
+                "description" : "Pricing model / engine selector. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (BlackScholesAnalytic)."
               },
         "binomial_steps" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647

--- a/flatbuffers/json/price_zero_coupon_bond_request.schema.json
+++ b/flatbuffers/json/price_zero_coupon_bond_request.schema.json
@@ -985,7 +985,8 @@
                 "$ref" : "#/definitions/quantra_enums_VolSurfaceShape"
               },
         "volatility_type" : {
-                "$ref" : "#/definitions/quantra_enums_VolatilityType"
+                "$ref" : "#/definitions/quantra_enums_VolatilityType",
+                "description" : "Quotation convention of the supplied vols. Presence-required: an omitted\ntype is a 400, never the alphabetical-0 default (Normal), which would\nprice a lognormal-quoted surface as normal vols."
               },
         "displacement" : {
                 "type" : "number",
@@ -1407,7 +1408,8 @@
       "description" : "Cap/Floor pricing model specification.",
       "properties" : {
         "model_type" : {
-                "$ref" : "#/definitions/quantra_enums_IrModelType"
+                "$ref" : "#/definitions/quantra_enums_IrModelType",
+                "description" : "Pricing model / engine selector. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (Black)."
               }
       },
       "additionalProperties" : false
@@ -1478,7 +1480,7 @@
       "properties" : {
         "model_type" : {
                 "$ref" : "#/definitions/quantra_enums_IrModelType",
-                "description" : "Swaption pricing model type."
+                "description" : "Swaption pricing model type. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (Black)."
               },
         "hw_a" : {
                 "type" : "number",
@@ -1530,7 +1532,8 @@
       "description" : "Equity vanilla option pricing model specification (future).",
       "properties" : {
         "model_type" : {
-                "$ref" : "#/definitions/quantra_enums_EquityModelType"
+                "$ref" : "#/definitions/quantra_enums_EquityModelType",
+                "description" : "Pricing model / engine selector. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (BlackScholesAnalytic)."
               },
         "binomial_steps" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647

--- a/flatbuffers/json/price_zero_coupon_inflation_swap_request.schema.json
+++ b/flatbuffers/json/price_zero_coupon_inflation_swap_request.schema.json
@@ -985,7 +985,8 @@
                 "$ref" : "#/definitions/quantra_enums_VolSurfaceShape"
               },
         "volatility_type" : {
-                "$ref" : "#/definitions/quantra_enums_VolatilityType"
+                "$ref" : "#/definitions/quantra_enums_VolatilityType",
+                "description" : "Quotation convention of the supplied vols. Presence-required: an omitted\ntype is a 400, never the alphabetical-0 default (Normal), which would\nprice a lognormal-quoted surface as normal vols."
               },
         "displacement" : {
                 "type" : "number",
@@ -1407,7 +1408,8 @@
       "description" : "Cap/Floor pricing model specification.",
       "properties" : {
         "model_type" : {
-                "$ref" : "#/definitions/quantra_enums_IrModelType"
+                "$ref" : "#/definitions/quantra_enums_IrModelType",
+                "description" : "Pricing model / engine selector. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (Black)."
               }
       },
       "additionalProperties" : false
@@ -1478,7 +1480,7 @@
       "properties" : {
         "model_type" : {
                 "$ref" : "#/definitions/quantra_enums_IrModelType",
-                "description" : "Swaption pricing model type."
+                "description" : "Swaption pricing model type. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (Black)."
               },
         "hw_a" : {
                 "type" : "number",
@@ -1530,7 +1532,8 @@
       "description" : "Equity vanilla option pricing model specification (future).",
       "properties" : {
         "model_type" : {
-                "$ref" : "#/definitions/quantra_enums_EquityModelType"
+                "$ref" : "#/definitions/quantra_enums_EquityModelType",
+                "description" : "Pricing model / engine selector. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (BlackScholesAnalytic)."
               },
         "binomial_steps" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647

--- a/flatbuffers/json/price_zero_coupon_swap_request.schema.json
+++ b/flatbuffers/json/price_zero_coupon_swap_request.schema.json
@@ -985,7 +985,8 @@
                 "$ref" : "#/definitions/quantra_enums_VolSurfaceShape"
               },
         "volatility_type" : {
-                "$ref" : "#/definitions/quantra_enums_VolatilityType"
+                "$ref" : "#/definitions/quantra_enums_VolatilityType",
+                "description" : "Quotation convention of the supplied vols. Presence-required: an omitted\ntype is a 400, never the alphabetical-0 default (Normal), which would\nprice a lognormal-quoted surface as normal vols."
               },
         "displacement" : {
                 "type" : "number",
@@ -1407,7 +1408,8 @@
       "description" : "Cap/Floor pricing model specification.",
       "properties" : {
         "model_type" : {
-                "$ref" : "#/definitions/quantra_enums_IrModelType"
+                "$ref" : "#/definitions/quantra_enums_IrModelType",
+                "description" : "Pricing model / engine selector. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (Black)."
               }
       },
       "additionalProperties" : false
@@ -1478,7 +1480,7 @@
       "properties" : {
         "model_type" : {
                 "$ref" : "#/definitions/quantra_enums_IrModelType",
-                "description" : "Swaption pricing model type."
+                "description" : "Swaption pricing model type. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (Black)."
               },
         "hw_a" : {
                 "type" : "number",
@@ -1530,7 +1532,8 @@
       "description" : "Equity vanilla option pricing model specification (future).",
       "properties" : {
         "model_type" : {
-                "$ref" : "#/definitions/quantra_enums_EquityModelType"
+                "$ref" : "#/definitions/quantra_enums_EquityModelType",
+                "description" : "Pricing model / engine selector. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (BlackScholesAnalytic)."
               },
         "binomial_steps" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647

--- a/flatbuffers/json/sample_vol_surfaces_request.schema.json
+++ b/flatbuffers/json/sample_vol_surfaces_request.schema.json
@@ -1005,7 +1005,8 @@
                 "$ref" : "#/definitions/quantra_enums_VolSurfaceShape"
               },
         "volatility_type" : {
-                "$ref" : "#/definitions/quantra_enums_VolatilityType"
+                "$ref" : "#/definitions/quantra_enums_VolatilityType",
+                "description" : "Quotation convention of the supplied vols. Presence-required: an omitted\ntype is a 400, never the alphabetical-0 default (Normal), which would\nprice a lognormal-quoted surface as normal vols."
               },
         "displacement" : {
                 "type" : "number",
@@ -1427,7 +1428,8 @@
       "description" : "Cap/Floor pricing model specification.",
       "properties" : {
         "model_type" : {
-                "$ref" : "#/definitions/quantra_enums_IrModelType"
+                "$ref" : "#/definitions/quantra_enums_IrModelType",
+                "description" : "Pricing model / engine selector. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (Black)."
               }
       },
       "additionalProperties" : false
@@ -1498,7 +1500,7 @@
       "properties" : {
         "model_type" : {
                 "$ref" : "#/definitions/quantra_enums_IrModelType",
-                "description" : "Swaption pricing model type."
+                "description" : "Swaption pricing model type. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (Black)."
               },
         "hw_a" : {
                 "type" : "number",
@@ -1550,7 +1552,8 @@
       "description" : "Equity vanilla option pricing model specification (future).",
       "properties" : {
         "model_type" : {
-                "$ref" : "#/definitions/quantra_enums_EquityModelType"
+                "$ref" : "#/definitions/quantra_enums_EquityModelType",
+                "description" : "Pricing model / engine selector. Presence-required: an omitted type is a\n400, never the alphabetical-0 default (BlackScholesAnalytic)."
               },
         "binomial_steps" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647

--- a/flatbuffers/json/swaption.schema.json
+++ b/flatbuffers/json/swaption.schema.json
@@ -675,11 +675,11 @@
       "properties" : {
         "exercise_type" : {
                 "$ref" : "#/definitions/quantra_enums_ExerciseType",
-                "description" : "Exercise style: European, Bermudan, or American."
+                "description" : "Exercise style: European, Bermudan, or American. Presence-required: an\nomitted style is a 400, never the alphabetical-0 default (European)."
               },
         "settlement_type" : {
                 "$ref" : "#/definitions/quantra_enums_SettlementType",
-                "description" : "Settlement type for swaption payoff handling."
+                "description" : "Settlement type for swaption payoff handling. Presence-required: an\nomitted type is a 400, never the alphabetical-0 default (Physical)."
               },
         "settlement_method" : {
                 "$ref" : "#/definitions/quantra_enums_SettlementMethod",

--- a/flatbuffers/python/quantra/CapFloorModelSpec.py
+++ b/flatbuffers/python/quantra/CapFloorModelSpec.py
@@ -25,12 +25,14 @@ class CapFloorModelSpec(object):
     def Init(self, buf, pos):
         self._tab = flatbuffers.table.Table(buf, pos)
 
+    # Pricing model / engine selector. Presence-required: an omitted type is a
+    # 400, never the alphabetical-0 default (Black).
     # CapFloorModelSpec
     def ModelType(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
 def CapFloorModelSpecStart(builder):
     builder.StartObject(1)
@@ -39,7 +41,7 @@ def Start(builder):
     CapFloorModelSpecStart(builder)
 
 def CapFloorModelSpecAddModelType(builder, modelType):
-    builder.PrependInt8Slot(0, modelType, 0)
+    builder.PrependInt8Slot(0, modelType, None)
 
 def AddModelType(builder, modelType):
     CapFloorModelSpecAddModelType(builder, modelType)
@@ -55,7 +57,7 @@ class CapFloorModelSpecT(object):
 
     # CapFloorModelSpecT
     def __init__(self):
-        self.modelType = 0  # type: int
+        self.modelType = None  # type: Optional[int]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):

--- a/flatbuffers/python/quantra/EquityVanillaModelSpec.py
+++ b/flatbuffers/python/quantra/EquityVanillaModelSpec.py
@@ -25,12 +25,14 @@ class EquityVanillaModelSpec(object):
     def Init(self, buf, pos):
         self._tab = flatbuffers.table.Table(buf, pos)
 
+    # Pricing model / engine selector. Presence-required: an omitted type is a
+    # 400, never the alphabetical-0 default (BlackScholesAnalytic).
     # EquityVanillaModelSpec
     def ModelType(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # EquityVanillaModelSpec
     def BinomialSteps(self):
@@ -46,7 +48,7 @@ def Start(builder):
     EquityVanillaModelSpecStart(builder)
 
 def EquityVanillaModelSpecAddModelType(builder, modelType):
-    builder.PrependInt8Slot(0, modelType, 0)
+    builder.PrependInt8Slot(0, modelType, None)
 
 def AddModelType(builder, modelType):
     EquityVanillaModelSpecAddModelType(builder, modelType)
@@ -68,7 +70,7 @@ class EquityVanillaModelSpecT(object):
 
     # EquityVanillaModelSpecT
     def __init__(self):
-        self.modelType = 0  # type: int
+        self.modelType = None  # type: Optional[int]
         self.binomialSteps = 500  # type: int
 
     @classmethod

--- a/flatbuffers/python/quantra/IrVolBaseSpec.py
+++ b/flatbuffers/python/quantra/IrVolBaseSpec.py
@@ -60,12 +60,15 @@ class IrVolBaseSpec(object):
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
         return 0
 
+    # Quotation convention of the supplied vols. Presence-required: an omitted
+    # type is a 400, never the alphabetical-0 default (Normal), which would
+    # price a lognormal-quoted surface as normal vols.
     # IrVolBaseSpec
     def VolatilityType(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(14))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # Only meaningful for ShiftedLognormal.
     # IrVolBaseSpec
@@ -127,7 +130,7 @@ def AddShape(builder, shape):
     IrVolBaseSpecAddShape(builder, shape)
 
 def IrVolBaseSpecAddVolatilityType(builder, volatilityType):
-    builder.PrependInt8Slot(5, volatilityType, 0)
+    builder.PrependInt8Slot(5, volatilityType, None)
 
 def AddVolatilityType(builder, volatilityType):
     IrVolBaseSpecAddVolatilityType(builder, volatilityType)
@@ -166,7 +169,7 @@ class IrVolBaseSpecT(object):
         self.businessDayConvention = None  # type: Optional[int]
         self.dayCounter = None  # type: Optional[int]
         self.shape = 0  # type: int
-        self.volatilityType = 0  # type: int
+        self.volatilityType = None  # type: Optional[int]
         self.displacement = 0.0  # type: float
         self.constantVol = 0.0  # type: float
         self.quoteId = None  # type: str

--- a/flatbuffers/python/quantra/Swaption.py
+++ b/flatbuffers/python/quantra/Swaption.py
@@ -25,21 +25,23 @@ class Swaption(object):
     def Init(self, buf, pos):
         self._tab = flatbuffers.table.Table(buf, pos)
 
-    # Exercise style: European, Bermudan, or American.
+    # Exercise style: European, Bermudan, or American. Presence-required: an
+    # omitted style is a 400, never the alphabetical-0 default (European).
     # Swaption
     def ExerciseType(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
-    # Settlement type for swaption payoff handling.
+    # Settlement type for swaption payoff handling. Presence-required: an
+    # omitted type is a 400, never the alphabetical-0 default (Physical).
     # Swaption
     def SettlementType(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # Settlement method (physical/other) per market convention.
     # Swaption
@@ -103,13 +105,13 @@ def Start(builder):
     SwaptionStart(builder)
 
 def SwaptionAddExerciseType(builder, exerciseType):
-    builder.PrependInt8Slot(0, exerciseType, 0)
+    builder.PrependInt8Slot(0, exerciseType, None)
 
 def AddExerciseType(builder, exerciseType):
     SwaptionAddExerciseType(builder, exerciseType)
 
 def SwaptionAddSettlementType(builder, settlementType):
-    builder.PrependInt8Slot(1, settlementType, 0)
+    builder.PrependInt8Slot(1, settlementType, None)
 
 def AddSettlementType(builder, settlementType):
     SwaptionAddSettlementType(builder, settlementType)
@@ -165,8 +167,8 @@ class SwaptionT(object):
 
     # SwaptionT
     def __init__(self):
-        self.exerciseType = 0  # type: int
-        self.settlementType = 0  # type: int
+        self.exerciseType = None  # type: Optional[int]
+        self.settlementType = None  # type: Optional[int]
         self.settlementMethod = 0  # type: int
         self.exerciseDate = None  # type: str
         self.exerciseDates = None  # type: List[str]

--- a/flatbuffers/python/quantra/SwaptionModelSpec.py
+++ b/flatbuffers/python/quantra/SwaptionModelSpec.py
@@ -25,13 +25,14 @@ class SwaptionModelSpec(object):
     def Init(self, buf, pos):
         self._tab = flatbuffers.table.Table(buf, pos)
 
-    # Swaption pricing model type.
+    # Swaption pricing model type. Presence-required: an omitted type is a
+    # 400, never the alphabetical-0 default (Black).
     # SwaptionModelSpec
     def ModelType(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # Explicit Hull-White "a" used when param_mode=Explicit.
     # SwaptionModelSpec
@@ -84,7 +85,7 @@ def Start(builder):
     SwaptionModelSpecStart(builder)
 
 def SwaptionModelSpecAddModelType(builder, modelType):
-    builder.PrependInt8Slot(0, modelType, 0)
+    builder.PrependInt8Slot(0, modelType, None)
 
 def AddModelType(builder, modelType):
     SwaptionModelSpecAddModelType(builder, modelType)
@@ -134,7 +135,7 @@ class SwaptionModelSpecT(object):
 
     # SwaptionModelSpecT
     def __init__(self):
-        self.modelType = 0  # type: int
+        self.modelType = None  # type: Optional[int]
         self.hwA = 0.03  # type: float
         self.hwSigma = 0.01  # type: float
         self.latticeSteps = 50  # type: int

--- a/src/evaluators/cap_floor_evaluator.cpp
+++ b/src/evaluators/cap_floor_evaluator.cpp
@@ -59,7 +59,8 @@ std::shared_ptr<QuantLib::PricingEngine> buildEngine(
         case IrModelTypeKind::HullWhiteLattice:
             QUANTRA_INVALID_ARGUMENT("Model '" + modelId + "': HullWhiteLattice is not supported for cap/floor");
     }
-    QUANTRA_INVALID_ARGUMENT("Model '" + modelId + "': Unknown IrModelType value " +
+    QUANTRA_INVALID_ARGUMENT("Model '" + modelId +
+                  "': CapFloorModelSpec.model_type is not a known model type: " +
                   std::to_string(static_cast<int>(model.model_type)));
     return nullptr;
 }

--- a/src/evaluators/equity_option_evaluator.cpp
+++ b/src/evaluators/equity_option_evaluator.cpp
@@ -183,7 +183,9 @@ EquityOptionPerTrade priceTrade(const EquityOptionTrade& trade,
                             break;
                         }
                         default:
-                            QUANTRA_INVALID_ARGUMENT("Unsupported EquityModelType");
+                            QUANTRA_INVALID_ARGUMENT(
+                                "EquityVanillaModelSpec.model_type is not a known model type: " +
+                                std::to_string(static_cast<int>(equityModel->model_type)));
                     }
                     break;
                 case QuantLib::Exercise::American:

--- a/src/evaluators/swaption_evaluator.cpp
+++ b/src/evaluators/swaption_evaluator.cpp
@@ -153,7 +153,9 @@ std::shared_ptr<QuantLib::Swaption> buildSwaptionInstrument(
                 inst.exerciseDate);
             break;
         default:
-            QUANTRA_INVALID_ARGUMENT("Invalid exercise type");
+            QUANTRA_INVALID_ARGUMENT(
+                "Swaption.exercise_type is not a known exercise style: " +
+                std::to_string(static_cast<int>(exerciseType)));
     }
 
     QuantLib::Settlement::Type settlementType;
@@ -167,7 +169,9 @@ std::shared_ptr<QuantLib::Swaption> buildSwaptionInstrument(
         default:
             // Fail closed: an unknown settlement type must not
             // silently price as Physical (mirrors the exercise-type switch).
-            QUANTRA_INVALID_ARGUMENT("Invalid settlement type");
+            QUANTRA_INVALID_ARGUMENT(
+                "Swaption.settlement_type is not a known settlement type: " +
+                std::to_string(static_cast<int>(inst.settlementType)));
     }
 
     return std::make_shared<QuantLib::Swaption>(
@@ -348,7 +352,8 @@ std::shared_ptr<QuantLib::PricingEngine> buildEngine(
             return std::make_shared<QuantLib::TreeSwaptionEngine>(hwModel, model.lattice_steps);
         }
     }
-    QUANTRA_INVALID_ARGUMENT("Model '" + modelId + "': Unknown IrModelType value " +
+    QUANTRA_INVALID_ARGUMENT("Model '" + modelId +
+                  "': SwaptionModelSpec.model_type is not a known model type: " +
                   std::to_string(static_cast<int>(model.model_type)));
     return nullptr;
 }

--- a/src/mappers/calibrate_swaption_model_mapper.cpp
+++ b/src/mappers/calibrate_swaption_model_mapper.cpp
@@ -71,7 +71,11 @@ CalibrateSwaptionModelInputs CalibrateSwaptionModelMapper::toInputs(
     if (modelSpec == nullptr) {
         QUANTRA_NOT_FOUND("Model not found: " + inputs.modelId);
     }
-    if (modelSpec->model_type() != quantra::enums::IrModelType_HullWhiteLattice) {
+    if (!modelSpec->model_type().has_value()) {
+        QUANTRA_INVALID_ARGUMENT(
+            "SwaptionModelSpec.model_type is required for model id: " + inputs.modelId);
+    }
+    if (modelSpec->model_type().value() != quantra::enums::IrModelType_HullWhiteLattice) {
         QUANTRA_INVALID_ARGUMENT(
             "Model '" + inputs.modelId + "' must be HullWhiteLattice for calibration");
     }

--- a/src/mappers/swaption_mapper.cpp
+++ b/src/mappers/swaption_mapper.cpp
@@ -198,7 +198,10 @@ OisSwapTrade extractOisUnderlying(const quantra::OisSwap* swap) {
 /// legacy per-call parse().
 SwaptionInstrument extractInstrument(const quantra::Swaption* sw) {
     SwaptionInstrument inst;
-    inst.exerciseType = sw->exercise_type();
+    if (!sw->exercise_type().has_value()) {
+        QUANTRA_INVALID_ARGUMENT("Swaption.exercise_type is required");
+    }
+    inst.exerciseType = sw->exercise_type().value();
 
     inst.hasExerciseDate = (sw->exercise_date() != nullptr);
     if (inst.hasExerciseDate) {
@@ -215,7 +218,10 @@ SwaptionInstrument extractInstrument(const quantra::Swaption* sw) {
         }
     }
 
-    inst.settlementType = sw->settlement_type();
+    if (!sw->settlement_type().has_value()) {
+        QUANTRA_INVALID_ARGUMENT("Swaption.settlement_type is required");
+    }
+    inst.settlementType = sw->settlement_type().value();
     inst.settlementMethod = SettlementMethodToQL(sw->settlement_method());
 
     switch (sw->underlying_type()) {

--- a/src/market/engine_factory.cpp
+++ b/src/market/engine_factory.cpp
@@ -57,8 +57,11 @@ std::shared_ptr<QuantLib::PricingEngine> EngineFactory::makeCapFloorEngine(
     if (!spec) {
         QUANTRA_INVALID_ARGUMENT("Model '" + modelId + "' has null CapFloorModelSpec payload");
     }
-    
-    auto modelType = spec->model_type();
+
+    if (!spec->model_type().has_value()) {
+        QUANTRA_INVALID_ARGUMENT("CapFloorModelSpec.model_type is required for model id: " + modelId);
+    }
+    auto modelType = spec->model_type().value();
 
     // =========================================================================
     // Validate model/vol compatibility and create engine
@@ -90,7 +93,8 @@ std::shared_ptr<QuantLib::PricingEngine> EngineFactory::makeCapFloorEngine(
                 discountCurve, volEntry.handle);
 
         default:
-            QUANTRA_INVALID_ARGUMENT("Model '" + modelId + "': Unknown IrModelType value " 
+            QUANTRA_INVALID_ARGUMENT("Model '" + modelId +
+                          "': CapFloorModelSpec.model_type is not a known model type: "
                           + std::to_string(modelType));
     }
     
@@ -120,8 +124,11 @@ std::shared_ptr<QuantLib::PricingEngine> EngineFactory::makeSwaptionEngine(
     if (!spec) {
         QUANTRA_INVALID_ARGUMENT("Model '" + modelId + "' has null SwaptionModelSpec payload");
     }
-    
-    auto modelType = spec->model_type();
+
+    if (!spec->model_type().has_value()) {
+        QUANTRA_INVALID_ARGUMENT("SwaptionModelSpec.model_type is required for model id: " + modelId);
+    }
+    auto modelType = spec->model_type().value();
 
     // =========================================================================
     // SABR vol kinds return Black (lognormal) vols via the Hagan expansion;
@@ -179,7 +186,8 @@ std::shared_ptr<QuantLib::PricingEngine> EngineFactory::makeSwaptionEngine(
         }
 
         default:
-            QUANTRA_INVALID_ARGUMENT("Model '" + modelId + "': Unknown IrModelType value "
+            QUANTRA_INVALID_ARGUMENT("Model '" + modelId +
+                          "': SwaptionModelSpec.model_type is not a known model type: "
                           + std::to_string(modelType));
     }
     

--- a/src/market/pricing_registry.cpp
+++ b/src/market/pricing_registry.cpp
@@ -226,15 +226,23 @@ PricingRegistry PricingRegistryBuilder::build(const quantra::Pricing* pricing,
             switch (spec->payload_type()) {
                 case quantra::ModelPayload_CapFloorModelSpec: {
                     const auto* p = spec->payload_as_CapFloorModelSpec();
+                    if (!p->model_type().has_value()) {
+                        QUANTRA_INVALID_ARGUMENT(
+                            "CapFloorModelSpec.model_type is required for model id: " + id);
+                    }
                     CapFloorModelDomain d;
-                    d.model_type = static_cast<IrModelTypeKind>(p->model_type());
+                    d.model_type = static_cast<IrModelTypeKind>(p->model_type().value());
                     domain.payload = d;
                     break;
                 }
                 case quantra::ModelPayload_SwaptionModelSpec: {
                     const auto* p = spec->payload_as_SwaptionModelSpec();
+                    if (!p->model_type().has_value()) {
+                        QUANTRA_INVALID_ARGUMENT(
+                            "SwaptionModelSpec.model_type is required for model id: " + id);
+                    }
                     SwaptionModelDomain d;
-                    d.model_type = static_cast<IrModelTypeKind>(p->model_type());
+                    d.model_type = static_cast<IrModelTypeKind>(p->model_type().value());
                     d.hw_a = p->hw_a();
                     d.hw_sigma = p->hw_sigma();
                     d.lattice_steps = p->lattice_steps();
@@ -281,8 +289,12 @@ PricingRegistry PricingRegistryBuilder::build(const quantra::Pricing* pricing,
                 }
                 case quantra::ModelPayload_EquityVanillaModelSpec: {
                     const auto* p = spec->payload_as_EquityVanillaModelSpec();
+                    if (!p->model_type().has_value()) {
+                        QUANTRA_INVALID_ARGUMENT(
+                            "EquityVanillaModelSpec.model_type is required for model id: " + id);
+                    }
                     EquityVanillaModelDomain d;
-                    d.model_type = static_cast<EquityModelTypeKind>(p->model_type());
+                    d.model_type = static_cast<EquityModelTypeKind>(p->model_type().value());
                     d.binomial_steps = p->binomial_steps();
                     domain.payload = d;
                     break;

--- a/src/parsers/vol_surface_parsers.cpp
+++ b/src/parsers/vol_surface_parsers.cpp
@@ -53,7 +53,9 @@ QuantLib::VolatilityType toQlVolType(quantra::enums::VolatilityType t) {
             return QuantLib::ShiftedLognormal;
             
         default:
-            QUANTRA_INVALID_ARGUMENT("Unknown VolatilityType enum value: " + std::to_string(static_cast<int>(t)));
+            QUANTRA_INVALID_ARGUMENT(
+                "IrVolBaseSpec.volatility_type is not a known volatility type: " +
+                std::to_string(static_cast<int>(t)));
     }
     return QuantLib::ShiftedLognormal; // Unreachable, but suppresses warning
 }
@@ -66,6 +68,16 @@ namespace {
 
 bool isBlankString(const std::string& s) {
     return std::all_of(s.begin(), s.end(), [](unsigned char c) { return std::isspace(c) != 0; });
+}
+
+/// Read the presence-required quotation convention off an IrVolBaseSpec. An
+/// omitted value must not fall through to the alphabetical-0 enum (Normal),
+/// which would price a lognormal-quoted surface as normal vols.
+quantra::enums::VolatilityType requiredVolType(const quantra::IrVolBaseSpec* b, const std::string& id) {
+    if (!b || !b->volatility_type().has_value()) {
+        QUANTRA_INVALID_ARGUMENT("IrVolBaseSpec.volatility_type is required for vol id: " + id);
+    }
+    return b->volatility_type().value();
 }
 
 void validateIrVolBaseCommon(const quantra::IrVolBaseSpec* b, const std::string& id) {
@@ -85,7 +97,7 @@ void validateIrVolBaseCommon(const quantra::IrVolBaseSpec* b, const std::string&
         QUANTRA_INVALID_ARGUMENT("IrVolBaseSpec.day_counter is required for vol id: " + id);
     }
 
-    auto volType = b->volatility_type();
+    auto volType = requiredVolType(b, id);
     double disp = b->displacement();
     
     if (volType == quantra::enums::VolatilityType_ShiftedLognormal && disp <= 0.0) {
@@ -889,7 +901,7 @@ OptionletVolEntry parseOptionletVol(const quantra::VolSurfaceSpec* spec, const Q
     QuantLib::DayCounter dc = DayCounterToQL(b->day_counter().value());
     double vol = resolveVolValue(b->constant_vol(), b->quote_id(), quotes, id);
     double disp = b->displacement();
-    QuantLib::VolatilityType qlType = toQlVolType(b->volatility_type());
+    QuantLib::VolatilityType qlType = toQlVolType(requiredVolType(b, id));
 
     auto qlVol = std::make_shared<QuantLib::ConstantOptionletVolatility>(
         ref, cal, bdc, vol, dc, qlType, disp
@@ -944,7 +956,7 @@ SwaptionVolEntry parseSwaptionVol(const quantra::VolSurfaceSpec* spec, const Quo
             QuantLib::DayCounter dc = DayCounterToQL(b->day_counter().value());
             double vol = resolveVolValue(b->constant_vol(), b->quote_id(), quotes, id);
             double disp = b->displacement();
-            QuantLib::VolatilityType qlType = toQlVolType(b->volatility_type());
+            QuantLib::VolatilityType qlType = toQlVolType(requiredVolType(b, id));
 
             auto qlVol = std::make_shared<QuantLib::ConstantSwaptionVolatility>(
                 ref, cal, bdc, vol, dc, qlType, disp
@@ -979,7 +991,7 @@ SwaptionVolEntry parseSwaptionVol(const quantra::VolSurfaceSpec* spec, const Quo
             QuantLib::BusinessDayConvention bdc = ConventionToQL(b->business_day_convention().value());
             QuantLib::DayCounter dc = DayCounterToQL(b->day_counter().value());
             double disp = b->displacement();
-            QuantLib::VolatilityType qlType = toQlVolType(b->volatility_type());
+            QuantLib::VolatilityType qlType = toQlVolType(requiredVolType(b, id));
 
             if (!payload->expiries() || !payload->tenors()) {
                 QUANTRA_INVALID_ARGUMENT("SwaptionVolAtmMatrixSpec expiries/tenors missing for vol id: " + id);
@@ -1062,7 +1074,7 @@ SwaptionVolEntry parseSwaptionVol(const quantra::VolSurfaceSpec* spec, const Quo
             QuantLib::BusinessDayConvention bdc = ConventionToQL(b->business_day_convention().value());
             QuantLib::DayCounter dc = DayCounterToQL(b->day_counter().value());
             double disp = b->displacement();
-            QuantLib::VolatilityType qlType = toQlVolType(b->volatility_type());
+            QuantLib::VolatilityType qlType = toQlVolType(requiredVolType(b, id));
 
             if (!payload->expiries() || !payload->tenors() || !payload->strikes()) {
                 QUANTRA_INVALID_ARGUMENT("SwaptionVolSmileCubeSpec grids missing for vol id: " + id);
@@ -1163,7 +1175,7 @@ SwaptionVolEntry parseSwaptionVol(const quantra::VolSurfaceSpec* spec, const Quo
             // when displacement > 0). Normal SABR is a separate model with its
             // own engine pairing rules; reject for v1 rather than producing
             // wrong vols silently.
-            if (b->volatility_type() == quantra::enums::VolatilityType_Normal) {
+            if (requiredVolType(b, id) == quantra::enums::VolatilityType_Normal) {
                 QUANTRA_INVALID_ARGUMENT(
                     "SwaptionSabrParamsSpec only supports Lognormal/ShiftedLognormal vol type "
                     "(Normal SABR is intentionally not supported for v1) for vol id: " + id);
@@ -1174,7 +1186,7 @@ SwaptionVolEntry parseSwaptionVol(const quantra::VolSurfaceSpec* spec, const Quo
             QuantLib::BusinessDayConvention bdc = ConventionToQL(b->business_day_convention().value());
             QuantLib::DayCounter dc = DayCounterToQL(b->day_counter().value());
             double disp = b->displacement();
-            QuantLib::VolatilityType qlType = toQlVolType(b->volatility_type());
+            QuantLib::VolatilityType qlType = toQlVolType(requiredVolType(b, id));
 
             if (!payload->expiries() || !payload->tenors()) {
                 QUANTRA_INVALID_ARGUMENT("SwaptionSabrParamsSpec expiries/tenors missing for vol id: " + id);
@@ -1278,7 +1290,7 @@ SwaptionVolEntry parseSwaptionVol(const quantra::VolSurfaceSpec* spec, const Quo
 
             // SABR via Hagan returns lognormal Black vol. Normal SABR is a
             // separate model with its own engine-pairing rules; reject for v1.
-            if (b->volatility_type() == quantra::enums::VolatilityType_Normal) {
+            if (requiredVolType(b, id) == quantra::enums::VolatilityType_Normal) {
                 QUANTRA_INVALID_ARGUMENT(
                     "SwaptionSabrCalibrateSpec only supports Lognormal/ShiftedLognormal vol type "
                     "(Normal SABR is intentionally not supported for v1) for vol id: " + id);
@@ -1300,7 +1312,7 @@ SwaptionVolEntry parseSwaptionVol(const quantra::VolSurfaceSpec* spec, const Quo
             QuantLib::BusinessDayConvention bdc = ConventionToQL(b->business_day_convention().value());
             QuantLib::DayCounter dc = DayCounterToQL(b->day_counter().value());
             double disp = b->displacement();
-            QuantLib::VolatilityType qlType = toQlVolType(b->volatility_type());
+            QuantLib::VolatilityType qlType = toQlVolType(requiredVolType(b, id));
 
             if (!payload->expiries() || !payload->tenors() || !payload->strikes()) {
                 QUANTRA_INVALID_ARGUMENT("SwaptionSabrCalibrateSpec expiries/tenors/strikes missing for vol id: " + id);

--- a/tests/contract/error_contract_test.py
+++ b/tests/contract/error_contract_test.py
@@ -293,6 +293,17 @@ def _ec_identity(req):
     return req
 
 
+def _ec_del_model_payload_field(field):
+    """Drop a field from every model payload in the request. model_type selects
+    the pricing engine, so it is presence-required: an omitted value is an
+    error, never an alphabetical-0 default."""
+    def f(req):
+        for m in req["pricing"].get("volatility", {}).get("models", []):
+            m["payload"].pop(field, None)
+        return req
+    return f
+
+
 def _ec_set_model_payload_field(field, value):
     def f(req):
         for m in req["pricing"].get("volatility", {}).get("models", []):
@@ -648,6 +659,47 @@ SCENARIOS = [
      "swaption_request.json", 400,
      _ec_del_vol_base_field("calendar"),
      _ec_body_contains("IrVolBaseSpec.calendar is required")),
+    # ---- 400 INVALID_ARGUMENT: vol quotation convention presence ----
+    # volatility_type says whether the supplied numbers are normal or lognormal
+    # vols. An omitted value is indistinguishable from the alphabetical-0
+    # default (Normal), which would price a lognormal-quoted surface as normal
+    # vols, so it must be rejected instead.
+    ("ec:400 swaption vol base missing volatility_type", "swaption",
+     "swaption_request.json", 400,
+     _ec_del_vol_base_field("volatility_type"),
+     _ec_body_contains("IrVolBaseSpec.volatility_type is required")),
+    ("ec:400 cap_floor vol base missing volatility_type", "cap_floor",
+     "cap_floor_request.json", 400,
+     _ec_del_vol_base_field("volatility_type"),
+     _ec_body_contains("IrVolBaseSpec.volatility_type is required")),
+    # ---- 400 INVALID_ARGUMENT: pricing-model discriminator presence ----
+    # model_type selects the pricing engine. An omitted value is
+    # indistinguishable from the alphabetical-0 default (Black for the rate
+    # models, BlackScholesAnalytic for equity), so it must be rejected rather
+    # than silently pricing on an engine the caller never asked for.
+    ("ec:400 swaption model missing model_type", "swaption",
+     "swaption_request.json", 400,
+     _ec_del_model_payload_field("model_type"),
+     _ec_body_contains("SwaptionModelSpec.model_type is required")),
+    ("ec:400 cap_floor model missing model_type", "cap_floor",
+     "cap_floor_request.json", 400,
+     _ec_del_model_payload_field("model_type"),
+     _ec_body_contains("CapFloorModelSpec.model_type is required")),
+    ("ec:400 equity_option model missing model_type", "equity_option",
+     "equity_option_request.json", 400,
+     _ec_del_model_payload_field("model_type"),
+     _ec_body_contains("EquityVanillaModelSpec.model_type is required")),
+    # ---- 400 INVALID_ARGUMENT: swaption exercise/settlement discriminators ----
+    # Both decide the payoff. An omitted value is indistinguishable from the
+    # alphabetical-0 default (European / Physical), so it must be rejected.
+    ("ec:400 swaption missing exercise_type", "swaption",
+     "swaption_request.json", 400,
+     _ec_del_instrument_field("swaptions", "swaption", "exercise_type"),
+     _ec_body_contains("Swaption.exercise_type is required")),
+    ("ec:400 swaption missing settlement_type", "swaption",
+     "swaption_request.json", 400,
+     _ec_del_instrument_field("swaptions", "swaption", "settlement_type"),
+     _ec_body_contains("Swaption.settlement_type is required")),
     # ---- 400 INVALID_ARGUMENT: FRA / cap-floor / CDS convention presence ----
     # An FRA, cap/floor or CDS convention enum omitted from the request must be
     # rejected, not silently defaulted to the alphabetical-0 value.
@@ -759,7 +811,7 @@ SCENARIOS = [
     ("ec:400 swaption settlement type out of range", "swaption",
      "swaption_request.json", 400,
      _ec_set_nested_field("swaptions", "swaption", "settlement_type", 99),
-     _ec_body_contains("Invalid settlement type")),
+     _ec_body_contains("Swaption.settlement_type is not a known settlement type")),
     # ---- 400 INVALID_ARGUMENT: equity exercise-style / payoff combinations
     #      QuantLib does not natively support are rejected, never silently
     #      re-routed to a different product. ----


### PR DESCRIPTION
**Second step of the schema completion batch.** Six more discriminators could be omitted and silently took the first enum value. Now optional-with-presence, returning a 400 naming table and field:

- **`IrVolBaseSpec.volatility_type`** — the costly one: a lognormal-quoted surface sent without a type was priced as **normal vols**. Guarded through a single helper at all nine read sites, so no raw read remains.
- **`model_type`** on the cap/floor, swaption and equity model specs.
- **`Swaption.exercise_type`** (silently European) and **`settlement_type`** (silently Physical).

Out-of-range wire values still fail closed, now naming the field and the offending value.

**Migration**: an audit of all 208 request JSONs (parsed, resolving union wrappers rather than text-matching) plus every C++ and Python builder found **three example requests genuinely relying on the implicit exercise type** — they now state `European` explicitly, preserving behavior. None is a catalog input; no catalog file changed and no priced result moved.

**Cache-key check**: the volatility and Hull-White calibration keys already store the *resolved* volatility type together with `displacement`; since the parser enforces Lognormal ⇒ displacement 0 and ShiftedLognormal ⇒ displacement > 0, that pair distinguishes all three wire values. No under-keying, no key change needed.

Seven error-contract scenarios. Full suite green (640 cases). Wire-breaking; lands in 0.5.0 with its migration guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
