### PR TITLE
Repoint an error-contract scenario to a surviving example file

### DIFF
--- a/tests/contract/error_contract_test.py
+++ b/tests/contract/error_contract_test.py
@@ -728,7 +728,7 @@ SCENARIOS = [
      _ec_del_model_payload_field("model_type"),
      _ec_body_contains("CapFloorModelSpec.model_type is required")),
     ("ec:400 equity_option model missing model_type", "equity_option",
-     "equity_option_request.json", 400,
+     "equity/eqopt_eur_call_atm_1y.json", 400,
      _ec_del_model_payload_field("model_type"),
      _ec_body_contains("EquityVanillaModelSpec.model_type is required")),
     # ---- 400 INVALID_ARGUMENT: swaption exercise/settlement discriminators ----


### PR DESCRIPTION
**Restores a green master.** Merging two individually-green PRs left a dangling reference: one added an error-contract scenario loading `examples/data/equity_option_request.json`, another removed that flat file in the nested-example cleanup. The scenario now points at `equity/eqopt_eur_call_atm_1y.json` — the nested example its sibling equity scenarios already use, carrying the same `EquityVanillaModelSpec.model_type` the mutation targets.

One line. Full suite green (646 cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
