### PR TITLE
Require explicit values for notionals, strikes, quotes and redemptions

### DIFF
--- a/flatbuffers/cpp/callable_fixed_rate_bond_generated.h
+++ b/flatbuffers/cpp/callable_fixed_rate_bond_generated.h
@@ -130,7 +130,7 @@ inline ::flatbuffers::Offset<CallabilityEntry> CreateCallabilityEntryDirect(
 struct CallableFixedRateBondT : public ::flatbuffers::NativeTable {
   typedef CallableFixedRateBond TableType;
   int32_t settlement_days = 0;
-  double face_amount = 0.0;
+  ::flatbuffers::Optional<double> face_amount = ::flatbuffers::nullopt;
   double rate = 0.0;
   ::flatbuffers::Optional<quantra::enums::DayCounter> accrual_day_counter = ::flatbuffers::nullopt;
   ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> payment_convention = ::flatbuffers::nullopt;
@@ -168,8 +168,10 @@ struct CallableFixedRateBond FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Ta
   int32_t settlement_days() const {
     return GetField<int32_t>(VT_SETTLEMENT_DAYS, 0);
   }
-  double face_amount() const {
-    return GetField<double>(VT_FACE_AMOUNT, 0.0);
+  /// Face amount. Presence-required and must be > 0 (a bare double would
+  /// default to a silent zero face).
+  ::flatbuffers::Optional<double> face_amount() const {
+    return GetOptional<double, double>(VT_FACE_AMOUNT);
   }
   double rate() const {
     return GetField<double>(VT_RATE, 0.0);
@@ -224,7 +226,7 @@ struct CallableFixedRateBondBuilder {
     fbb_.AddElement<int32_t>(CallableFixedRateBond::VT_SETTLEMENT_DAYS, settlement_days, 0);
   }
   void add_face_amount(double face_amount) {
-    fbb_.AddElement<double>(CallableFixedRateBond::VT_FACE_AMOUNT, face_amount, 0.0);
+    fbb_.AddElement<double>(CallableFixedRateBond::VT_FACE_AMOUNT, face_amount);
   }
   void add_rate(double rate) {
     fbb_.AddElement<double>(CallableFixedRateBond::VT_RATE, rate, 0.0);
@@ -262,7 +264,7 @@ struct CallableFixedRateBondBuilder {
 inline ::flatbuffers::Offset<CallableFixedRateBond> CreateCallableFixedRateBond(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     int32_t settlement_days = 0,
-    double face_amount = 0.0,
+    ::flatbuffers::Optional<double> face_amount = ::flatbuffers::nullopt,
     double rate = 0.0,
     ::flatbuffers::Optional<quantra::enums::DayCounter> accrual_day_counter = ::flatbuffers::nullopt,
     ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> payment_convention = ::flatbuffers::nullopt,
@@ -273,7 +275,7 @@ inline ::flatbuffers::Offset<CallableFixedRateBond> CreateCallableFixedRateBond(
   CallableFixedRateBondBuilder builder_(_fbb);
   builder_.add_redemption(redemption);
   builder_.add_rate(rate);
-  builder_.add_face_amount(face_amount);
+  if(face_amount) { builder_.add_face_amount(*face_amount); }
   builder_.add_call_schedule(call_schedule);
   builder_.add_schedule(schedule);
   builder_.add_issue_date(issue_date);
@@ -286,7 +288,7 @@ inline ::flatbuffers::Offset<CallableFixedRateBond> CreateCallableFixedRateBond(
 inline ::flatbuffers::Offset<CallableFixedRateBond> CreateCallableFixedRateBondDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     int32_t settlement_days = 0,
-    double face_amount = 0.0,
+    ::flatbuffers::Optional<double> face_amount = ::flatbuffers::nullopt,
     double rate = 0.0,
     ::flatbuffers::Optional<quantra::enums::DayCounter> accrual_day_counter = ::flatbuffers::nullopt,
     ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> payment_convention = ::flatbuffers::nullopt,

--- a/flatbuffers/cpp/cap_floor_generated.h
+++ b/flatbuffers/cpp/cap_floor_generated.h
@@ -26,8 +26,8 @@ struct CapFloorT;
 struct CapFloorT : public ::flatbuffers::NativeTable {
   typedef CapFloor TableType;
   ::flatbuffers::Optional<quantra::enums::CapFloorType> cap_floor_type = ::flatbuffers::nullopt;
-  double notional = 0.0;
-  double strike = 0.0;
+  ::flatbuffers::Optional<double> notional = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<double> strike = ::flatbuffers::nullopt;
   std::unique_ptr<quantra::ScheduleT> schedule{};
   std::unique_ptr<quantra::IndexRefT> index{};
   ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt;
@@ -54,12 +54,14 @@ struct CapFloor FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   ::flatbuffers::Optional<quantra::enums::CapFloorType> cap_floor_type() const {
     return GetOptional<int8_t, quantra::enums::CapFloorType>(VT_CAP_FLOOR_TYPE);
   }
-  double notional() const {
-    return GetField<double>(VT_NOTIONAL, 0.0);
+  /// Notional. Presence-required and must be > 0.
+  ::flatbuffers::Optional<double> notional() const {
+    return GetOptional<double, double>(VT_NOTIONAL);
   }
-  /// Strike rate (e.g., 0.04 for 4%).
-  double strike() const {
-    return GetField<double>(VT_STRIKE, 0.0);
+  /// Strike rate (e.g., 0.04 for 4%). Presence-required; may be negative, only
+  /// a missing or non-finite value is rejected.
+  ::flatbuffers::Optional<double> strike() const {
+    return GetOptional<double, double>(VT_STRIKE);
   }
   const quantra::Schedule *schedule() const {
     return GetPointer<const quantra::Schedule *>(VT_SCHEDULE);
@@ -100,10 +102,10 @@ struct CapFloorBuilder {
     fbb_.AddElement<int8_t>(CapFloor::VT_CAP_FLOOR_TYPE, static_cast<int8_t>(cap_floor_type));
   }
   void add_notional(double notional) {
-    fbb_.AddElement<double>(CapFloor::VT_NOTIONAL, notional, 0.0);
+    fbb_.AddElement<double>(CapFloor::VT_NOTIONAL, notional);
   }
   void add_strike(double strike) {
-    fbb_.AddElement<double>(CapFloor::VT_STRIKE, strike, 0.0);
+    fbb_.AddElement<double>(CapFloor::VT_STRIKE, strike);
   }
   void add_schedule(::flatbuffers::Offset<quantra::Schedule> schedule) {
     fbb_.AddOffset(CapFloor::VT_SCHEDULE, schedule);
@@ -132,15 +134,15 @@ struct CapFloorBuilder {
 inline ::flatbuffers::Offset<CapFloor> CreateCapFloor(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     ::flatbuffers::Optional<quantra::enums::CapFloorType> cap_floor_type = ::flatbuffers::nullopt,
-    double notional = 0.0,
-    double strike = 0.0,
+    ::flatbuffers::Optional<double> notional = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<double> strike = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::Schedule> schedule = 0,
     ::flatbuffers::Offset<quantra::IndexRef> index = 0,
     ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
     ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt) {
   CapFloorBuilder builder_(_fbb);
-  builder_.add_strike(strike);
-  builder_.add_notional(notional);
+  if(strike) { builder_.add_strike(*strike); }
+  if(notional) { builder_.add_notional(*notional); }
   builder_.add_index(index);
   builder_.add_schedule(schedule);
   if(business_day_convention) { builder_.add_business_day_convention(*business_day_convention); }

--- a/flatbuffers/cpp/cds_generated.h
+++ b/flatbuffers/cpp/cds_generated.h
@@ -25,7 +25,7 @@ struct CDST;
 struct CDST : public ::flatbuffers::NativeTable {
   typedef CDS TableType;
   ::flatbuffers::Optional<quantra::enums::ProtectionSide> side = ::flatbuffers::nullopt;
-  double notional = 0.0;
+  ::flatbuffers::Optional<double> notional = ::flatbuffers::nullopt;
   ::flatbuffers::Optional<double> running_coupon = ::flatbuffers::nullopt;
   std::unique_ptr<quantra::ScheduleT> schedule{};
   ::flatbuffers::Optional<double> upfront = ::flatbuffers::nullopt;
@@ -69,8 +69,9 @@ struct CDS FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   ::flatbuffers::Optional<quantra::enums::ProtectionSide> side() const {
     return GetOptional<int8_t, quantra::enums::ProtectionSide>(VT_SIDE);
   }
-  double notional() const {
-    return GetField<double>(VT_NOTIONAL, 0.0);
+  /// Notional. Presence-required and must be > 0.
+  ::flatbuffers::Optional<double> notional() const {
+    return GetOptional<double, double>(VT_NOTIONAL);
   }
   /// Running coupon in decimal (0.01 = 100bps). Required; presence-driven
   /// (a genuine 0 is a valid zero-coupon CDS, an absent value is rejected).
@@ -152,7 +153,7 @@ struct CDSBuilder {
     fbb_.AddElement<int8_t>(CDS::VT_SIDE, static_cast<int8_t>(side));
   }
   void add_notional(double notional) {
-    fbb_.AddElement<double>(CDS::VT_NOTIONAL, notional, 0.0);
+    fbb_.AddElement<double>(CDS::VT_NOTIONAL, notional);
   }
   void add_running_coupon(double running_coupon) {
     fbb_.AddElement<double>(CDS::VT_RUNNING_COUPON, running_coupon);
@@ -207,7 +208,7 @@ struct CDSBuilder {
 inline ::flatbuffers::Offset<CDS> CreateCDS(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     ::flatbuffers::Optional<quantra::enums::ProtectionSide> side = ::flatbuffers::nullopt,
-    double notional = 0.0,
+    ::flatbuffers::Optional<double> notional = ::flatbuffers::nullopt,
     ::flatbuffers::Optional<double> running_coupon = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::Schedule> schedule = 0,
     ::flatbuffers::Optional<double> upfront = ::flatbuffers::nullopt,
@@ -224,7 +225,7 @@ inline ::flatbuffers::Offset<CDS> CreateCDS(
   CDSBuilder builder_(_fbb);
   if(upfront) { builder_.add_upfront(*upfront); }
   if(running_coupon) { builder_.add_running_coupon(*running_coupon); }
-  builder_.add_notional(notional);
+  if(notional) { builder_.add_notional(*notional); }
   builder_.add_cash_settlement_days(cash_settlement_days);
   builder_.add_trade_date(trade_date);
   builder_.add_upfront_date(upfront_date);
@@ -243,7 +244,7 @@ inline ::flatbuffers::Offset<CDS> CreateCDS(
 inline ::flatbuffers::Offset<CDS> CreateCDSDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     ::flatbuffers::Optional<quantra::enums::ProtectionSide> side = ::flatbuffers::nullopt,
-    double notional = 0.0,
+    ::flatbuffers::Optional<double> notional = ::flatbuffers::nullopt,
     ::flatbuffers::Optional<double> running_coupon = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::Schedule> schedule = 0,
     ::flatbuffers::Optional<double> upfront = ::flatbuffers::nullopt,

--- a/flatbuffers/cpp/coupon_pricer_generated.h
+++ b/flatbuffers/cpp/coupon_pricer_generated.h
@@ -34,7 +34,7 @@ struct ConstantOptionletVolatilityT : public ::flatbuffers::NativeTable {
   int32_t settlement_days = 0;
   ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt;
   ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt;
-  double volatility = 0.0;
+  ::flatbuffers::Optional<double> volatility = ::flatbuffers::nullopt;
   ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt;
 };
 
@@ -58,8 +58,13 @@ struct ConstantOptionletVolatility FLATBUFFERS_FINAL_CLASS : private ::flatbuffe
   ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention() const {
     return GetOptional<int8_t, quantra::enums::BusinessDayConvention>(VT_BUSINESS_DAY_CONVENTION);
   }
-  double volatility() const {
-    return GetField<double>(VT_VOLATILITY, 0.0);
+  /// Constant optionlet volatility. Presence-required (a bare double would
+  /// default to a silent zero) and must be finite and non-negative. A genuine
+  /// 0 is valid: for a coupon leg without caps/floors the Black pricer with
+  /// zero vol reproduces the deterministic forward, so 0 is accepted while an
+  /// omitted value is rejected.
+  ::flatbuffers::Optional<double> volatility() const {
+    return GetOptional<double, double>(VT_VOLATILITY);
   }
   ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter() const {
     return GetOptional<int8_t, quantra::enums::DayCounter>(VT_DAY_COUNTER);
@@ -92,7 +97,7 @@ struct ConstantOptionletVolatilityBuilder {
     fbb_.AddElement<int8_t>(ConstantOptionletVolatility::VT_BUSINESS_DAY_CONVENTION, static_cast<int8_t>(business_day_convention));
   }
   void add_volatility(double volatility) {
-    fbb_.AddElement<double>(ConstantOptionletVolatility::VT_VOLATILITY, volatility, 0.0);
+    fbb_.AddElement<double>(ConstantOptionletVolatility::VT_VOLATILITY, volatility);
   }
   void add_day_counter(quantra::enums::DayCounter day_counter) {
     fbb_.AddElement<int8_t>(ConstantOptionletVolatility::VT_DAY_COUNTER, static_cast<int8_t>(day_counter));
@@ -113,10 +118,10 @@ inline ::flatbuffers::Offset<ConstantOptionletVolatility> CreateConstantOptionle
     int32_t settlement_days = 0,
     ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
     ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt,
-    double volatility = 0.0,
+    ::flatbuffers::Optional<double> volatility = ::flatbuffers::nullopt,
     ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt) {
   ConstantOptionletVolatilityBuilder builder_(_fbb);
-  builder_.add_volatility(volatility);
+  if(volatility) { builder_.add_volatility(*volatility); }
   builder_.add_settlement_days(settlement_days);
   if(day_counter) { builder_.add_day_counter(*day_counter); }
   if(business_day_convention) { builder_.add_business_day_convention(*business_day_convention); }

--- a/flatbuffers/cpp/credit_curve_generated.h
+++ b/flatbuffers/cpp/credit_curve_generated.h
@@ -33,7 +33,7 @@ struct CreditCurveSpecT;
 struct CdsQuoteT : public ::flatbuffers::NativeTable {
   typedef CdsQuote TableType;
   std::unique_ptr<quantra::PeriodT> tenor{};
-  quantra::enums::CdsQuoteType quote_type = quantra::enums::CdsQuoteType_ParSpread;
+  ::flatbuffers::Optional<quantra::enums::CdsQuoteType> quote_type = ::flatbuffers::nullopt;
   std::string quote_id{};
   double quoted_par_spread = 0.0;
   double quoted_upfront = 0.0;
@@ -59,8 +59,10 @@ struct CdsQuote FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   const quantra::Period *tenor() const {
     return GetPointer<const quantra::Period *>(VT_TENOR);
   }
-  quantra::enums::CdsQuoteType quote_type() const {
-    return static_cast<quantra::enums::CdsQuoteType>(GetField<int8_t>(VT_QUOTE_TYPE, 0));
+  /// Quote convention (ParSpread / Upfront). Presence-required: an omitted
+  /// value is a 400, never the alphabetical-0 default (ParSpread).
+  ::flatbuffers::Optional<quantra::enums::CdsQuoteType> quote_type() const {
+    return GetOptional<int8_t, quantra::enums::CdsQuoteType>(VT_QUOTE_TYPE);
   }
   /// Optional; resolves from Pricing.quotes (QuoteType=Credit).
   const ::flatbuffers::String *quote_id() const {
@@ -105,7 +107,7 @@ struct CdsQuoteBuilder {
     fbb_.AddOffset(CdsQuote::VT_TENOR, tenor);
   }
   void add_quote_type(quantra::enums::CdsQuoteType quote_type) {
-    fbb_.AddElement<int8_t>(CdsQuote::VT_QUOTE_TYPE, static_cast<int8_t>(quote_type), 0);
+    fbb_.AddElement<int8_t>(CdsQuote::VT_QUOTE_TYPE, static_cast<int8_t>(quote_type));
   }
   void add_quote_id(::flatbuffers::Offset<::flatbuffers::String> quote_id) {
     fbb_.AddOffset(CdsQuote::VT_QUOTE_ID, quote_id);
@@ -133,7 +135,7 @@ struct CdsQuoteBuilder {
 inline ::flatbuffers::Offset<CdsQuote> CreateCdsQuote(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     ::flatbuffers::Offset<quantra::Period> tenor = 0,
-    quantra::enums::CdsQuoteType quote_type = quantra::enums::CdsQuoteType_ParSpread,
+    ::flatbuffers::Optional<quantra::enums::CdsQuoteType> quote_type = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<::flatbuffers::String> quote_id = 0,
     double quoted_par_spread = 0.0,
     double quoted_upfront = 0.0,
@@ -144,14 +146,14 @@ inline ::flatbuffers::Offset<CdsQuote> CreateCdsQuote(
   builder_.add_quoted_par_spread(quoted_par_spread);
   builder_.add_quote_id(quote_id);
   builder_.add_tenor(tenor);
-  builder_.add_quote_type(quote_type);
+  if(quote_type) { builder_.add_quote_type(*quote_type); }
   return builder_.Finish();
 }
 
 inline ::flatbuffers::Offset<CdsQuote> CreateCdsQuoteDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     ::flatbuffers::Offset<quantra::Period> tenor = 0,
-    quantra::enums::CdsQuoteType quote_type = quantra::enums::CdsQuoteType_ParSpread,
+    ::flatbuffers::Optional<quantra::enums::CdsQuoteType> quote_type = ::flatbuffers::nullopt,
     const char *quote_id = nullptr,
     double quoted_par_spread = 0.0,
     double quoted_upfront = 0.0,

--- a/flatbuffers/cpp/equity_option_generated.h
+++ b/flatbuffers/cpp/equity_option_generated.h
@@ -728,7 +728,7 @@ inline ::flatbuffers::Offset<EquityBermudanExercise> CreateEquityBermudanExercis
 struct EquityPlainVanillaPayoffT : public ::flatbuffers::NativeTable {
   typedef EquityPlainVanillaPayoff TableType;
   quantra::enums::EquityOptionType option_type = quantra::enums::EquityOptionType_Call;
-  double strike = 0.0;
+  ::flatbuffers::Optional<double> strike = ::flatbuffers::nullopt;
 };
 
 /// Plain vanilla payoff.
@@ -742,8 +742,9 @@ struct EquityPlainVanillaPayoff FLATBUFFERS_FINAL_CLASS : private ::flatbuffers:
   quantra::enums::EquityOptionType option_type() const {
     return static_cast<quantra::enums::EquityOptionType>(GetField<int8_t>(VT_OPTION_TYPE, 0));
   }
-  double strike() const {
-    return GetField<double>(VT_STRIKE, 0.0);
+  /// Strike price. Presence-required and must be > 0.
+  ::flatbuffers::Optional<double> strike() const {
+    return GetOptional<double, double>(VT_STRIKE);
   }
   bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -764,7 +765,7 @@ struct EquityPlainVanillaPayoffBuilder {
     fbb_.AddElement<int8_t>(EquityPlainVanillaPayoff::VT_OPTION_TYPE, static_cast<int8_t>(option_type), 0);
   }
   void add_strike(double strike) {
-    fbb_.AddElement<double>(EquityPlainVanillaPayoff::VT_STRIKE, strike, 0.0);
+    fbb_.AddElement<double>(EquityPlainVanillaPayoff::VT_STRIKE, strike);
   }
   explicit EquityPlainVanillaPayoffBuilder(::flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
@@ -780,9 +781,9 @@ struct EquityPlainVanillaPayoffBuilder {
 inline ::flatbuffers::Offset<EquityPlainVanillaPayoff> CreateEquityPlainVanillaPayoff(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     quantra::enums::EquityOptionType option_type = quantra::enums::EquityOptionType_Call,
-    double strike = 0.0) {
+    ::flatbuffers::Optional<double> strike = ::flatbuffers::nullopt) {
   EquityPlainVanillaPayoffBuilder builder_(_fbb);
-  builder_.add_strike(strike);
+  if(strike) { builder_.add_strike(*strike); }
   builder_.add_option_type(option_type);
   return builder_.Finish();
 }
@@ -792,8 +793,8 @@ inline ::flatbuffers::Offset<EquityPlainVanillaPayoff> CreateEquityPlainVanillaP
 struct EquityCashOrNothingPayoffT : public ::flatbuffers::NativeTable {
   typedef EquityCashOrNothingPayoff TableType;
   quantra::enums::EquityOptionType option_type = quantra::enums::EquityOptionType_Call;
-  double strike = 0.0;
-  double cash = 0.0;
+  ::flatbuffers::Optional<double> strike = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<double> cash = ::flatbuffers::nullopt;
 };
 
 /// Cash-or-nothing digital payoff.
@@ -808,11 +809,13 @@ struct EquityCashOrNothingPayoff FLATBUFFERS_FINAL_CLASS : private ::flatbuffers
   quantra::enums::EquityOptionType option_type() const {
     return static_cast<quantra::enums::EquityOptionType>(GetField<int8_t>(VT_OPTION_TYPE, 0));
   }
-  double strike() const {
-    return GetField<double>(VT_STRIKE, 0.0);
+  /// Strike price. Presence-required and must be > 0.
+  ::flatbuffers::Optional<double> strike() const {
+    return GetOptional<double, double>(VT_STRIKE);
   }
-  double cash() const {
-    return GetField<double>(VT_CASH, 0.0);
+  /// Cash payout on exercise. Presence-required and must be > 0.
+  ::flatbuffers::Optional<double> cash() const {
+    return GetOptional<double, double>(VT_CASH);
   }
   bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -834,10 +837,10 @@ struct EquityCashOrNothingPayoffBuilder {
     fbb_.AddElement<int8_t>(EquityCashOrNothingPayoff::VT_OPTION_TYPE, static_cast<int8_t>(option_type), 0);
   }
   void add_strike(double strike) {
-    fbb_.AddElement<double>(EquityCashOrNothingPayoff::VT_STRIKE, strike, 0.0);
+    fbb_.AddElement<double>(EquityCashOrNothingPayoff::VT_STRIKE, strike);
   }
   void add_cash(double cash) {
-    fbb_.AddElement<double>(EquityCashOrNothingPayoff::VT_CASH, cash, 0.0);
+    fbb_.AddElement<double>(EquityCashOrNothingPayoff::VT_CASH, cash);
   }
   explicit EquityCashOrNothingPayoffBuilder(::flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
@@ -853,11 +856,11 @@ struct EquityCashOrNothingPayoffBuilder {
 inline ::flatbuffers::Offset<EquityCashOrNothingPayoff> CreateEquityCashOrNothingPayoff(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     quantra::enums::EquityOptionType option_type = quantra::enums::EquityOptionType_Call,
-    double strike = 0.0,
-    double cash = 0.0) {
+    ::flatbuffers::Optional<double> strike = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<double> cash = ::flatbuffers::nullopt) {
   EquityCashOrNothingPayoffBuilder builder_(_fbb);
-  builder_.add_cash(cash);
-  builder_.add_strike(strike);
+  if(cash) { builder_.add_cash(*cash); }
+  if(strike) { builder_.add_strike(*strike); }
   builder_.add_option_type(option_type);
   return builder_.Finish();
 }
@@ -867,7 +870,7 @@ inline ::flatbuffers::Offset<EquityCashOrNothingPayoff> CreateEquityCashOrNothin
 struct EquityAssetOrNothingPayoffT : public ::flatbuffers::NativeTable {
   typedef EquityAssetOrNothingPayoff TableType;
   quantra::enums::EquityOptionType option_type = quantra::enums::EquityOptionType_Call;
-  double strike = 0.0;
+  ::flatbuffers::Optional<double> strike = ::flatbuffers::nullopt;
 };
 
 /// Asset-or-nothing digital payoff.
@@ -881,8 +884,9 @@ struct EquityAssetOrNothingPayoff FLATBUFFERS_FINAL_CLASS : private ::flatbuffer
   quantra::enums::EquityOptionType option_type() const {
     return static_cast<quantra::enums::EquityOptionType>(GetField<int8_t>(VT_OPTION_TYPE, 0));
   }
-  double strike() const {
-    return GetField<double>(VT_STRIKE, 0.0);
+  /// Strike price. Presence-required and must be > 0.
+  ::flatbuffers::Optional<double> strike() const {
+    return GetOptional<double, double>(VT_STRIKE);
   }
   bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -903,7 +907,7 @@ struct EquityAssetOrNothingPayoffBuilder {
     fbb_.AddElement<int8_t>(EquityAssetOrNothingPayoff::VT_OPTION_TYPE, static_cast<int8_t>(option_type), 0);
   }
   void add_strike(double strike) {
-    fbb_.AddElement<double>(EquityAssetOrNothingPayoff::VT_STRIKE, strike, 0.0);
+    fbb_.AddElement<double>(EquityAssetOrNothingPayoff::VT_STRIKE, strike);
   }
   explicit EquityAssetOrNothingPayoffBuilder(::flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
@@ -919,9 +923,9 @@ struct EquityAssetOrNothingPayoffBuilder {
 inline ::flatbuffers::Offset<EquityAssetOrNothingPayoff> CreateEquityAssetOrNothingPayoff(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     quantra::enums::EquityOptionType option_type = quantra::enums::EquityOptionType_Call,
-    double strike = 0.0) {
+    ::flatbuffers::Optional<double> strike = ::flatbuffers::nullopt) {
   EquityAssetOrNothingPayoffBuilder builder_(_fbb);
-  builder_.add_strike(strike);
+  if(strike) { builder_.add_strike(*strike); }
   builder_.add_option_type(option_type);
   return builder_.Finish();
 }

--- a/flatbuffers/cpp/fixed_rate_bond_generated.h
+++ b/flatbuffers/cpp/fixed_rate_bond_generated.h
@@ -25,7 +25,7 @@ struct FixedRateBondT;
 struct FixedRateBondT : public ::flatbuffers::NativeTable {
   typedef FixedRateBond TableType;
   int32_t settlement_days = 0;
-  double face_amount = 0.0;
+  ::flatbuffers::Optional<double> face_amount = ::flatbuffers::nullopt;
   std::vector<double> notionals{};
   double rate = 0.0;
   ::flatbuffers::Optional<quantra::enums::DayCounter> accrual_day_counter = ::flatbuffers::nullopt;
@@ -57,8 +57,10 @@ struct FixedRateBond FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   int32_t settlement_days() const {
     return GetField<int32_t>(VT_SETTLEMENT_DAYS, 0);
   }
-  double face_amount() const {
-    return GetField<double>(VT_FACE_AMOUNT, 0.0);
+  /// Face amount. Presence-required and must be > 0 (a bare double would
+  /// default to a silent zero face).
+  ::flatbuffers::Optional<double> face_amount() const {
+    return GetOptional<double, double>(VT_FACE_AMOUNT);
   }
   /// Optional per-period notionals, one entry per coupon period in schedule
   /// order. Present => amortizing/step-up bond (overrides `face_amount`,
@@ -114,7 +116,7 @@ struct FixedRateBondBuilder {
     fbb_.AddElement<int32_t>(FixedRateBond::VT_SETTLEMENT_DAYS, settlement_days, 0);
   }
   void add_face_amount(double face_amount) {
-    fbb_.AddElement<double>(FixedRateBond::VT_FACE_AMOUNT, face_amount, 0.0);
+    fbb_.AddElement<double>(FixedRateBond::VT_FACE_AMOUNT, face_amount);
   }
   void add_notionals(::flatbuffers::Offset<::flatbuffers::Vector<double>> notionals) {
     fbb_.AddOffset(FixedRateBond::VT_NOTIONALS, notionals);
@@ -151,7 +153,7 @@ struct FixedRateBondBuilder {
 inline ::flatbuffers::Offset<FixedRateBond> CreateFixedRateBond(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     int32_t settlement_days = 0,
-    double face_amount = 0.0,
+    ::flatbuffers::Optional<double> face_amount = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<::flatbuffers::Vector<double>> notionals = 0,
     double rate = 0.0,
     ::flatbuffers::Optional<quantra::enums::DayCounter> accrual_day_counter = ::flatbuffers::nullopt,
@@ -162,7 +164,7 @@ inline ::flatbuffers::Offset<FixedRateBond> CreateFixedRateBond(
   FixedRateBondBuilder builder_(_fbb);
   builder_.add_redemption(redemption);
   builder_.add_rate(rate);
-  builder_.add_face_amount(face_amount);
+  if(face_amount) { builder_.add_face_amount(*face_amount); }
   builder_.add_schedule(schedule);
   builder_.add_issue_date(issue_date);
   builder_.add_notionals(notionals);
@@ -175,7 +177,7 @@ inline ::flatbuffers::Offset<FixedRateBond> CreateFixedRateBond(
 inline ::flatbuffers::Offset<FixedRateBond> CreateFixedRateBondDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     int32_t settlement_days = 0,
-    double face_amount = 0.0,
+    ::flatbuffers::Optional<double> face_amount = ::flatbuffers::nullopt,
     const std::vector<double> *notionals = nullptr,
     double rate = 0.0,
     ::flatbuffers::Optional<quantra::enums::DayCounter> accrual_day_counter = ::flatbuffers::nullopt,

--- a/flatbuffers/cpp/floating_rate_bond_generated.h
+++ b/flatbuffers/cpp/floating_rate_bond_generated.h
@@ -26,7 +26,7 @@ struct FloatingRateBondT;
 struct FloatingRateBondT : public ::flatbuffers::NativeTable {
   typedef FloatingRateBond TableType;
   int32_t settlement_days = 0;
-  double face_amount = 0.0;
+  ::flatbuffers::Optional<double> face_amount = ::flatbuffers::nullopt;
   std::vector<double> notionals{};
   std::unique_ptr<quantra::ScheduleT> schedule{};
   std::unique_ptr<quantra::IndexRefT> index{};
@@ -64,8 +64,10 @@ struct FloatingRateBond FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   int32_t settlement_days() const {
     return GetField<int32_t>(VT_SETTLEMENT_DAYS, 0);
   }
-  double face_amount() const {
-    return GetField<double>(VT_FACE_AMOUNT, 0.0);
+  /// Face amount. Presence-required and must be > 0 (a bare double would
+  /// default to a silent zero face).
+  ::flatbuffers::Optional<double> face_amount() const {
+    return GetOptional<double, double>(VT_FACE_AMOUNT);
   }
   /// Optional per-period notionals, one entry per coupon period in schedule
   /// order. Present => amortizing/step-up bond (overrides `face_amount`,
@@ -135,7 +137,7 @@ struct FloatingRateBondBuilder {
     fbb_.AddElement<int32_t>(FloatingRateBond::VT_SETTLEMENT_DAYS, settlement_days, 0);
   }
   void add_face_amount(double face_amount) {
-    fbb_.AddElement<double>(FloatingRateBond::VT_FACE_AMOUNT, face_amount, 0.0);
+    fbb_.AddElement<double>(FloatingRateBond::VT_FACE_AMOUNT, face_amount);
   }
   void add_notionals(::flatbuffers::Offset<::flatbuffers::Vector<double>> notionals) {
     fbb_.AddOffset(FloatingRateBond::VT_NOTIONALS, notionals);
@@ -182,7 +184,7 @@ struct FloatingRateBondBuilder {
 inline ::flatbuffers::Offset<FloatingRateBond> CreateFloatingRateBond(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     int32_t settlement_days = 0,
-    double face_amount = 0.0,
+    ::flatbuffers::Optional<double> face_amount = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<::flatbuffers::Vector<double>> notionals = 0,
     ::flatbuffers::Offset<quantra::Schedule> schedule = 0,
     ::flatbuffers::Offset<quantra::IndexRef> index = 0,
@@ -196,7 +198,7 @@ inline ::flatbuffers::Offset<FloatingRateBond> CreateFloatingRateBond(
   FloatingRateBondBuilder builder_(_fbb);
   builder_.add_redemption(redemption);
   builder_.add_spread(spread);
-  builder_.add_face_amount(face_amount);
+  if(face_amount) { builder_.add_face_amount(*face_amount); }
   builder_.add_issue_date(issue_date);
   builder_.add_fixing_days(fixing_days);
   builder_.add_index(index);
@@ -212,7 +214,7 @@ inline ::flatbuffers::Offset<FloatingRateBond> CreateFloatingRateBond(
 inline ::flatbuffers::Offset<FloatingRateBond> CreateFloatingRateBondDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     int32_t settlement_days = 0,
-    double face_amount = 0.0,
+    ::flatbuffers::Optional<double> face_amount = ::flatbuffers::nullopt,
     const std::vector<double> *notionals = nullptr,
     ::flatbuffers::Offset<quantra::Schedule> schedule = 0,
     ::flatbuffers::Offset<quantra::IndexRef> index = 0,

--- a/flatbuffers/cpp/fra_generated.h
+++ b/flatbuffers/cpp/fra_generated.h
@@ -25,10 +25,10 @@ struct FRAT;
 struct FRAT : public ::flatbuffers::NativeTable {
   typedef FRA TableType;
   ::flatbuffers::Optional<quantra::enums::FRAType> fra_type = ::flatbuffers::nullopt;
-  double notional = 0.0;
+  ::flatbuffers::Optional<double> notional = ::flatbuffers::nullopt;
   std::string start_date{};
   std::string maturity_date{};
-  double strike = 0.0;
+  ::flatbuffers::Optional<double> strike = ::flatbuffers::nullopt;
   std::unique_ptr<quantra::IndexRefT> index{};
   ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt;
   ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt;
@@ -57,8 +57,9 @@ struct FRA FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   ::flatbuffers::Optional<quantra::enums::FRAType> fra_type() const {
     return GetOptional<int8_t, quantra::enums::FRAType>(VT_FRA_TYPE);
   }
-  double notional() const {
-    return GetField<double>(VT_NOTIONAL, 0.0);
+  /// Notional. Presence-required and must be > 0.
+  ::flatbuffers::Optional<double> notional() const {
+    return GetOptional<double, double>(VT_NOTIONAL);
   }
   /// When the FRA period starts.
   const ::flatbuffers::String *start_date() const {
@@ -68,9 +69,10 @@ struct FRA FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   const ::flatbuffers::String *maturity_date() const {
     return GetPointer<const ::flatbuffers::String *>(VT_MATURITY_DATE);
   }
-  /// The agreed forward rate (e.g., 0.035 for 3.5%).
-  double strike() const {
-    return GetField<double>(VT_STRIKE, 0.0);
+  /// The agreed forward rate (e.g., 0.035 for 3.5%). Presence-required; may be
+  /// negative, only a missing or non-finite value is rejected.
+  ::flatbuffers::Optional<double> strike() const {
+    return GetOptional<double, double>(VT_STRIKE);
   }
   /// Reference to an IndexDef by id (e.g., "EUR_3M").
   const quantra::IndexRef *index() const {
@@ -114,7 +116,7 @@ struct FRABuilder {
     fbb_.AddElement<int8_t>(FRA::VT_FRA_TYPE, static_cast<int8_t>(fra_type));
   }
   void add_notional(double notional) {
-    fbb_.AddElement<double>(FRA::VT_NOTIONAL, notional, 0.0);
+    fbb_.AddElement<double>(FRA::VT_NOTIONAL, notional);
   }
   void add_start_date(::flatbuffers::Offset<::flatbuffers::String> start_date) {
     fbb_.AddOffset(FRA::VT_START_DATE, start_date);
@@ -123,7 +125,7 @@ struct FRABuilder {
     fbb_.AddOffset(FRA::VT_MATURITY_DATE, maturity_date);
   }
   void add_strike(double strike) {
-    fbb_.AddElement<double>(FRA::VT_STRIKE, strike, 0.0);
+    fbb_.AddElement<double>(FRA::VT_STRIKE, strike);
   }
   void add_index(::flatbuffers::Offset<quantra::IndexRef> index) {
     fbb_.AddOffset(FRA::VT_INDEX, index);
@@ -152,17 +154,17 @@ struct FRABuilder {
 inline ::flatbuffers::Offset<FRA> CreateFRA(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     ::flatbuffers::Optional<quantra::enums::FRAType> fra_type = ::flatbuffers::nullopt,
-    double notional = 0.0,
+    ::flatbuffers::Optional<double> notional = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<::flatbuffers::String> start_date = 0,
     ::flatbuffers::Offset<::flatbuffers::String> maturity_date = 0,
-    double strike = 0.0,
+    ::flatbuffers::Optional<double> strike = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::IndexRef> index = 0,
     ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
     ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
     ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt) {
   FRABuilder builder_(_fbb);
-  builder_.add_strike(strike);
-  builder_.add_notional(notional);
+  if(strike) { builder_.add_strike(*strike); }
+  if(notional) { builder_.add_notional(*notional); }
   builder_.add_index(index);
   builder_.add_maturity_date(maturity_date);
   builder_.add_start_date(start_date);
@@ -176,10 +178,10 @@ inline ::flatbuffers::Offset<FRA> CreateFRA(
 inline ::flatbuffers::Offset<FRA> CreateFRADirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     ::flatbuffers::Optional<quantra::enums::FRAType> fra_type = ::flatbuffers::nullopt,
-    double notional = 0.0,
+    ::flatbuffers::Optional<double> notional = ::flatbuffers::nullopt,
     const char *start_date = nullptr,
     const char *maturity_date = nullptr,
-    double strike = 0.0,
+    ::flatbuffers::Optional<double> strike = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::IndexRef> index = 0,
     ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
     ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,

--- a/flatbuffers/cpp/inflation_generated.h
+++ b/flatbuffers/cpp/inflation_generated.h
@@ -396,7 +396,7 @@ inline ::flatbuffers::Offset<InflationIndexSpec> CreateInflationIndexSpecDirect(
 struct ZeroCouponInflationSwapHelperT : public ::flatbuffers::NativeTable {
   typedef ZeroCouponInflationSwapHelper TableType;
   std::string quote_id{};
-  double quote_value = 0.0;
+  ::flatbuffers::Optional<double> quote_value = ::flatbuffers::nullopt;
   std::unique_ptr<quantra::PeriodT> swap_observation_lag{};
   std::unique_ptr<quantra::PeriodT> tenor{};
   std::string start_date{};
@@ -431,9 +431,11 @@ struct ZeroCouponInflationSwapHelper FLATBUFFERS_FINAL_CLASS : private ::flatbuf
   const ::flatbuffers::String *quote_id() const {
     return GetPointer<const ::flatbuffers::String *>(VT_QUOTE_ID);
   }
-  /// Inline quote value used when quote_id is empty.
-  double quote_value() const {
-    return GetField<double>(VT_QUOTE_VALUE, 0.0);
+  /// Inline quote value used when quote_id is empty. Presence-required on the
+  /// inline path (a bare double would default to a silent zero quote); may be
+  /// negative, only a missing or non-finite value is rejected.
+  ::flatbuffers::Optional<double> quote_value() const {
+    return GetOptional<double, double>(VT_QUOTE_VALUE);
   }
   /// Lag applied when observing the CPI index in the swap.
   const quantra::Period *swap_observation_lag() const {
@@ -495,7 +497,7 @@ struct ZeroCouponInflationSwapHelperBuilder {
     fbb_.AddOffset(ZeroCouponInflationSwapHelper::VT_QUOTE_ID, quote_id);
   }
   void add_quote_value(double quote_value) {
-    fbb_.AddElement<double>(ZeroCouponInflationSwapHelper::VT_QUOTE_VALUE, quote_value, 0.0);
+    fbb_.AddElement<double>(ZeroCouponInflationSwapHelper::VT_QUOTE_VALUE, quote_value);
   }
   void add_swap_observation_lag(::flatbuffers::Offset<quantra::Period> swap_observation_lag) {
     fbb_.AddOffset(ZeroCouponInflationSwapHelper::VT_SWAP_OBSERVATION_LAG, swap_observation_lag);
@@ -536,7 +538,7 @@ struct ZeroCouponInflationSwapHelperBuilder {
 inline ::flatbuffers::Offset<ZeroCouponInflationSwapHelper> CreateZeroCouponInflationSwapHelper(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     ::flatbuffers::Offset<::flatbuffers::String> quote_id = 0,
-    double quote_value = 0.0,
+    ::flatbuffers::Optional<double> quote_value = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::Period> swap_observation_lag = 0,
     ::flatbuffers::Offset<quantra::Period> tenor = 0,
     ::flatbuffers::Offset<::flatbuffers::String> start_date = 0,
@@ -546,7 +548,7 @@ inline ::flatbuffers::Offset<ZeroCouponInflationSwapHelper> CreateZeroCouponInfl
     quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual365Fixed,
     quantra::enums::CPIInterpolationType observation_interpolation = quantra::enums::CPIInterpolationType_AsIndex) {
   ZeroCouponInflationSwapHelperBuilder builder_(_fbb);
-  builder_.add_quote_value(quote_value);
+  if(quote_value) { builder_.add_quote_value(*quote_value); }
   builder_.add_end_date(end_date);
   builder_.add_start_date(start_date);
   builder_.add_tenor(tenor);
@@ -562,7 +564,7 @@ inline ::flatbuffers::Offset<ZeroCouponInflationSwapHelper> CreateZeroCouponInfl
 inline ::flatbuffers::Offset<ZeroCouponInflationSwapHelper> CreateZeroCouponInflationSwapHelperDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     const char *quote_id = nullptr,
-    double quote_value = 0.0,
+    ::flatbuffers::Optional<double> quote_value = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::Period> swap_observation_lag = 0,
     ::flatbuffers::Offset<quantra::Period> tenor = 0,
     const char *start_date = nullptr,
@@ -593,7 +595,7 @@ inline ::flatbuffers::Offset<ZeroCouponInflationSwapHelper> CreateZeroCouponInfl
 struct YearOnYearInflationSwapHelperT : public ::flatbuffers::NativeTable {
   typedef YearOnYearInflationSwapHelper TableType;
   std::string quote_id{};
-  double quote_value = 0.0;
+  ::flatbuffers::Optional<double> quote_value = ::flatbuffers::nullopt;
   std::unique_ptr<quantra::PeriodT> swap_observation_lag{};
   std::unique_ptr<quantra::PeriodT> tenor{};
   std::string start_date{};
@@ -630,9 +632,11 @@ struct YearOnYearInflationSwapHelper FLATBUFFERS_FINAL_CLASS : private ::flatbuf
   const ::flatbuffers::String *quote_id() const {
     return GetPointer<const ::flatbuffers::String *>(VT_QUOTE_ID);
   }
-  /// Inline quote value used when quote_id is empty.
-  double quote_value() const {
-    return GetField<double>(VT_QUOTE_VALUE, 0.0);
+  /// Inline quote value used when quote_id is empty. Presence-required on the
+  /// inline path (a bare double would default to a silent zero quote); may be
+  /// negative, only a missing or non-finite value is rejected.
+  ::flatbuffers::Optional<double> quote_value() const {
+    return GetOptional<double, double>(VT_QUOTE_VALUE);
   }
   const quantra::Period *swap_observation_lag() const {
     return GetPointer<const quantra::Period *>(VT_SWAP_OBSERVATION_LAG);
@@ -696,7 +700,7 @@ struct YearOnYearInflationSwapHelperBuilder {
     fbb_.AddOffset(YearOnYearInflationSwapHelper::VT_QUOTE_ID, quote_id);
   }
   void add_quote_value(double quote_value) {
-    fbb_.AddElement<double>(YearOnYearInflationSwapHelper::VT_QUOTE_VALUE, quote_value, 0.0);
+    fbb_.AddElement<double>(YearOnYearInflationSwapHelper::VT_QUOTE_VALUE, quote_value);
   }
   void add_swap_observation_lag(::flatbuffers::Offset<quantra::Period> swap_observation_lag) {
     fbb_.AddOffset(YearOnYearInflationSwapHelper::VT_SWAP_OBSERVATION_LAG, swap_observation_lag);
@@ -741,7 +745,7 @@ struct YearOnYearInflationSwapHelperBuilder {
 inline ::flatbuffers::Offset<YearOnYearInflationSwapHelper> CreateYearOnYearInflationSwapHelper(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     ::flatbuffers::Offset<::flatbuffers::String> quote_id = 0,
-    double quote_value = 0.0,
+    ::flatbuffers::Optional<double> quote_value = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::Period> swap_observation_lag = 0,
     ::flatbuffers::Offset<quantra::Period> tenor = 0,
     ::flatbuffers::Offset<::flatbuffers::String> start_date = 0,
@@ -752,7 +756,7 @@ inline ::flatbuffers::Offset<YearOnYearInflationSwapHelper> CreateYearOnYearInfl
     quantra::enums::CPIInterpolationType observation_interpolation = quantra::enums::CPIInterpolationType_AsIndex,
     ::flatbuffers::Offset<::flatbuffers::String> nominal_curve_id = 0) {
   YearOnYearInflationSwapHelperBuilder builder_(_fbb);
-  builder_.add_quote_value(quote_value);
+  if(quote_value) { builder_.add_quote_value(*quote_value); }
   builder_.add_nominal_curve_id(nominal_curve_id);
   builder_.add_end_date(end_date);
   builder_.add_start_date(start_date);
@@ -769,7 +773,7 @@ inline ::flatbuffers::Offset<YearOnYearInflationSwapHelper> CreateYearOnYearInfl
 inline ::flatbuffers::Offset<YearOnYearInflationSwapHelper> CreateYearOnYearInflationSwapHelperDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     const char *quote_id = nullptr,
-    double quote_value = 0.0,
+    ::flatbuffers::Optional<double> quote_value = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::Period> swap_observation_lag = 0,
     ::flatbuffers::Offset<quantra::Period> tenor = 0,
     const char *start_date = nullptr,

--- a/flatbuffers/cpp/ois_swap_generated.h
+++ b/flatbuffers/cpp/ois_swap_generated.h
@@ -31,7 +31,7 @@ struct OisSwapT;
 struct OisFloatingLegT : public ::flatbuffers::NativeTable {
   typedef OisFloatingLeg TableType;
   std::unique_ptr<quantra::ScheduleT> schedule{};
-  double notional = 0.0;
+  ::flatbuffers::Optional<double> notional = ::flatbuffers::nullopt;
   std::unique_ptr<quantra::IndexRefT> index{};
   double spread = 0.0;
   quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360;
@@ -71,8 +71,10 @@ struct OisFloatingLeg FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   const quantra::Schedule *schedule() const {
     return GetPointer<const quantra::Schedule *>(VT_SCHEDULE);
   }
-  double notional() const {
-    return GetField<double>(VT_NOTIONAL, 0.0);
+  /// Notional. Presence-required and must be > 0 (a bare double would default
+  /// to a silent zero notional).
+  ::flatbuffers::Optional<double> notional() const {
+    return GetOptional<double, double>(VT_NOTIONAL);
   }
   /// Reference to an overnight IndexDef by id (e.g., "USD_SOFR").
   const quantra::IndexRef *index() const {
@@ -142,7 +144,7 @@ struct OisFloatingLegBuilder {
     fbb_.AddOffset(OisFloatingLeg::VT_SCHEDULE, schedule);
   }
   void add_notional(double notional) {
-    fbb_.AddElement<double>(OisFloatingLeg::VT_NOTIONAL, notional, 0.0);
+    fbb_.AddElement<double>(OisFloatingLeg::VT_NOTIONAL, notional);
   }
   void add_index(::flatbuffers::Offset<quantra::IndexRef> index) {
     fbb_.AddOffset(OisFloatingLeg::VT_INDEX, index);
@@ -192,7 +194,7 @@ struct OisFloatingLegBuilder {
 inline ::flatbuffers::Offset<OisFloatingLeg> CreateOisFloatingLeg(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     ::flatbuffers::Offset<quantra::Schedule> schedule = 0,
-    double notional = 0.0,
+    ::flatbuffers::Optional<double> notional = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::IndexRef> index = 0,
     double spread = 0.0,
     quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360,
@@ -206,7 +208,7 @@ inline ::flatbuffers::Offset<OisFloatingLeg> CreateOisFloatingLeg(
     bool telescopic_value_dates = false) {
   OisFloatingLegBuilder builder_(_fbb);
   builder_.add_spread(spread);
-  builder_.add_notional(notional);
+  if(notional) { builder_.add_notional(*notional); }
   builder_.add_lockout_days(lockout_days);
   builder_.add_lookback_days(lookback_days);
   builder_.add_payment_lag(payment_lag);

--- a/flatbuffers/cpp/quotes_generated.h
+++ b/flatbuffers/cpp/quotes_generated.h
@@ -102,7 +102,7 @@ struct QuoteSpecT : public ::flatbuffers::NativeTable {
   typedef QuoteSpec TableType;
   std::string id{};
   quantra::QuoteKind kind = quantra::QuoteKind_Rate;
-  double value = 0.0;
+  ::flatbuffers::Optional<double> value = ::flatbuffers::nullopt;
   quantra::QuoteType quote_type = quantra::QuoteType_Curve;
 };
 
@@ -122,8 +122,11 @@ struct QuoteSpec FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   quantra::QuoteKind kind() const {
     return static_cast<quantra::QuoteKind>(GetField<int8_t>(VT_KIND, 0));
   }
-  double value() const {
-    return GetField<double>(VT_VALUE, 0.0);
+  /// Quote value. Presence-required (a bare double would default to 0 and
+  /// silently bootstrap every referencing helper off a zero rate). May be
+  /// negative (rates/spreads); only a missing or non-finite value is rejected.
+  ::flatbuffers::Optional<double> value() const {
+    return GetOptional<double, double>(VT_VALUE);
   }
   quantra::QuoteType quote_type() const {
     return static_cast<quantra::QuoteType>(GetField<int8_t>(VT_QUOTE_TYPE, 0));
@@ -153,7 +156,7 @@ struct QuoteSpecBuilder {
     fbb_.AddElement<int8_t>(QuoteSpec::VT_KIND, static_cast<int8_t>(kind), 0);
   }
   void add_value(double value) {
-    fbb_.AddElement<double>(QuoteSpec::VT_VALUE, value, 0.0);
+    fbb_.AddElement<double>(QuoteSpec::VT_VALUE, value);
   }
   void add_quote_type(quantra::QuoteType quote_type) {
     fbb_.AddElement<int8_t>(QuoteSpec::VT_QUOTE_TYPE, static_cast<int8_t>(quote_type), 0);
@@ -174,10 +177,10 @@ inline ::flatbuffers::Offset<QuoteSpec> CreateQuoteSpec(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     ::flatbuffers::Offset<::flatbuffers::String> id = 0,
     quantra::QuoteKind kind = quantra::QuoteKind_Rate,
-    double value = 0.0,
+    ::flatbuffers::Optional<double> value = ::flatbuffers::nullopt,
     quantra::QuoteType quote_type = quantra::QuoteType_Curve) {
   QuoteSpecBuilder builder_(_fbb);
-  builder_.add_value(value);
+  if(value) { builder_.add_value(*value); }
   builder_.add_id(id);
   builder_.add_quote_type(quote_type);
   builder_.add_kind(kind);
@@ -188,7 +191,7 @@ inline ::flatbuffers::Offset<QuoteSpec> CreateQuoteSpecDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     const char *id = nullptr,
     quantra::QuoteKind kind = quantra::QuoteKind_Rate,
-    double value = 0.0,
+    ::flatbuffers::Optional<double> value = ::flatbuffers::nullopt,
     quantra::QuoteType quote_type = quantra::QuoteType_Curve) {
   auto id__ = id ? _fbb.CreateString(id) : 0;
   return quantra::CreateQuoteSpec(

--- a/flatbuffers/cpp/term_structure_generated.h
+++ b/flatbuffers/cpp/term_structure_generated.h
@@ -1267,12 +1267,12 @@ struct BondHelperT : public ::flatbuffers::NativeTable {
   typedef BondHelper TableType;
   ::flatbuffers::Optional<double> rate = ::flatbuffers::nullopt;
   int32_t settlement_days = 0;
-  double face_amount = 0.0;
+  ::flatbuffers::Optional<double> face_amount = ::flatbuffers::nullopt;
   std::unique_ptr<quantra::ScheduleT> schedule{};
-  double coupon_rate = 0.0;
+  ::flatbuffers::Optional<double> coupon_rate = ::flatbuffers::nullopt;
   ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt;
   ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt;
-  double redemption = 0.0;
+  ::flatbuffers::Optional<double> redemption = ::flatbuffers::nullopt;
   std::string issue_date{};
   ::flatbuffers::Optional<double> price = ::flatbuffers::nullopt;
   std::string quote_id{};
@@ -1307,14 +1307,18 @@ struct BondHelper FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   int32_t settlement_days() const {
     return GetField<int32_t>(VT_SETTLEMENT_DAYS, 0);
   }
-  double face_amount() const {
-    return GetField<double>(VT_FACE_AMOUNT, 0.0);
+  /// Bond face amount. Presence-required and must be > 0 (a bare double would
+  /// default to a silent zero face).
+  ::flatbuffers::Optional<double> face_amount() const {
+    return GetOptional<double, double>(VT_FACE_AMOUNT);
   }
   const quantra::Schedule *schedule() const {
     return GetPointer<const quantra::Schedule *>(VT_SCHEDULE);
   }
-  double coupon_rate() const {
-    return GetField<double>(VT_COUPON_RATE, 0.0);
+  /// Coupon rate. Presence-required (a bare double would default to a silent
+  /// zero coupon); may be negative, only a missing or non-finite value is rejected.
+  ::flatbuffers::Optional<double> coupon_rate() const {
+    return GetOptional<double, double>(VT_COUPON_RATE);
   }
   ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter() const {
     return GetOptional<int8_t, quantra::enums::DayCounter>(VT_DAY_COUNTER);
@@ -1322,8 +1326,11 @@ struct BondHelper FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention() const {
     return GetOptional<int8_t, quantra::enums::BusinessDayConvention>(VT_BUSINESS_DAY_CONVENTION);
   }
-  double redemption() const {
-    return GetField<double>(VT_REDEMPTION, 0.0);
+  /// Redemption as a percentage of face. Presence-required and must be > 0
+  /// (a bare double would default to a silent zero redemption that destroys
+  /// the helper).
+  ::flatbuffers::Optional<double> redemption() const {
+    return GetOptional<double, double>(VT_REDEMPTION);
   }
   const ::flatbuffers::String *issue_date() const {
     return GetPointer<const ::flatbuffers::String *>(VT_ISSUE_DATE);
@@ -1369,13 +1376,13 @@ struct BondHelperBuilder {
     fbb_.AddElement<int32_t>(BondHelper::VT_SETTLEMENT_DAYS, settlement_days, 0);
   }
   void add_face_amount(double face_amount) {
-    fbb_.AddElement<double>(BondHelper::VT_FACE_AMOUNT, face_amount, 0.0);
+    fbb_.AddElement<double>(BondHelper::VT_FACE_AMOUNT, face_amount);
   }
   void add_schedule(::flatbuffers::Offset<quantra::Schedule> schedule) {
     fbb_.AddOffset(BondHelper::VT_SCHEDULE, schedule);
   }
   void add_coupon_rate(double coupon_rate) {
-    fbb_.AddElement<double>(BondHelper::VT_COUPON_RATE, coupon_rate, 0.0);
+    fbb_.AddElement<double>(BondHelper::VT_COUPON_RATE, coupon_rate);
   }
   void add_day_counter(quantra::enums::DayCounter day_counter) {
     fbb_.AddElement<int8_t>(BondHelper::VT_DAY_COUNTER, static_cast<int8_t>(day_counter));
@@ -1384,7 +1391,7 @@ struct BondHelperBuilder {
     fbb_.AddElement<int8_t>(BondHelper::VT_BUSINESS_DAY_CONVENTION, static_cast<int8_t>(business_day_convention));
   }
   void add_redemption(double redemption) {
-    fbb_.AddElement<double>(BondHelper::VT_REDEMPTION, redemption, 0.0);
+    fbb_.AddElement<double>(BondHelper::VT_REDEMPTION, redemption);
   }
   void add_issue_date(::flatbuffers::Offset<::flatbuffers::String> issue_date) {
     fbb_.AddOffset(BondHelper::VT_ISSUE_DATE, issue_date);
@@ -1410,20 +1417,20 @@ inline ::flatbuffers::Offset<BondHelper> CreateBondHelper(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     ::flatbuffers::Optional<double> rate = ::flatbuffers::nullopt,
     int32_t settlement_days = 0,
-    double face_amount = 0.0,
+    ::flatbuffers::Optional<double> face_amount = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::Schedule> schedule = 0,
-    double coupon_rate = 0.0,
+    ::flatbuffers::Optional<double> coupon_rate = ::flatbuffers::nullopt,
     ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
     ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt,
-    double redemption = 0.0,
+    ::flatbuffers::Optional<double> redemption = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<::flatbuffers::String> issue_date = 0,
     ::flatbuffers::Optional<double> price = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<::flatbuffers::String> quote_id = 0) {
   BondHelperBuilder builder_(_fbb);
   if(price) { builder_.add_price(*price); }
-  builder_.add_redemption(redemption);
-  builder_.add_coupon_rate(coupon_rate);
-  builder_.add_face_amount(face_amount);
+  if(redemption) { builder_.add_redemption(*redemption); }
+  if(coupon_rate) { builder_.add_coupon_rate(*coupon_rate); }
+  if(face_amount) { builder_.add_face_amount(*face_amount); }
   if(rate) { builder_.add_rate(*rate); }
   builder_.add_quote_id(quote_id);
   builder_.add_issue_date(issue_date);
@@ -1438,12 +1445,12 @@ inline ::flatbuffers::Offset<BondHelper> CreateBondHelperDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     ::flatbuffers::Optional<double> rate = ::flatbuffers::nullopt,
     int32_t settlement_days = 0,
-    double face_amount = 0.0,
+    ::flatbuffers::Optional<double> face_amount = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::Schedule> schedule = 0,
-    double coupon_rate = 0.0,
+    ::flatbuffers::Optional<double> coupon_rate = ::flatbuffers::nullopt,
     ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
     ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt,
-    double redemption = 0.0,
+    ::flatbuffers::Optional<double> redemption = ::flatbuffers::nullopt,
     const char *issue_date = nullptr,
     ::flatbuffers::Optional<double> price = ::flatbuffers::nullopt,
     const char *quote_id = nullptr) {

--- a/flatbuffers/cpp/vanilla_swap_generated.h
+++ b/flatbuffers/cpp/vanilla_swap_generated.h
@@ -42,7 +42,7 @@ struct VanillaSwapT;
 struct SwapFixedLegT : public ::flatbuffers::NativeTable {
   typedef SwapFixedLeg TableType;
   std::unique_ptr<quantra::ScheduleT> schedule{};
-  double notional = 0.0;
+  ::flatbuffers::Optional<double> notional = ::flatbuffers::nullopt;
   std::vector<double> notionals{};
   double rate = 0.0;
   ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt;
@@ -68,8 +68,11 @@ struct SwapFixedLeg FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   const quantra::Schedule *schedule() const {
     return GetPointer<const quantra::Schedule *>(VT_SCHEDULE);
   }
-  double notional() const {
-    return GetField<double>(VT_NOTIONAL, 0.0);
+  /// Constant notional. Presence-required and must be > 0 (unless the
+  /// per-period `notionals` vector is supplied). A bare double would default
+  /// to a silent zero notional.
+  ::flatbuffers::Optional<double> notional() const {
+    return GetOptional<double, double>(VT_NOTIONAL);
   }
   /// Optional per-period notionals, one entry per coupon period in schedule
   /// order. Present => amortizing/step-up leg (overrides `notional`); absent
@@ -112,7 +115,7 @@ struct SwapFixedLegBuilder {
     fbb_.AddOffset(SwapFixedLeg::VT_SCHEDULE, schedule);
   }
   void add_notional(double notional) {
-    fbb_.AddElement<double>(SwapFixedLeg::VT_NOTIONAL, notional, 0.0);
+    fbb_.AddElement<double>(SwapFixedLeg::VT_NOTIONAL, notional);
   }
   void add_notionals(::flatbuffers::Offset<::flatbuffers::Vector<double>> notionals) {
     fbb_.AddOffset(SwapFixedLeg::VT_NOTIONALS, notionals);
@@ -140,14 +143,14 @@ struct SwapFixedLegBuilder {
 inline ::flatbuffers::Offset<SwapFixedLeg> CreateSwapFixedLeg(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     ::flatbuffers::Offset<quantra::Schedule> schedule = 0,
-    double notional = 0.0,
+    ::flatbuffers::Optional<double> notional = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<::flatbuffers::Vector<double>> notionals = 0,
     double rate = 0.0,
     ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
     ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> payment_convention = ::flatbuffers::nullopt) {
   SwapFixedLegBuilder builder_(_fbb);
   builder_.add_rate(rate);
-  builder_.add_notional(notional);
+  if(notional) { builder_.add_notional(*notional); }
   builder_.add_notionals(notionals);
   builder_.add_schedule(schedule);
   if(payment_convention) { builder_.add_payment_convention(*payment_convention); }
@@ -158,7 +161,7 @@ inline ::flatbuffers::Offset<SwapFixedLeg> CreateSwapFixedLeg(
 inline ::flatbuffers::Offset<SwapFixedLeg> CreateSwapFixedLegDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     ::flatbuffers::Offset<quantra::Schedule> schedule = 0,
-    double notional = 0.0,
+    ::flatbuffers::Optional<double> notional = ::flatbuffers::nullopt,
     const std::vector<double> *notionals = nullptr,
     double rate = 0.0,
     ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
@@ -179,7 +182,7 @@ inline ::flatbuffers::Offset<SwapFixedLeg> CreateSwapFixedLegDirect(
 struct SwapFloatingLegT : public ::flatbuffers::NativeTable {
   typedef SwapFloatingLeg TableType;
   std::unique_ptr<quantra::ScheduleT> schedule{};
-  double notional = 0.0;
+  ::flatbuffers::Optional<double> notional = ::flatbuffers::nullopt;
   std::vector<double> notionals{};
   std::unique_ptr<quantra::IndexRefT> index{};
   double spread = 0.0;
@@ -211,8 +214,11 @@ struct SwapFloatingLeg FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   const quantra::Schedule *schedule() const {
     return GetPointer<const quantra::Schedule *>(VT_SCHEDULE);
   }
-  double notional() const {
-    return GetField<double>(VT_NOTIONAL, 0.0);
+  /// Constant notional. Presence-required and must be > 0 (unless the
+  /// per-period `notionals` vector is supplied). A bare double would default
+  /// to a silent zero notional.
+  ::flatbuffers::Optional<double> notional() const {
+    return GetOptional<double, double>(VT_NOTIONAL);
   }
   /// Optional per-period notionals, one entry per coupon period in schedule
   /// order. Present => amortizing/step-up leg (overrides `notional`); absent
@@ -270,7 +276,7 @@ struct SwapFloatingLegBuilder {
     fbb_.AddOffset(SwapFloatingLeg::VT_SCHEDULE, schedule);
   }
   void add_notional(double notional) {
-    fbb_.AddElement<double>(SwapFloatingLeg::VT_NOTIONAL, notional, 0.0);
+    fbb_.AddElement<double>(SwapFloatingLeg::VT_NOTIONAL, notional);
   }
   void add_notionals(::flatbuffers::Offset<::flatbuffers::Vector<double>> notionals) {
     fbb_.AddOffset(SwapFloatingLeg::VT_NOTIONALS, notionals);
@@ -308,7 +314,7 @@ struct SwapFloatingLegBuilder {
 inline ::flatbuffers::Offset<SwapFloatingLeg> CreateSwapFloatingLeg(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     ::flatbuffers::Offset<quantra::Schedule> schedule = 0,
-    double notional = 0.0,
+    ::flatbuffers::Optional<double> notional = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<::flatbuffers::Vector<double>> notionals = 0,
     ::flatbuffers::Offset<quantra::IndexRef> index = 0,
     double spread = 0.0,
@@ -318,7 +324,7 @@ inline ::flatbuffers::Offset<SwapFloatingLeg> CreateSwapFloatingLeg(
     bool in_arrears = false) {
   SwapFloatingLegBuilder builder_(_fbb);
   builder_.add_spread(spread);
-  builder_.add_notional(notional);
+  if(notional) { builder_.add_notional(*notional); }
   builder_.add_fixing_days(fixing_days);
   builder_.add_index(index);
   builder_.add_notionals(notionals);
@@ -332,7 +338,7 @@ inline ::flatbuffers::Offset<SwapFloatingLeg> CreateSwapFloatingLeg(
 inline ::flatbuffers::Offset<SwapFloatingLeg> CreateSwapFloatingLegDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     ::flatbuffers::Offset<quantra::Schedule> schedule = 0,
-    double notional = 0.0,
+    ::flatbuffers::Optional<double> notional = ::flatbuffers::nullopt,
     const std::vector<double> *notionals = nullptr,
     ::flatbuffers::Offset<quantra::IndexRef> index = 0,
     double spread = 0.0,
@@ -487,7 +493,7 @@ inline ::flatbuffers::Offset<CmsPricerSpec> CreateCmsPricerSpec(
 struct SwapCmsLegT : public ::flatbuffers::NativeTable {
   typedef SwapCmsLeg TableType;
   std::unique_ptr<quantra::ScheduleT> schedule{};
-  double notional = 0.0;
+  ::flatbuffers::Optional<double> notional = ::flatbuffers::nullopt;
   std::string swap_index_id{};
   std::unique_ptr<quantra::PeriodT> swap_tenor{};
   std::string swaption_vol_id{};
@@ -529,9 +535,9 @@ struct SwapCmsLeg FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   const quantra::Schedule *schedule() const {
     return GetPointer<const quantra::Schedule *>(VT_SCHEDULE);
   }
-  /// Coupon notional.
-  double notional() const {
-    return GetField<double>(VT_NOTIONAL, 0.0);
+  /// Coupon notional. Presence-required and must be > 0.
+  ::flatbuffers::Optional<double> notional() const {
+    return GetOptional<double, double>(VT_NOTIONAL);
   }
   /// Swap index conventions id from Pricing.swap_indices (e.g. "EUR_SWAP_6M").
   const ::flatbuffers::String *swap_index_id() const {
@@ -615,7 +621,7 @@ struct SwapCmsLegBuilder {
     fbb_.AddOffset(SwapCmsLeg::VT_SCHEDULE, schedule);
   }
   void add_notional(double notional) {
-    fbb_.AddElement<double>(SwapCmsLeg::VT_NOTIONAL, notional, 0.0);
+    fbb_.AddElement<double>(SwapCmsLeg::VT_NOTIONAL, notional);
   }
   void add_swap_index_id(::flatbuffers::Offset<::flatbuffers::String> swap_index_id) {
     fbb_.AddOffset(SwapCmsLeg::VT_SWAP_INDEX_ID, swap_index_id);
@@ -667,7 +673,7 @@ struct SwapCmsLegBuilder {
 inline ::flatbuffers::Offset<SwapCmsLeg> CreateSwapCmsLeg(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     ::flatbuffers::Offset<quantra::Schedule> schedule = 0,
-    double notional = 0.0,
+    ::flatbuffers::Optional<double> notional = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<::flatbuffers::String> swap_index_id = 0,
     ::flatbuffers::Offset<quantra::Period> swap_tenor = 0,
     ::flatbuffers::Offset<::flatbuffers::String> swaption_vol_id = 0,
@@ -684,7 +690,7 @@ inline ::flatbuffers::Offset<SwapCmsLeg> CreateSwapCmsLeg(
   if(cap) { builder_.add_cap(*cap); }
   builder_.add_spread(spread);
   builder_.add_gear(gear);
-  builder_.add_notional(notional);
+  if(notional) { builder_.add_notional(*notional); }
   builder_.add_pricer(pricer);
   builder_.add_fixing_days(fixing_days);
   builder_.add_swaption_vol_id(swaption_vol_id);
@@ -699,7 +705,7 @@ inline ::flatbuffers::Offset<SwapCmsLeg> CreateSwapCmsLeg(
 inline ::flatbuffers::Offset<SwapCmsLeg> CreateSwapCmsLegDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     ::flatbuffers::Offset<quantra::Schedule> schedule = 0,
-    double notional = 0.0,
+    ::flatbuffers::Optional<double> notional = ::flatbuffers::nullopt,
     const char *swap_index_id = nullptr,
     ::flatbuffers::Offset<quantra::Period> swap_tenor = 0,
     const char *swaption_vol_id = nullptr,

--- a/flatbuffers/cpp/year_on_year_inflation_cap_floor_generated.h
+++ b/flatbuffers/cpp/year_on_year_inflation_cap_floor_generated.h
@@ -26,7 +26,7 @@ struct YoYInflationCapFloorT;
 struct YoYInflationCapFloorT : public ::flatbuffers::NativeTable {
   typedef YoYInflationCapFloor TableType;
   ::flatbuffers::Optional<quantra::enums::CapFloorType> cap_floor_type = ::flatbuffers::nullopt;
-  double notional = 0.0;
+  ::flatbuffers::Optional<double> notional = ::flatbuffers::nullopt;
   std::unique_ptr<quantra::ScheduleT> schedule{};
   std::string inflation_index_id{};
   std::unique_ptr<quantra::PeriodT> observation_lag{};
@@ -71,9 +71,9 @@ struct YoYInflationCapFloor FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Tab
   ::flatbuffers::Optional<quantra::enums::CapFloorType> cap_floor_type() const {
     return GetOptional<int8_t, quantra::enums::CapFloorType>(VT_CAP_FLOOR_TYPE);
   }
-  /// Notional per optionlet.
-  double notional() const {
-    return GetField<double>(VT_NOTIONAL, 0.0);
+  /// Notional per optionlet. Presence-required and must be > 0.
+  ::flatbuffers::Optional<double> notional() const {
+    return GetOptional<double, double>(VT_NOTIONAL);
   }
   /// Coupon schedule for the year-on-year optionlet strip.
   const quantra::Schedule *schedule() const {
@@ -148,7 +148,7 @@ struct YoYInflationCapFloorBuilder {
     fbb_.AddElement<int8_t>(YoYInflationCapFloor::VT_CAP_FLOOR_TYPE, static_cast<int8_t>(cap_floor_type));
   }
   void add_notional(double notional) {
-    fbb_.AddElement<double>(YoYInflationCapFloor::VT_NOTIONAL, notional, 0.0);
+    fbb_.AddElement<double>(YoYInflationCapFloor::VT_NOTIONAL, notional);
   }
   void add_schedule(::flatbuffers::Offset<quantra::Schedule> schedule) {
     fbb_.AddOffset(YoYInflationCapFloor::VT_SCHEDULE, schedule);
@@ -193,7 +193,7 @@ struct YoYInflationCapFloorBuilder {
 inline ::flatbuffers::Offset<YoYInflationCapFloor> CreateYoYInflationCapFloor(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     ::flatbuffers::Optional<quantra::enums::CapFloorType> cap_floor_type = ::flatbuffers::nullopt,
-    double notional = 0.0,
+    ::flatbuffers::Optional<double> notional = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::Schedule> schedule = 0,
     ::flatbuffers::Offset<::flatbuffers::String> inflation_index_id = 0,
     ::flatbuffers::Offset<quantra::Period> observation_lag = 0,
@@ -208,7 +208,7 @@ inline ::flatbuffers::Offset<YoYInflationCapFloor> CreateYoYInflationCapFloor(
   if(gearing) { builder_.add_gearing(*gearing); }
   if(floor_rate) { builder_.add_floor_rate(*floor_rate); }
   if(cap_rate) { builder_.add_cap_rate(*cap_rate); }
-  builder_.add_notional(notional);
+  if(notional) { builder_.add_notional(*notional); }
   builder_.add_observation_lag(observation_lag);
   builder_.add_inflation_index_id(inflation_index_id);
   builder_.add_schedule(schedule);
@@ -221,7 +221,7 @@ inline ::flatbuffers::Offset<YoYInflationCapFloor> CreateYoYInflationCapFloor(
 inline ::flatbuffers::Offset<YoYInflationCapFloor> CreateYoYInflationCapFloorDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     ::flatbuffers::Optional<quantra::enums::CapFloorType> cap_floor_type = ::flatbuffers::nullopt,
-    double notional = 0.0,
+    ::flatbuffers::Optional<double> notional = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::Schedule> schedule = 0,
     const char *inflation_index_id = nullptr,
     ::flatbuffers::Offset<quantra::Period> observation_lag = 0,

--- a/flatbuffers/cpp/year_on_year_inflation_swap_generated.h
+++ b/flatbuffers/cpp/year_on_year_inflation_swap_generated.h
@@ -26,7 +26,7 @@ struct YearOnYearInflationSwapT;
 struct YearOnYearInflationSwapT : public ::flatbuffers::NativeTable {
   typedef YearOnYearInflationSwap TableType;
   ::flatbuffers::Optional<quantra::enums::SwapType> swap_type = ::flatbuffers::nullopt;
-  double notional = 0.0;
+  ::flatbuffers::Optional<double> notional = ::flatbuffers::nullopt;
   std::unique_ptr<quantra::ScheduleT> fixed_schedule{};
   double fixed_rate = 0.0;
   quantra::enums::DayCounter fixed_day_counter = quantra::enums::DayCounter_Actual365Fixed;
@@ -70,8 +70,9 @@ struct YearOnYearInflationSwap FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::
   ::flatbuffers::Optional<quantra::enums::SwapType> swap_type() const {
     return GetOptional<int8_t, quantra::enums::SwapType>(VT_SWAP_TYPE);
   }
-  double notional() const {
-    return GetField<double>(VT_NOTIONAL, 0.0);
+  /// Notional. Presence-required and must be > 0.
+  ::flatbuffers::Optional<double> notional() const {
+    return GetOptional<double, double>(VT_NOTIONAL);
   }
   const quantra::Schedule *fixed_schedule() const {
     return GetPointer<const quantra::Schedule *>(VT_FIXED_SCHEDULE);
@@ -141,7 +142,7 @@ struct YearOnYearInflationSwapBuilder {
     fbb_.AddElement<int8_t>(YearOnYearInflationSwap::VT_SWAP_TYPE, static_cast<int8_t>(swap_type));
   }
   void add_notional(double notional) {
-    fbb_.AddElement<double>(YearOnYearInflationSwap::VT_NOTIONAL, notional, 0.0);
+    fbb_.AddElement<double>(YearOnYearInflationSwap::VT_NOTIONAL, notional);
   }
   void add_fixed_schedule(::flatbuffers::Offset<quantra::Schedule> fixed_schedule) {
     fbb_.AddOffset(YearOnYearInflationSwap::VT_FIXED_SCHEDULE, fixed_schedule);
@@ -194,7 +195,7 @@ struct YearOnYearInflationSwapBuilder {
 inline ::flatbuffers::Offset<YearOnYearInflationSwap> CreateYearOnYearInflationSwap(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     ::flatbuffers::Optional<quantra::enums::SwapType> swap_type = ::flatbuffers::nullopt,
-    double notional = 0.0,
+    ::flatbuffers::Optional<double> notional = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::Schedule> fixed_schedule = 0,
     double fixed_rate = 0.0,
     quantra::enums::DayCounter fixed_day_counter = quantra::enums::DayCounter_Actual365Fixed,
@@ -209,7 +210,7 @@ inline ::flatbuffers::Offset<YearOnYearInflationSwap> CreateYearOnYearInflationS
   YearOnYearInflationSwapBuilder builder_(_fbb);
   builder_.add_spread(spread);
   builder_.add_fixed_rate(fixed_rate);
-  builder_.add_notional(notional);
+  if(notional) { builder_.add_notional(*notional); }
   builder_.add_observation_lag(observation_lag);
   builder_.add_inflation_index_id(inflation_index_id);
   builder_.add_yoy_schedule(yoy_schedule);
@@ -226,7 +227,7 @@ inline ::flatbuffers::Offset<YearOnYearInflationSwap> CreateYearOnYearInflationS
 inline ::flatbuffers::Offset<YearOnYearInflationSwap> CreateYearOnYearInflationSwapDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     ::flatbuffers::Optional<quantra::enums::SwapType> swap_type = ::flatbuffers::nullopt,
-    double notional = 0.0,
+    ::flatbuffers::Optional<double> notional = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::Schedule> fixed_schedule = 0,
     double fixed_rate = 0.0,
     quantra::enums::DayCounter fixed_day_counter = quantra::enums::DayCounter_Actual365Fixed,

--- a/flatbuffers/cpp/zero_coupon_bond_generated.h
+++ b/flatbuffers/cpp/zero_coupon_bond_generated.h
@@ -25,7 +25,7 @@ struct ZeroCouponBondT : public ::flatbuffers::NativeTable {
   typedef ZeroCouponBond TableType;
   int32_t settlement_days = 0;
   ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt;
-  double face_amount = 0.0;
+  ::flatbuffers::Optional<double> face_amount = ::flatbuffers::nullopt;
   std::string maturity_date{};
   ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> payment_convention = ::flatbuffers::nullopt;
   ::flatbuffers::Optional<double> redemption = ::flatbuffers::nullopt;
@@ -56,8 +56,10 @@ struct ZeroCouponBond FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
     return GetOptional<int8_t, quantra::enums::Calendar>(VT_CALENDAR);
   }
   /// Notional / face amount the redemption percentage applies to.
-  double face_amount() const {
-    return GetField<double>(VT_FACE_AMOUNT, 0.0);
+  /// Presence-required and must be > 0 (a bare double would default to a
+  /// silent zero face).
+  ::flatbuffers::Optional<double> face_amount() const {
+    return GetOptional<double, double>(VT_FACE_AMOUNT);
   }
   /// Single redemption/maturity date (ISO yyyy-mm-dd).
   const ::flatbuffers::String *maturity_date() const {
@@ -106,7 +108,7 @@ struct ZeroCouponBondBuilder {
     fbb_.AddElement<int8_t>(ZeroCouponBond::VT_CALENDAR, static_cast<int8_t>(calendar));
   }
   void add_face_amount(double face_amount) {
-    fbb_.AddElement<double>(ZeroCouponBond::VT_FACE_AMOUNT, face_amount, 0.0);
+    fbb_.AddElement<double>(ZeroCouponBond::VT_FACE_AMOUNT, face_amount);
   }
   void add_maturity_date(::flatbuffers::Offset<::flatbuffers::String> maturity_date) {
     fbb_.AddOffset(ZeroCouponBond::VT_MATURITY_DATE, maturity_date);
@@ -135,14 +137,14 @@ inline ::flatbuffers::Offset<ZeroCouponBond> CreateZeroCouponBond(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     int32_t settlement_days = 0,
     ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
-    double face_amount = 0.0,
+    ::flatbuffers::Optional<double> face_amount = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<::flatbuffers::String> maturity_date = 0,
     ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> payment_convention = ::flatbuffers::nullopt,
     ::flatbuffers::Optional<double> redemption = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<::flatbuffers::String> issue_date = 0) {
   ZeroCouponBondBuilder builder_(_fbb);
   if(redemption) { builder_.add_redemption(*redemption); }
-  builder_.add_face_amount(face_amount);
+  if(face_amount) { builder_.add_face_amount(*face_amount); }
   builder_.add_issue_date(issue_date);
   builder_.add_maturity_date(maturity_date);
   builder_.add_settlement_days(settlement_days);
@@ -155,7 +157,7 @@ inline ::flatbuffers::Offset<ZeroCouponBond> CreateZeroCouponBondDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     int32_t settlement_days = 0,
     ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
-    double face_amount = 0.0,
+    ::flatbuffers::Optional<double> face_amount = ::flatbuffers::nullopt,
     const char *maturity_date = nullptr,
     ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> payment_convention = ::flatbuffers::nullopt,
     ::flatbuffers::Optional<double> redemption = ::flatbuffers::nullopt,

--- a/flatbuffers/cpp/zero_coupon_inflation_swap_generated.h
+++ b/flatbuffers/cpp/zero_coupon_inflation_swap_generated.h
@@ -25,7 +25,7 @@ struct ZeroCouponInflationSwapT;
 struct ZeroCouponInflationSwapT : public ::flatbuffers::NativeTable {
   typedef ZeroCouponInflationSwap TableType;
   ::flatbuffers::Optional<quantra::enums::SwapType> swap_type = ::flatbuffers::nullopt;
-  double notional = 0.0;
+  ::flatbuffers::Optional<double> notional = ::flatbuffers::nullopt;
   std::string start_date{};
   std::string maturity_date{};
   quantra::enums::Calendar fixed_calendar = quantra::enums::Calendar_TARGET;
@@ -69,8 +69,9 @@ struct ZeroCouponInflationSwap FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::
   ::flatbuffers::Optional<quantra::enums::SwapType> swap_type() const {
     return GetOptional<int8_t, quantra::enums::SwapType>(VT_SWAP_TYPE);
   }
-  double notional() const {
-    return GetField<double>(VT_NOTIONAL, 0.0);
+  /// Notional. Presence-required and must be > 0.
+  ::flatbuffers::Optional<double> notional() const {
+    return GetOptional<double, double>(VT_NOTIONAL);
   }
   const ::flatbuffers::String *start_date() const {
     return GetPointer<const ::flatbuffers::String *>(VT_START_DATE);
@@ -149,7 +150,7 @@ struct ZeroCouponInflationSwapBuilder {
     fbb_.AddElement<int8_t>(ZeroCouponInflationSwap::VT_SWAP_TYPE, static_cast<int8_t>(swap_type));
   }
   void add_notional(double notional) {
-    fbb_.AddElement<double>(ZeroCouponInflationSwap::VT_NOTIONAL, notional, 0.0);
+    fbb_.AddElement<double>(ZeroCouponInflationSwap::VT_NOTIONAL, notional);
   }
   void add_start_date(::flatbuffers::Offset<::flatbuffers::String> start_date) {
     fbb_.AddOffset(ZeroCouponInflationSwap::VT_START_DATE, start_date);
@@ -205,7 +206,7 @@ struct ZeroCouponInflationSwapBuilder {
 inline ::flatbuffers::Offset<ZeroCouponInflationSwap> CreateZeroCouponInflationSwap(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     ::flatbuffers::Optional<quantra::enums::SwapType> swap_type = ::flatbuffers::nullopt,
-    double notional = 0.0,
+    ::flatbuffers::Optional<double> notional = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<::flatbuffers::String> start_date = 0,
     ::flatbuffers::Offset<::flatbuffers::String> maturity_date = 0,
     quantra::enums::Calendar fixed_calendar = quantra::enums::Calendar_TARGET,
@@ -220,7 +221,7 @@ inline ::flatbuffers::Offset<ZeroCouponInflationSwap> CreateZeroCouponInflationS
     quantra::enums::BusinessDayConvention inflation_convention = quantra::enums::BusinessDayConvention_Following) {
   ZeroCouponInflationSwapBuilder builder_(_fbb);
   builder_.add_fixed_rate(fixed_rate);
-  builder_.add_notional(notional);
+  if(notional) { builder_.add_notional(*notional); }
   builder_.add_observation_lag(observation_lag);
   builder_.add_inflation_index_id(inflation_index_id);
   builder_.add_maturity_date(maturity_date);
@@ -239,7 +240,7 @@ inline ::flatbuffers::Offset<ZeroCouponInflationSwap> CreateZeroCouponInflationS
 inline ::flatbuffers::Offset<ZeroCouponInflationSwap> CreateZeroCouponInflationSwapDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     ::flatbuffers::Optional<quantra::enums::SwapType> swap_type = ::flatbuffers::nullopt,
-    double notional = 0.0,
+    ::flatbuffers::Optional<double> notional = ::flatbuffers::nullopt,
     const char *start_date = nullptr,
     const char *maturity_date = nullptr,
     quantra::enums::Calendar fixed_calendar = quantra::enums::Calendar_TARGET,

--- a/flatbuffers/cpp/zero_coupon_swap_generated.h
+++ b/flatbuffers/cpp/zero_coupon_swap_generated.h
@@ -25,7 +25,7 @@ struct ZeroCouponSwapT;
 struct ZeroCouponSwapT : public ::flatbuffers::NativeTable {
   typedef ZeroCouponSwap TableType;
   ::flatbuffers::Optional<quantra::enums::SwapType> swap_type = ::flatbuffers::nullopt;
-  double base_nominal = 0.0;
+  ::flatbuffers::Optional<double> base_nominal = ::flatbuffers::nullopt;
   std::string start_date{};
   std::string maturity_date{};
   ::flatbuffers::Optional<double> fixed_payment = ::flatbuffers::nullopt;
@@ -66,9 +66,10 @@ struct ZeroCouponSwap FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   ::flatbuffers::Optional<quantra::enums::SwapType> swap_type() const {
     return GetOptional<int8_t, quantra::enums::SwapType>(VT_SWAP_TYPE);
   }
-  /// Base notional prior to compounding.
-  double base_nominal() const {
-    return GetField<double>(VT_BASE_NOMINAL, 0.0);
+  /// Base notional prior to compounding. Presence-required and must be > 0
+  /// (a bare double would default to a silent zero notional).
+  ::flatbuffers::Optional<double> base_nominal() const {
+    return GetOptional<double, double>(VT_BASE_NOMINAL);
   }
   /// Contract start date (ISO yyyy-mm-dd).
   const ::flatbuffers::String *start_date() const {
@@ -145,7 +146,7 @@ struct ZeroCouponSwapBuilder {
     fbb_.AddElement<int8_t>(ZeroCouponSwap::VT_SWAP_TYPE, static_cast<int8_t>(swap_type));
   }
   void add_base_nominal(double base_nominal) {
-    fbb_.AddElement<double>(ZeroCouponSwap::VT_BASE_NOMINAL, base_nominal, 0.0);
+    fbb_.AddElement<double>(ZeroCouponSwap::VT_BASE_NOMINAL, base_nominal);
   }
   void add_start_date(::flatbuffers::Offset<::flatbuffers::String> start_date) {
     fbb_.AddOffset(ZeroCouponSwap::VT_START_DATE, start_date);
@@ -189,7 +190,7 @@ struct ZeroCouponSwapBuilder {
 inline ::flatbuffers::Offset<ZeroCouponSwap> CreateZeroCouponSwap(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     ::flatbuffers::Optional<quantra::enums::SwapType> swap_type = ::flatbuffers::nullopt,
-    double base_nominal = 0.0,
+    ::flatbuffers::Optional<double> base_nominal = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<::flatbuffers::String> start_date = 0,
     ::flatbuffers::Offset<::flatbuffers::String> maturity_date = 0,
     ::flatbuffers::Optional<double> fixed_payment = ::flatbuffers::nullopt,
@@ -202,7 +203,7 @@ inline ::flatbuffers::Offset<ZeroCouponSwap> CreateZeroCouponSwap(
   ZeroCouponSwapBuilder builder_(_fbb);
   if(fixed_rate) { builder_.add_fixed_rate(*fixed_rate); }
   if(fixed_payment) { builder_.add_fixed_payment(*fixed_payment); }
-  builder_.add_base_nominal(base_nominal);
+  if(base_nominal) { builder_.add_base_nominal(*base_nominal); }
   builder_.add_payment_delay(payment_delay);
   builder_.add_index(index);
   builder_.add_maturity_date(maturity_date);
@@ -217,7 +218,7 @@ inline ::flatbuffers::Offset<ZeroCouponSwap> CreateZeroCouponSwap(
 inline ::flatbuffers::Offset<ZeroCouponSwap> CreateZeroCouponSwapDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     ::flatbuffers::Optional<quantra::enums::SwapType> swap_type = ::flatbuffers::nullopt,
-    double base_nominal = 0.0,
+    ::flatbuffers::Optional<double> base_nominal = ::flatbuffers::nullopt,
     const char *start_date = nullptr,
     const char *maturity_date = nullptr,
     ::flatbuffers::Optional<double> fixed_payment = ::flatbuffers::nullopt,

--- a/flatbuffers/fbs/callable_fixed_rate_bond.fbs
+++ b/flatbuffers/fbs/callable_fixed_rate_bond.fbs
@@ -31,7 +31,9 @@ table CallabilityEntry {
 /// constant-notional).
 table CallableFixedRateBond {
     settlement_days:int;
-    face_amount:double;
+    /// Face amount. Presence-required and must be > 0 (a bare double would
+    /// default to a silent zero face).
+    face_amount:double = null;
     rate:double;
     accrual_day_counter:enums.DayCounter = null;
     payment_convention:enums.BusinessDayConvention = null;

--- a/flatbuffers/fbs/cap_floor.fbs
+++ b/flatbuffers/fbs/cap_floor.fbs
@@ -7,9 +7,11 @@ namespace quantra;
 /// Cap or Floor instrument.
 table CapFloor {
     cap_floor_type:enums.CapFloorType = null;
-    notional:double;
-    /// Strike rate (e.g., 0.04 for 4%).
-    strike:double;
+    /// Notional. Presence-required and must be > 0.
+    notional:double = null;
+    /// Strike rate (e.g., 0.04 for 4%). Presence-required; may be negative, only
+    /// a missing or non-finite value is rejected.
+    strike:double = null;
     schedule:Schedule;
     /// Reference to an IndexDef by id (e.g., "EUR_3M").
     index:IndexRef (required);

--- a/flatbuffers/fbs/cds.fbs
+++ b/flatbuffers/fbs/cds.fbs
@@ -6,7 +6,8 @@ namespace quantra;
 /// Credit Default Swap instrument.
 table CDS {
     side:enums.ProtectionSide = null;
-    notional:double;
+    /// Notional. Presence-required and must be > 0.
+    notional:double = null;
     /// Running coupon in decimal (0.01 = 100bps). Required; presence-driven
     /// (a genuine 0 is a valid zero-coupon CDS, an absent value is rejected).
     running_coupon:double = null;

--- a/flatbuffers/fbs/coupon_pricer.fbs
+++ b/flatbuffers/fbs/coupon_pricer.fbs
@@ -7,7 +7,12 @@ table ConstantOptionletVolatility {
     settlement_days:int;
     calendar:enums.Calendar = null;
     business_day_convention:enums.BusinessDayConvention = null;
-    volatility:double;
+    /// Constant optionlet volatility. Presence-required (a bare double would
+    /// default to a silent zero) and must be finite and non-negative. A genuine
+    /// 0 is valid: for a coupon leg without caps/floors the Black pricer with
+    /// zero vol reproduces the deterministic forward, so 0 is accepted while an
+    /// omitted value is rejected.
+    volatility:double = null;
     day_counter:enums.DayCounter = null;
 }
 

--- a/flatbuffers/fbs/credit_curve.fbs
+++ b/flatbuffers/fbs/credit_curve.fbs
@@ -6,7 +6,9 @@ namespace quantra;
 /// CDS market quote specification.
 table CdsQuote {
     tenor:Period;
-    quote_type:enums.CdsQuoteType;
+    /// Quote convention (ParSpread / Upfront). Presence-required: an omitted
+    /// value is a 400, never the alphabetical-0 default (ParSpread).
+    quote_type:enums.CdsQuoteType = null;
     /// Optional; resolves from Pricing.quotes (QuoteType=Credit).
     quote_id:string;
     /// Used when quote_type=ParSpread (decimal, 0.01=100bps).

--- a/flatbuffers/fbs/equity_option.fbs
+++ b/flatbuffers/fbs/equity_option.fbs
@@ -43,20 +43,24 @@ union EquityExercise {
 /// Plain vanilla payoff.
 table EquityPlainVanillaPayoff {
     option_type:enums.EquityOptionType = Call;
-    strike:double;
+    /// Strike price. Presence-required and must be > 0.
+    strike:double = null;
 }
 
 /// Cash-or-nothing digital payoff.
 table EquityCashOrNothingPayoff {
     option_type:enums.EquityOptionType = Call;
-    strike:double;
-    cash:double;
+    /// Strike price. Presence-required and must be > 0.
+    strike:double = null;
+    /// Cash payout on exercise. Presence-required and must be > 0.
+    cash:double = null;
 }
 
 /// Asset-or-nothing digital payoff.
 table EquityAssetOrNothingPayoff {
     option_type:enums.EquityOptionType = Call;
-    strike:double;
+    /// Strike price. Presence-required and must be > 0.
+    strike:double = null;
 }
 
 /// Equity payoff payload.

--- a/flatbuffers/fbs/fixed_rate_bond.fbs
+++ b/flatbuffers/fbs/fixed_rate_bond.fbs
@@ -6,7 +6,9 @@ namespace quantra;
 /// Fixed-rate bond instrument.
 table FixedRateBond {
     settlement_days:int;
-    face_amount:double;
+    /// Face amount. Presence-required and must be > 0 (a bare double would
+    /// default to a silent zero face).
+    face_amount:double = null;
     /// Optional per-period notionals, one entry per coupon period in schedule
     /// order. Present => amortizing/step-up bond (overrides `face_amount`,
     /// priced as a QuantLib AmortizingFixedRateBond); absent => constant

--- a/flatbuffers/fbs/floating_rate_bond.fbs
+++ b/flatbuffers/fbs/floating_rate_bond.fbs
@@ -7,7 +7,9 @@ namespace quantra;
 /// Floating-rate bond instrument.
 table FloatingRateBond {
     settlement_days:int;
-    face_amount:double;
+    /// Face amount. Presence-required and must be > 0 (a bare double would
+    /// default to a silent zero face).
+    face_amount:double = null;
     /// Optional per-period notionals, one entry per coupon period in schedule
     /// order. Present => amortizing/step-up bond (overrides `face_amount`,
     /// priced as a QuantLib AmortizingFloatingRateBond); absent => constant

--- a/flatbuffers/fbs/fra.fbs
+++ b/flatbuffers/fbs/fra.fbs
@@ -6,13 +6,15 @@ namespace quantra;
 /// Forward Rate Agreement instrument.
 table FRA {
     fra_type:enums.FRAType = null;
-    notional:double;
+    /// Notional. Presence-required and must be > 0.
+    notional:double = null;
     /// When the FRA period starts.
     start_date:string;
     /// When the FRA period ends.
     maturity_date:string;
-    /// The agreed forward rate (e.g., 0.035 for 3.5%).
-    strike:double;
+    /// The agreed forward rate (e.g., 0.035 for 3.5%). Presence-required; may be
+    /// negative, only a missing or non-finite value is rejected.
+    strike:double = null;
     /// Reference to an IndexDef by id (e.g., "EUR_3M").
     index:IndexRef (required);
     day_counter:enums.DayCounter = null;

--- a/flatbuffers/fbs/inflation.fbs
+++ b/flatbuffers/fbs/inflation.fbs
@@ -37,8 +37,10 @@ table InflationIndexSpec {
 table ZeroCouponInflationSwapHelper {
     /// Optional: resolve quote from pricing.quotes (QuoteType=Curve).
     quote_id:string;
-    /// Inline quote value used when quote_id is empty.
-    quote_value:double;
+    /// Inline quote value used when quote_id is empty. Presence-required on the
+    /// inline path (a bare double would default to a silent zero quote); may be
+    /// negative, only a missing or non-finite value is rejected.
+    quote_value:double = null;
     /// Lag applied when observing the CPI index in the swap.
     swap_observation_lag:Period (required);
     /// Relative helper maturity from InflationCurveBaseSpec.reference_date.
@@ -57,8 +59,10 @@ table ZeroCouponInflationSwapHelper {
 table YearOnYearInflationSwapHelper {
     /// Optional: resolve quote from pricing.quotes (QuoteType=Curve).
     quote_id:string;
-    /// Inline quote value used when quote_id is empty.
-    quote_value:double;
+    /// Inline quote value used when quote_id is empty. Presence-required on the
+    /// inline path (a bare double would default to a silent zero quote); may be
+    /// negative, only a missing or non-finite value is rejected.
+    quote_value:double = null;
     swap_observation_lag:Period (required);
     tenor:Period;
     start_date:string;

--- a/flatbuffers/fbs/ois_swap.fbs
+++ b/flatbuffers/fbs/ois_swap.fbs
@@ -8,7 +8,9 @@ namespace quantra;
 /// Floating leg for OIS swaps (compounded overnight).
 table OisFloatingLeg {
     schedule:Schedule;
-    notional:double;
+    /// Notional. Presence-required and must be > 0 (a bare double would default
+    /// to a silent zero notional).
+    notional:double = null;
     /// Reference to an overnight IndexDef by id (e.g., "USD_SOFR").
     index:IndexRef (required);
     spread:double = 0.0;

--- a/flatbuffers/fbs/quotes.fbs
+++ b/flatbuffers/fbs/quotes.fbs
@@ -23,6 +23,9 @@ enum QuoteType : byte {
 table QuoteSpec {
     id:string (required);
     kind:QuoteKind = Rate;
-    value:double;
+    /// Quote value. Presence-required (a bare double would default to 0 and
+    /// silently bootstrap every referencing helper off a zero rate). May be
+    /// negative (rates/spreads); only a missing or non-finite value is rejected.
+    value:double = null;
     quote_type:QuoteType = Curve;
 }

--- a/flatbuffers/fbs/term_structure.fbs
+++ b/flatbuffers/fbs/term_structure.fbs
@@ -89,12 +89,19 @@ table BondHelper {
     /// rate, price or quote_id must be provided.
     rate:double = null;
     settlement_days:int;
-    face_amount:double;
+    /// Bond face amount. Presence-required and must be > 0 (a bare double would
+    /// default to a silent zero face).
+    face_amount:double = null;
     schedule:Schedule;
-    coupon_rate:double;
+    /// Coupon rate. Presence-required (a bare double would default to a silent
+    /// zero coupon); may be negative, only a missing or non-finite value is rejected.
+    coupon_rate:double = null;
     day_counter:enums.DayCounter = null;
     business_day_convention:enums.BusinessDayConvention = null;
-    redemption:double;
+    /// Redemption as a percentage of face. Presence-required and must be > 0
+    /// (a bare double would default to a silent zero redemption that destroys
+    /// the helper).
+    redemption:double = null;
     issue_date:string;
     /// Bond (clean) price; when present, rate is ignored.
     price:double = null;

--- a/flatbuffers/fbs/vanilla_swap.fbs
+++ b/flatbuffers/fbs/vanilla_swap.fbs
@@ -7,7 +7,10 @@ namespace quantra;
 /// Fixed leg of a swap.
 table SwapFixedLeg {
     schedule:Schedule;
-    notional:double;
+    /// Constant notional. Presence-required and must be > 0 (unless the
+    /// per-period `notionals` vector is supplied). A bare double would default
+    /// to a silent zero notional.
+    notional:double = null;
     /// Optional per-period notionals, one entry per coupon period in schedule
     /// order. Present => amortizing/step-up leg (overrides `notional`); absent
     /// => constant `notional`. Honored only on the vanilla fixed-vs-IBOR swap
@@ -21,7 +24,10 @@ table SwapFixedLeg {
 /// Floating leg of a swap.
 table SwapFloatingLeg {
     schedule:Schedule;
-    notional:double;
+    /// Constant notional. Presence-required and must be > 0 (unless the
+    /// per-period `notionals` vector is supplied). A bare double would default
+    /// to a silent zero notional.
+    notional:double = null;
     /// Optional per-period notionals, one entry per coupon period in schedule
     /// order. Present => amortizing/step-up leg (overrides `notional`); absent
     /// => constant `notional`. Honored only on the vanilla fixed-vs-IBOR swap
@@ -62,8 +68,8 @@ table CmsPricerSpec {
 table SwapCmsLeg {
     /// Coupon/payment schedule.
     schedule:Schedule;
-    /// Coupon notional.
-    notional:double;
+    /// Coupon notional. Presence-required and must be > 0.
+    notional:double = null;
     /// Swap index conventions id from Pricing.swap_indices (e.g. "EUR_SWAP_6M").
     swap_index_id:string (required);
     /// Constant maturity tenor for CMS fixing (e.g. 10Y).

--- a/flatbuffers/fbs/year_on_year_inflation_cap_floor.fbs
+++ b/flatbuffers/fbs/year_on_year_inflation_cap_floor.fbs
@@ -16,8 +16,8 @@ table YoYInflationCapFloor {
     /// never the alphabetical-0 default (Cap). Reuses the shared CapFloorType
     /// enum (Cap/Floor/Collar).
     cap_floor_type:enums.CapFloorType = null;
-    /// Notional per optionlet.
-    notional:double;
+    /// Notional per optionlet. Presence-required and must be > 0.
+    notional:double = null;
     /// Coupon schedule for the year-on-year optionlet strip.
     schedule:Schedule (required);
     /// Link to InflationIndexSpec.id — the YoY inflation index (must resolve to

--- a/flatbuffers/fbs/year_on_year_inflation_swap.fbs
+++ b/flatbuffers/fbs/year_on_year_inflation_swap.fbs
@@ -11,7 +11,8 @@ table YearOnYearInflationSwap {
     /// Presence-required: an omitted type is a 400, never the alphabetical-0
     /// default (Payer).
     swap_type:enums.SwapType = null;
-    notional:double;
+    /// Notional. Presence-required and must be > 0.
+    notional:double = null;
     fixed_schedule:Schedule (required);
     fixed_rate:double;
     fixed_day_counter:enums.DayCounter = Actual365Fixed;

--- a/flatbuffers/fbs/zero_coupon_bond.fbs
+++ b/flatbuffers/fbs/zero_coupon_bond.fbs
@@ -11,7 +11,9 @@ table ZeroCouponBond {
     /// 400, never the alphabetical-0 default (Argentina).
     calendar:enums.Calendar = null;
     /// Notional / face amount the redemption percentage applies to.
-    face_amount:double;
+    /// Presence-required and must be > 0 (a bare double would default to a
+    /// silent zero face).
+    face_amount:double = null;
     /// Single redemption/maturity date (ISO yyyy-mm-dd).
     maturity_date:string;
     /// Business-day convention for the payment date. Presence-required: an

--- a/flatbuffers/fbs/zero_coupon_inflation_swap.fbs
+++ b/flatbuffers/fbs/zero_coupon_inflation_swap.fbs
@@ -8,7 +8,8 @@ table ZeroCouponInflationSwap {
     /// "Payer" / "Receiver" refers to the inflation leg. Presence-required: an
     /// omitted type is a 400, never the alphabetical-0 default (Payer).
     swap_type:enums.SwapType = null;
-    notional:double;
+    /// Notional. Presence-required and must be > 0.
+    notional:double = null;
     start_date:string (required);
     /// Contract maturity date before any internal observation adjustment.
     maturity_date:string (required);

--- a/flatbuffers/fbs/zero_coupon_swap.fbs
+++ b/flatbuffers/fbs/zero_coupon_swap.fbs
@@ -11,8 +11,9 @@ table ZeroCouponSwap {
     /// Payer/receiver refer to the fixed leg. Presence-required: an omitted
     /// type is a 400, never the alphabetical-0 default (Payer).
     swap_type:enums.SwapType = null;
-    /// Base notional prior to compounding.
-    base_nominal:double;
+    /// Base notional prior to compounding. Presence-required and must be > 0
+    /// (a bare double would default to a silent zero notional).
+    base_nominal:double = null;
     /// Contract start date (ISO yyyy-mm-dd).
     start_date:string;
     /// Contract maturity / single-payment date (ISO yyyy-mm-dd).

--- a/flatbuffers/json/basis_swap.schema.json
+++ b/flatbuffers/json/basis_swap.schema.json
@@ -426,7 +426,8 @@
                 "$ref" : "#/definitions/quantra_Schedule"
               },
         "notional" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Constant notional. Presence-required and must be > 0 (unless the\nper-period `notionals` vector is supplied). A bare double would default\nto a silent zero notional."
               },
         "notionals" : {
                 "type" : "array", "items" : {"type" : "number"},
@@ -452,7 +453,8 @@
                 "$ref" : "#/definitions/quantra_Schedule"
               },
         "notional" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Constant notional. Presence-required and must be > 0 (unless the\nper-period `notionals` vector is supplied). A bare double would default\nto a silent zero notional."
               },
         "notionals" : {
                 "type" : "array", "items" : {"type" : "number"},
@@ -526,7 +528,7 @@
               },
         "notional" : {
                 "type" : "number",
-                "description" : "Coupon notional."
+                "description" : "Coupon notional. Presence-required and must be > 0."
               },
         "swap_index_id" : {
                 "type" : "string",

--- a/flatbuffers/json/bootstrap_curves_request.schema.json
+++ b/flatbuffers/json/bootstrap_curves_request.schema.json
@@ -659,13 +659,15 @@
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
               },
         "face_amount" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Bond face amount. Presence-required and must be > 0 (a bare double would\ndefault to a silent zero face)."
               },
         "schedule" : {
                 "$ref" : "#/definitions/quantra_Schedule"
               },
         "coupon_rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Coupon rate. Presence-required (a bare double would default to a silent\nzero coupon); may be negative, only a missing or non-finite value is rejected."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter"
@@ -674,7 +676,8 @@
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention"
               },
         "redemption" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Redemption as a percentage of face. Presence-required and must be > 0\n(a bare double would default to a silent zero redemption that destroys\nthe helper)."
               },
         "issue_date" : {
                 "type" : "string"
@@ -1415,7 +1418,8 @@
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention"
               },
         "volatility" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Constant optionlet volatility. Presence-required (a bare double would\ndefault to a silent zero) and must be finite and non-negative. A genuine\n0 is valid: for a coupon leg without caps/floors the Black pricer with\nzero vol reproduces the deterministic forward, so 0 is accepted while an\nomitted value is rejected."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter"
@@ -1457,7 +1461,8 @@
                 "$ref" : "#/definitions/quantra_QuoteKind"
               },
         "value" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Quote value. Presence-required (a bare double would default to 0 and\nsilently bootstrap every referencing helper off a zero rate). May be\nnegative (rates/spreads); only a missing or non-finite value is rejected."
               },
         "quote_type" : {
                 "$ref" : "#/definitions/quantra_QuoteType"
@@ -1722,7 +1727,8 @@
                 "$ref" : "#/definitions/quantra_Period"
               },
         "quote_type" : {
-                "$ref" : "#/definitions/quantra_enums_CdsQuoteType"
+                "$ref" : "#/definitions/quantra_enums_CdsQuoteType",
+                "description" : "Quote convention (ParSpread / Upfront). Presence-required: an omitted\nvalue is a 400, never the alphabetical-0 default (ParSpread)."
               },
         "quote_id" : {
                 "type" : "string",
@@ -1891,7 +1897,8 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -1904,10 +1911,12 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               },
         "cash" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Cash payout on exercise. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -1920,7 +1929,8 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -2048,7 +2058,7 @@
               },
         "quote_value" : {
                 "type" : "number",
-                "description" : "Inline quote value used when quote_id is empty."
+                "description" : "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
               },
         "swap_observation_lag" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -2092,7 +2102,7 @@
               },
         "quote_value" : {
                 "type" : "number",
-                "description" : "Inline quote value used when quote_id is empty."
+                "description" : "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
               },
         "swap_observation_lag" : {
                 "$ref" : "#/definitions/quantra_Period"

--- a/flatbuffers/json/bootstrap_inflation_curves_request.schema.json
+++ b/flatbuffers/json/bootstrap_inflation_curves_request.schema.json
@@ -651,13 +651,15 @@
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
               },
         "face_amount" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Bond face amount. Presence-required and must be > 0 (a bare double would\ndefault to a silent zero face)."
               },
         "schedule" : {
                 "$ref" : "#/definitions/quantra_Schedule"
               },
         "coupon_rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Coupon rate. Presence-required (a bare double would default to a silent\nzero coupon); may be negative, only a missing or non-finite value is rejected."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter"
@@ -666,7 +668,8 @@
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention"
               },
         "redemption" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Redemption as a percentage of face. Presence-required and must be > 0\n(a bare double would default to a silent zero redemption that destroys\nthe helper)."
               },
         "issue_date" : {
                 "type" : "string"
@@ -1407,7 +1410,8 @@
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention"
               },
         "volatility" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Constant optionlet volatility. Presence-required (a bare double would\ndefault to a silent zero) and must be finite and non-negative. A genuine\n0 is valid: for a coupon leg without caps/floors the Black pricer with\nzero vol reproduces the deterministic forward, so 0 is accepted while an\nomitted value is rejected."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter"
@@ -1449,7 +1453,8 @@
                 "$ref" : "#/definitions/quantra_QuoteKind"
               },
         "value" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Quote value. Presence-required (a bare double would default to 0 and\nsilently bootstrap every referencing helper off a zero rate). May be\nnegative (rates/spreads); only a missing or non-finite value is rejected."
               },
         "quote_type" : {
                 "$ref" : "#/definitions/quantra_QuoteType"
@@ -1714,7 +1719,8 @@
                 "$ref" : "#/definitions/quantra_Period"
               },
         "quote_type" : {
-                "$ref" : "#/definitions/quantra_enums_CdsQuoteType"
+                "$ref" : "#/definitions/quantra_enums_CdsQuoteType",
+                "description" : "Quote convention (ParSpread / Upfront). Presence-required: an omitted\nvalue is a 400, never the alphabetical-0 default (ParSpread)."
               },
         "quote_id" : {
                 "type" : "string",
@@ -1883,7 +1889,8 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -1896,10 +1903,12 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               },
         "cash" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Cash payout on exercise. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -1912,7 +1921,8 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -2040,7 +2050,7 @@
               },
         "quote_value" : {
                 "type" : "number",
-                "description" : "Inline quote value used when quote_id is empty."
+                "description" : "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
               },
         "swap_observation_lag" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -2084,7 +2094,7 @@
               },
         "quote_value" : {
                 "type" : "number",
-                "description" : "Inline quote value used when quote_id is empty."
+                "description" : "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
               },
         "swap_observation_lag" : {
                 "$ref" : "#/definitions/quantra_Period"

--- a/flatbuffers/json/calibrate_swaption_model_request.schema.json
+++ b/flatbuffers/json/calibrate_swaption_model_request.schema.json
@@ -647,13 +647,15 @@
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
               },
         "face_amount" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Bond face amount. Presence-required and must be > 0 (a bare double would\ndefault to a silent zero face)."
               },
         "schedule" : {
                 "$ref" : "#/definitions/quantra_Schedule"
               },
         "coupon_rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Coupon rate. Presence-required (a bare double would default to a silent\nzero coupon); may be negative, only a missing or non-finite value is rejected."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter"
@@ -662,7 +664,8 @@
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention"
               },
         "redemption" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Redemption as a percentage of face. Presence-required and must be > 0\n(a bare double would default to a silent zero redemption that destroys\nthe helper)."
               },
         "issue_date" : {
                 "type" : "string"
@@ -1403,7 +1406,8 @@
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention"
               },
         "volatility" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Constant optionlet volatility. Presence-required (a bare double would\ndefault to a silent zero) and must be finite and non-negative. A genuine\n0 is valid: for a coupon leg without caps/floors the Black pricer with\nzero vol reproduces the deterministic forward, so 0 is accepted while an\nomitted value is rejected."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter"
@@ -1445,7 +1449,8 @@
                 "$ref" : "#/definitions/quantra_QuoteKind"
               },
         "value" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Quote value. Presence-required (a bare double would default to 0 and\nsilently bootstrap every referencing helper off a zero rate). May be\nnegative (rates/spreads); only a missing or non-finite value is rejected."
               },
         "quote_type" : {
                 "$ref" : "#/definitions/quantra_QuoteType"
@@ -1710,7 +1715,8 @@
                 "$ref" : "#/definitions/quantra_Period"
               },
         "quote_type" : {
-                "$ref" : "#/definitions/quantra_enums_CdsQuoteType"
+                "$ref" : "#/definitions/quantra_enums_CdsQuoteType",
+                "description" : "Quote convention (ParSpread / Upfront). Presence-required: an omitted\nvalue is a 400, never the alphabetical-0 default (ParSpread)."
               },
         "quote_id" : {
                 "type" : "string",
@@ -1879,7 +1885,8 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -1892,10 +1899,12 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               },
         "cash" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Cash payout on exercise. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -1908,7 +1917,8 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -2036,7 +2046,7 @@
               },
         "quote_value" : {
                 "type" : "number",
-                "description" : "Inline quote value used when quote_id is empty."
+                "description" : "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
               },
         "swap_observation_lag" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -2080,7 +2090,7 @@
               },
         "quote_value" : {
                 "type" : "number",
-                "description" : "Inline quote value used when quote_id is empty."
+                "description" : "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
               },
         "swap_observation_lag" : {
                 "$ref" : "#/definitions/quantra_Period"

--- a/flatbuffers/json/calibrate_swaption_vol_request.schema.json
+++ b/flatbuffers/json/calibrate_swaption_vol_request.schema.json
@@ -647,13 +647,15 @@
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
               },
         "face_amount" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Bond face amount. Presence-required and must be > 0 (a bare double would\ndefault to a silent zero face)."
               },
         "schedule" : {
                 "$ref" : "#/definitions/quantra_Schedule"
               },
         "coupon_rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Coupon rate. Presence-required (a bare double would default to a silent\nzero coupon); may be negative, only a missing or non-finite value is rejected."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter"
@@ -662,7 +664,8 @@
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention"
               },
         "redemption" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Redemption as a percentage of face. Presence-required and must be > 0\n(a bare double would default to a silent zero redemption that destroys\nthe helper)."
               },
         "issue_date" : {
                 "type" : "string"
@@ -1403,7 +1406,8 @@
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention"
               },
         "volatility" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Constant optionlet volatility. Presence-required (a bare double would\ndefault to a silent zero) and must be finite and non-negative. A genuine\n0 is valid: for a coupon leg without caps/floors the Black pricer with\nzero vol reproduces the deterministic forward, so 0 is accepted while an\nomitted value is rejected."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter"
@@ -1445,7 +1449,8 @@
                 "$ref" : "#/definitions/quantra_QuoteKind"
               },
         "value" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Quote value. Presence-required (a bare double would default to 0 and\nsilently bootstrap every referencing helper off a zero rate). May be\nnegative (rates/spreads); only a missing or non-finite value is rejected."
               },
         "quote_type" : {
                 "$ref" : "#/definitions/quantra_QuoteType"
@@ -1710,7 +1715,8 @@
                 "$ref" : "#/definitions/quantra_Period"
               },
         "quote_type" : {
-                "$ref" : "#/definitions/quantra_enums_CdsQuoteType"
+                "$ref" : "#/definitions/quantra_enums_CdsQuoteType",
+                "description" : "Quote convention (ParSpread / Upfront). Presence-required: an omitted\nvalue is a 400, never the alphabetical-0 default (ParSpread)."
               },
         "quote_id" : {
                 "type" : "string",
@@ -1879,7 +1885,8 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -1892,10 +1899,12 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               },
         "cash" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Cash payout on exercise. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -1908,7 +1917,8 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -2036,7 +2046,7 @@
               },
         "quote_value" : {
                 "type" : "number",
-                "description" : "Inline quote value used when quote_id is empty."
+                "description" : "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
               },
         "swap_observation_lag" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -2080,7 +2090,7 @@
               },
         "quote_value" : {
                 "type" : "number",
-                "description" : "Inline quote value used when quote_id is empty."
+                "description" : "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
               },
         "swap_observation_lag" : {
                 "$ref" : "#/definitions/quantra_Period"

--- a/flatbuffers/json/callable_fixed_rate_bond.schema.json
+++ b/flatbuffers/json/callable_fixed_rate_bond.schema.json
@@ -239,7 +239,8 @@
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
               },
         "face_amount" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Face amount. Presence-required and must be > 0 (a bare double would\ndefault to a silent zero face)."
               },
         "rate" : {
                 "type" : "number"

--- a/flatbuffers/json/cap_floor.schema.json
+++ b/flatbuffers/json/cap_floor.schema.json
@@ -426,11 +426,12 @@
                 "$ref" : "#/definitions/quantra_enums_CapFloorType"
               },
         "notional" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Notional. Presence-required and must be > 0."
               },
         "strike" : {
                 "type" : "number",
-                "description" : "Strike rate (e.g., 0.04 for 4%)."
+                "description" : "Strike rate (e.g., 0.04 for 4%). Presence-required; may be negative, only\na missing or non-finite value is rejected."
               },
         "schedule" : {
                 "$ref" : "#/definitions/quantra_Schedule"

--- a/flatbuffers/json/cds.schema.json
+++ b/flatbuffers/json/cds.schema.json
@@ -220,7 +220,8 @@
                 "$ref" : "#/definitions/quantra_enums_ProtectionSide"
               },
         "notional" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Notional. Presence-required and must be > 0."
               },
         "running_coupon" : {
                 "type" : "number",

--- a/flatbuffers/json/coupon_pricer.schema.json
+++ b/flatbuffers/json/coupon_pricer.schema.json
@@ -187,7 +187,8 @@
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention"
               },
         "volatility" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Constant optionlet volatility. Presence-required (a bare double would\ndefault to a silent zero) and must be finite and non-negative. A genuine\n0 is valid: for a coupon leg without caps/floors the Black pricer with\nzero vol reproduces the deterministic forward, so 0 is accepted while an\nomitted value is rejected."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter"

--- a/flatbuffers/json/equity_option.schema.json
+++ b/flatbuffers/json/equity_option.schema.json
@@ -258,7 +258,8 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -271,10 +272,12 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               },
         "cash" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Cash payout on exercise. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -287,7 +290,8 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false

--- a/flatbuffers/json/fixed_rate_bond.schema.json
+++ b/flatbuffers/json/fixed_rate_bond.schema.json
@@ -220,7 +220,8 @@
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
               },
         "face_amount" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Face amount. Presence-required and must be > 0 (a bare double would\ndefault to a silent zero face)."
               },
         "notionals" : {
                 "type" : "array", "items" : {"type" : "number"},

--- a/flatbuffers/json/floating_rate_bond.schema.json
+++ b/flatbuffers/json/floating_rate_bond.schema.json
@@ -426,7 +426,8 @@
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
               },
         "face_amount" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Face amount. Presence-required and must be > 0 (a bare double would\ndefault to a silent zero face)."
               },
         "notionals" : {
                 "type" : "array", "items" : {"type" : "number"},

--- a/flatbuffers/json/fra.schema.json
+++ b/flatbuffers/json/fra.schema.json
@@ -387,7 +387,8 @@
                 "$ref" : "#/definitions/quantra_enums_FRAType"
               },
         "notional" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Notional. Presence-required and must be > 0."
               },
         "start_date" : {
                 "type" : "string",
@@ -399,7 +400,7 @@
               },
         "strike" : {
                 "type" : "number",
-                "description" : "The agreed forward rate (e.g., 0.035 for 3.5%)."
+                "description" : "The agreed forward rate (e.g., 0.035 for 3.5%). Presence-required; may be\nnegative, only a missing or non-finite value is rejected."
               },
         "index" : {
                 "$ref" : "#/definitions/quantra_IndexRef",

--- a/flatbuffers/json/price_basis_swap_request.schema.json
+++ b/flatbuffers/json/price_basis_swap_request.schema.json
@@ -647,13 +647,15 @@
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
               },
         "face_amount" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Bond face amount. Presence-required and must be > 0 (a bare double would\ndefault to a silent zero face)."
               },
         "schedule" : {
                 "$ref" : "#/definitions/quantra_Schedule"
               },
         "coupon_rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Coupon rate. Presence-required (a bare double would default to a silent\nzero coupon); may be negative, only a missing or non-finite value is rejected."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter"
@@ -662,7 +664,8 @@
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention"
               },
         "redemption" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Redemption as a percentage of face. Presence-required and must be > 0\n(a bare double would default to a silent zero redemption that destroys\nthe helper)."
               },
         "issue_date" : {
                 "type" : "string"
@@ -1403,7 +1406,8 @@
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention"
               },
         "volatility" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Constant optionlet volatility. Presence-required (a bare double would\ndefault to a silent zero) and must be finite and non-negative. A genuine\n0 is valid: for a coupon leg without caps/floors the Black pricer with\nzero vol reproduces the deterministic forward, so 0 is accepted while an\nomitted value is rejected."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter"
@@ -1445,7 +1449,8 @@
                 "$ref" : "#/definitions/quantra_QuoteKind"
               },
         "value" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Quote value. Presence-required (a bare double would default to 0 and\nsilently bootstrap every referencing helper off a zero rate). May be\nnegative (rates/spreads); only a missing or non-finite value is rejected."
               },
         "quote_type" : {
                 "$ref" : "#/definitions/quantra_QuoteType"
@@ -1710,7 +1715,8 @@
                 "$ref" : "#/definitions/quantra_Period"
               },
         "quote_type" : {
-                "$ref" : "#/definitions/quantra_enums_CdsQuoteType"
+                "$ref" : "#/definitions/quantra_enums_CdsQuoteType",
+                "description" : "Quote convention (ParSpread / Upfront). Presence-required: an omitted\nvalue is a 400, never the alphabetical-0 default (ParSpread)."
               },
         "quote_id" : {
                 "type" : "string",
@@ -1879,7 +1885,8 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -1892,10 +1899,12 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               },
         "cash" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Cash payout on exercise. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -1908,7 +1917,8 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -2036,7 +2046,7 @@
               },
         "quote_value" : {
                 "type" : "number",
-                "description" : "Inline quote value used when quote_id is empty."
+                "description" : "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
               },
         "swap_observation_lag" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -2080,7 +2090,7 @@
               },
         "quote_value" : {
                 "type" : "number",
-                "description" : "Inline quote value used when quote_id is empty."
+                "description" : "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
               },
         "swap_observation_lag" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -2316,7 +2326,8 @@
                 "$ref" : "#/definitions/quantra_Schedule"
               },
         "notional" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Constant notional. Presence-required and must be > 0 (unless the\nper-period `notionals` vector is supplied). A bare double would default\nto a silent zero notional."
               },
         "notionals" : {
                 "type" : "array", "items" : {"type" : "number"},
@@ -2342,7 +2353,8 @@
                 "$ref" : "#/definitions/quantra_Schedule"
               },
         "notional" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Constant notional. Presence-required and must be > 0 (unless the\nper-period `notionals` vector is supplied). A bare double would default\nto a silent zero notional."
               },
         "notionals" : {
                 "type" : "array", "items" : {"type" : "number"},
@@ -2416,7 +2428,7 @@
               },
         "notional" : {
                 "type" : "number",
-                "description" : "Coupon notional."
+                "description" : "Coupon notional. Presence-required and must be > 0."
               },
         "swap_index_id" : {
                 "type" : "string",

--- a/flatbuffers/json/price_callable_fixed_rate_bond_request.schema.json
+++ b/flatbuffers/json/price_callable_fixed_rate_bond_request.schema.json
@@ -647,13 +647,15 @@
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
               },
         "face_amount" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Bond face amount. Presence-required and must be > 0 (a bare double would\ndefault to a silent zero face)."
               },
         "schedule" : {
                 "$ref" : "#/definitions/quantra_Schedule"
               },
         "coupon_rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Coupon rate. Presence-required (a bare double would default to a silent\nzero coupon); may be negative, only a missing or non-finite value is rejected."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter"
@@ -662,7 +664,8 @@
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention"
               },
         "redemption" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Redemption as a percentage of face. Presence-required and must be > 0\n(a bare double would default to a silent zero redemption that destroys\nthe helper)."
               },
         "issue_date" : {
                 "type" : "string"
@@ -1403,7 +1406,8 @@
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention"
               },
         "volatility" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Constant optionlet volatility. Presence-required (a bare double would\ndefault to a silent zero) and must be finite and non-negative. A genuine\n0 is valid: for a coupon leg without caps/floors the Black pricer with\nzero vol reproduces the deterministic forward, so 0 is accepted while an\nomitted value is rejected."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter"
@@ -1445,7 +1449,8 @@
                 "$ref" : "#/definitions/quantra_QuoteKind"
               },
         "value" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Quote value. Presence-required (a bare double would default to 0 and\nsilently bootstrap every referencing helper off a zero rate). May be\nnegative (rates/spreads); only a missing or non-finite value is rejected."
               },
         "quote_type" : {
                 "$ref" : "#/definitions/quantra_QuoteType"
@@ -1710,7 +1715,8 @@
                 "$ref" : "#/definitions/quantra_Period"
               },
         "quote_type" : {
-                "$ref" : "#/definitions/quantra_enums_CdsQuoteType"
+                "$ref" : "#/definitions/quantra_enums_CdsQuoteType",
+                "description" : "Quote convention (ParSpread / Upfront). Presence-required: an omitted\nvalue is a 400, never the alphabetical-0 default (ParSpread)."
               },
         "quote_id" : {
                 "type" : "string",
@@ -1879,7 +1885,8 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -1892,10 +1899,12 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               },
         "cash" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Cash payout on exercise. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -1908,7 +1917,8 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -2036,7 +2046,7 @@
               },
         "quote_value" : {
                 "type" : "number",
-                "description" : "Inline quote value used when quote_id is empty."
+                "description" : "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
               },
         "swap_observation_lag" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -2080,7 +2090,7 @@
               },
         "quote_value" : {
                 "type" : "number",
-                "description" : "Inline quote value used when quote_id is empty."
+                "description" : "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
               },
         "swap_observation_lag" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -2335,7 +2345,8 @@
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
               },
         "face_amount" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Face amount. Presence-required and must be > 0 (a bare double would\ndefault to a silent zero face)."
               },
         "rate" : {
                 "type" : "number"

--- a/flatbuffers/json/price_cap_floor_request.schema.json
+++ b/flatbuffers/json/price_cap_floor_request.schema.json
@@ -647,13 +647,15 @@
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
               },
         "face_amount" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Bond face amount. Presence-required and must be > 0 (a bare double would\ndefault to a silent zero face)."
               },
         "schedule" : {
                 "$ref" : "#/definitions/quantra_Schedule"
               },
         "coupon_rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Coupon rate. Presence-required (a bare double would default to a silent\nzero coupon); may be negative, only a missing or non-finite value is rejected."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter"
@@ -662,7 +664,8 @@
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention"
               },
         "redemption" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Redemption as a percentage of face. Presence-required and must be > 0\n(a bare double would default to a silent zero redemption that destroys\nthe helper)."
               },
         "issue_date" : {
                 "type" : "string"
@@ -1403,7 +1406,8 @@
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention"
               },
         "volatility" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Constant optionlet volatility. Presence-required (a bare double would\ndefault to a silent zero) and must be finite and non-negative. A genuine\n0 is valid: for a coupon leg without caps/floors the Black pricer with\nzero vol reproduces the deterministic forward, so 0 is accepted while an\nomitted value is rejected."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter"
@@ -1445,7 +1449,8 @@
                 "$ref" : "#/definitions/quantra_QuoteKind"
               },
         "value" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Quote value. Presence-required (a bare double would default to 0 and\nsilently bootstrap every referencing helper off a zero rate). May be\nnegative (rates/spreads); only a missing or non-finite value is rejected."
               },
         "quote_type" : {
                 "$ref" : "#/definitions/quantra_QuoteType"
@@ -1710,7 +1715,8 @@
                 "$ref" : "#/definitions/quantra_Period"
               },
         "quote_type" : {
-                "$ref" : "#/definitions/quantra_enums_CdsQuoteType"
+                "$ref" : "#/definitions/quantra_enums_CdsQuoteType",
+                "description" : "Quote convention (ParSpread / Upfront). Presence-required: an omitted\nvalue is a 400, never the alphabetical-0 default (ParSpread)."
               },
         "quote_id" : {
                 "type" : "string",
@@ -1879,7 +1885,8 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -1892,10 +1899,12 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               },
         "cash" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Cash payout on exercise. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -1908,7 +1917,8 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -2036,7 +2046,7 @@
               },
         "quote_value" : {
                 "type" : "number",
-                "description" : "Inline quote value used when quote_id is empty."
+                "description" : "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
               },
         "swap_observation_lag" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -2080,7 +2090,7 @@
               },
         "quote_value" : {
                 "type" : "number",
-                "description" : "Inline quote value used when quote_id is empty."
+                "description" : "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
               },
         "swap_observation_lag" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -2316,11 +2326,12 @@
                 "$ref" : "#/definitions/quantra_enums_CapFloorType"
               },
         "notional" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Notional. Presence-required and must be > 0."
               },
         "strike" : {
                 "type" : "number",
-                "description" : "Strike rate (e.g., 0.04 for 4%)."
+                "description" : "Strike rate (e.g., 0.04 for 4%). Presence-required; may be negative, only\na missing or non-finite value is rejected."
               },
         "schedule" : {
                 "$ref" : "#/definitions/quantra_Schedule"

--- a/flatbuffers/json/price_cds_request.schema.json
+++ b/flatbuffers/json/price_cds_request.schema.json
@@ -647,13 +647,15 @@
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
               },
         "face_amount" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Bond face amount. Presence-required and must be > 0 (a bare double would\ndefault to a silent zero face)."
               },
         "schedule" : {
                 "$ref" : "#/definitions/quantra_Schedule"
               },
         "coupon_rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Coupon rate. Presence-required (a bare double would default to a silent\nzero coupon); may be negative, only a missing or non-finite value is rejected."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter"
@@ -662,7 +664,8 @@
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention"
               },
         "redemption" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Redemption as a percentage of face. Presence-required and must be > 0\n(a bare double would default to a silent zero redemption that destroys\nthe helper)."
               },
         "issue_date" : {
                 "type" : "string"
@@ -1403,7 +1406,8 @@
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention"
               },
         "volatility" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Constant optionlet volatility. Presence-required (a bare double would\ndefault to a silent zero) and must be finite and non-negative. A genuine\n0 is valid: for a coupon leg without caps/floors the Black pricer with\nzero vol reproduces the deterministic forward, so 0 is accepted while an\nomitted value is rejected."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter"
@@ -1445,7 +1449,8 @@
                 "$ref" : "#/definitions/quantra_QuoteKind"
               },
         "value" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Quote value. Presence-required (a bare double would default to 0 and\nsilently bootstrap every referencing helper off a zero rate). May be\nnegative (rates/spreads); only a missing or non-finite value is rejected."
               },
         "quote_type" : {
                 "$ref" : "#/definitions/quantra_QuoteType"
@@ -1710,7 +1715,8 @@
                 "$ref" : "#/definitions/quantra_Period"
               },
         "quote_type" : {
-                "$ref" : "#/definitions/quantra_enums_CdsQuoteType"
+                "$ref" : "#/definitions/quantra_enums_CdsQuoteType",
+                "description" : "Quote convention (ParSpread / Upfront). Presence-required: an omitted\nvalue is a 400, never the alphabetical-0 default (ParSpread)."
               },
         "quote_id" : {
                 "type" : "string",
@@ -1879,7 +1885,8 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -1892,10 +1899,12 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               },
         "cash" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Cash payout on exercise. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -1908,7 +1917,8 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -2036,7 +2046,7 @@
               },
         "quote_value" : {
                 "type" : "number",
-                "description" : "Inline quote value used when quote_id is empty."
+                "description" : "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
               },
         "swap_observation_lag" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -2080,7 +2090,7 @@
               },
         "quote_value" : {
                 "type" : "number",
-                "description" : "Inline quote value used when quote_id is empty."
+                "description" : "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
               },
         "swap_observation_lag" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -2316,7 +2326,8 @@
                 "$ref" : "#/definitions/quantra_enums_ProtectionSide"
               },
         "notional" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Notional. Presence-required and must be > 0."
               },
         "running_coupon" : {
                 "type" : "number",

--- a/flatbuffers/json/price_equity_option_request.schema.json
+++ b/flatbuffers/json/price_equity_option_request.schema.json
@@ -647,13 +647,15 @@
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
               },
         "face_amount" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Bond face amount. Presence-required and must be > 0 (a bare double would\ndefault to a silent zero face)."
               },
         "schedule" : {
                 "$ref" : "#/definitions/quantra_Schedule"
               },
         "coupon_rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Coupon rate. Presence-required (a bare double would default to a silent\nzero coupon); may be negative, only a missing or non-finite value is rejected."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter"
@@ -662,7 +664,8 @@
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention"
               },
         "redemption" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Redemption as a percentage of face. Presence-required and must be > 0\n(a bare double would default to a silent zero redemption that destroys\nthe helper)."
               },
         "issue_date" : {
                 "type" : "string"
@@ -1403,7 +1406,8 @@
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention"
               },
         "volatility" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Constant optionlet volatility. Presence-required (a bare double would\ndefault to a silent zero) and must be finite and non-negative. A genuine\n0 is valid: for a coupon leg without caps/floors the Black pricer with\nzero vol reproduces the deterministic forward, so 0 is accepted while an\nomitted value is rejected."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter"
@@ -1445,7 +1449,8 @@
                 "$ref" : "#/definitions/quantra_QuoteKind"
               },
         "value" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Quote value. Presence-required (a bare double would default to 0 and\nsilently bootstrap every referencing helper off a zero rate). May be\nnegative (rates/spreads); only a missing or non-finite value is rejected."
               },
         "quote_type" : {
                 "$ref" : "#/definitions/quantra_QuoteType"
@@ -1710,7 +1715,8 @@
                 "$ref" : "#/definitions/quantra_Period"
               },
         "quote_type" : {
-                "$ref" : "#/definitions/quantra_enums_CdsQuoteType"
+                "$ref" : "#/definitions/quantra_enums_CdsQuoteType",
+                "description" : "Quote convention (ParSpread / Upfront). Presence-required: an omitted\nvalue is a 400, never the alphabetical-0 default (ParSpread)."
               },
         "quote_id" : {
                 "type" : "string",
@@ -1879,7 +1885,8 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -1892,10 +1899,12 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               },
         "cash" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Cash payout on exercise. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -1908,7 +1917,8 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -2036,7 +2046,7 @@
               },
         "quote_value" : {
                 "type" : "number",
-                "description" : "Inline quote value used when quote_id is empty."
+                "description" : "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
               },
         "swap_observation_lag" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -2080,7 +2090,7 @@
               },
         "quote_value" : {
                 "type" : "number",
-                "description" : "Inline quote value used when quote_id is empty."
+                "description" : "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
               },
         "swap_observation_lag" : {
                 "$ref" : "#/definitions/quantra_Period"

--- a/flatbuffers/json/price_fixed_rate_bond_request.schema.json
+++ b/flatbuffers/json/price_fixed_rate_bond_request.schema.json
@@ -647,13 +647,15 @@
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
               },
         "face_amount" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Bond face amount. Presence-required and must be > 0 (a bare double would\ndefault to a silent zero face)."
               },
         "schedule" : {
                 "$ref" : "#/definitions/quantra_Schedule"
               },
         "coupon_rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Coupon rate. Presence-required (a bare double would default to a silent\nzero coupon); may be negative, only a missing or non-finite value is rejected."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter"
@@ -662,7 +664,8 @@
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention"
               },
         "redemption" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Redemption as a percentage of face. Presence-required and must be > 0\n(a bare double would default to a silent zero redemption that destroys\nthe helper)."
               },
         "issue_date" : {
                 "type" : "string"
@@ -1403,7 +1406,8 @@
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention"
               },
         "volatility" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Constant optionlet volatility. Presence-required (a bare double would\ndefault to a silent zero) and must be finite and non-negative. A genuine\n0 is valid: for a coupon leg without caps/floors the Black pricer with\nzero vol reproduces the deterministic forward, so 0 is accepted while an\nomitted value is rejected."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter"
@@ -1445,7 +1449,8 @@
                 "$ref" : "#/definitions/quantra_QuoteKind"
               },
         "value" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Quote value. Presence-required (a bare double would default to 0 and\nsilently bootstrap every referencing helper off a zero rate). May be\nnegative (rates/spreads); only a missing or non-finite value is rejected."
               },
         "quote_type" : {
                 "$ref" : "#/definitions/quantra_QuoteType"
@@ -1710,7 +1715,8 @@
                 "$ref" : "#/definitions/quantra_Period"
               },
         "quote_type" : {
-                "$ref" : "#/definitions/quantra_enums_CdsQuoteType"
+                "$ref" : "#/definitions/quantra_enums_CdsQuoteType",
+                "description" : "Quote convention (ParSpread / Upfront). Presence-required: an omitted\nvalue is a 400, never the alphabetical-0 default (ParSpread)."
               },
         "quote_id" : {
                 "type" : "string",
@@ -1879,7 +1885,8 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -1892,10 +1899,12 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               },
         "cash" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Cash payout on exercise. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -1908,7 +1917,8 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -2036,7 +2046,7 @@
               },
         "quote_value" : {
                 "type" : "number",
-                "description" : "Inline quote value used when quote_id is empty."
+                "description" : "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
               },
         "swap_observation_lag" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -2080,7 +2090,7 @@
               },
         "quote_value" : {
                 "type" : "number",
-                "description" : "Inline quote value used when quote_id is empty."
+                "description" : "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
               },
         "swap_observation_lag" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -2316,7 +2326,8 @@
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
               },
         "face_amount" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Face amount. Presence-required and must be > 0 (a bare double would\ndefault to a silent zero face)."
               },
         "notionals" : {
                 "type" : "array", "items" : {"type" : "number"},
@@ -2351,7 +2362,8 @@
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
               },
         "face_amount" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Face amount. Presence-required and must be > 0 (a bare double would\ndefault to a silent zero face)."
               },
         "notionals" : {
                 "type" : "array", "items" : {"type" : "number"},

--- a/flatbuffers/json/price_floating_rate_bond_request.schema.json
+++ b/flatbuffers/json/price_floating_rate_bond_request.schema.json
@@ -647,13 +647,15 @@
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
               },
         "face_amount" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Bond face amount. Presence-required and must be > 0 (a bare double would\ndefault to a silent zero face)."
               },
         "schedule" : {
                 "$ref" : "#/definitions/quantra_Schedule"
               },
         "coupon_rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Coupon rate. Presence-required (a bare double would default to a silent\nzero coupon); may be negative, only a missing or non-finite value is rejected."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter"
@@ -662,7 +664,8 @@
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention"
               },
         "redemption" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Redemption as a percentage of face. Presence-required and must be > 0\n(a bare double would default to a silent zero redemption that destroys\nthe helper)."
               },
         "issue_date" : {
                 "type" : "string"
@@ -1403,7 +1406,8 @@
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention"
               },
         "volatility" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Constant optionlet volatility. Presence-required (a bare double would\ndefault to a silent zero) and must be finite and non-negative. A genuine\n0 is valid: for a coupon leg without caps/floors the Black pricer with\nzero vol reproduces the deterministic forward, so 0 is accepted while an\nomitted value is rejected."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter"
@@ -1445,7 +1449,8 @@
                 "$ref" : "#/definitions/quantra_QuoteKind"
               },
         "value" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Quote value. Presence-required (a bare double would default to 0 and\nsilently bootstrap every referencing helper off a zero rate). May be\nnegative (rates/spreads); only a missing or non-finite value is rejected."
               },
         "quote_type" : {
                 "$ref" : "#/definitions/quantra_QuoteType"
@@ -1710,7 +1715,8 @@
                 "$ref" : "#/definitions/quantra_Period"
               },
         "quote_type" : {
-                "$ref" : "#/definitions/quantra_enums_CdsQuoteType"
+                "$ref" : "#/definitions/quantra_enums_CdsQuoteType",
+                "description" : "Quote convention (ParSpread / Upfront). Presence-required: an omitted\nvalue is a 400, never the alphabetical-0 default (ParSpread)."
               },
         "quote_id" : {
                 "type" : "string",
@@ -1879,7 +1885,8 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -1892,10 +1899,12 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               },
         "cash" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Cash payout on exercise. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -1908,7 +1917,8 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -2036,7 +2046,7 @@
               },
         "quote_value" : {
                 "type" : "number",
-                "description" : "Inline quote value used when quote_id is empty."
+                "description" : "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
               },
         "swap_observation_lag" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -2080,7 +2090,7 @@
               },
         "quote_value" : {
                 "type" : "number",
-                "description" : "Inline quote value used when quote_id is empty."
+                "description" : "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
               },
         "swap_observation_lag" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -2316,7 +2326,8 @@
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
               },
         "face_amount" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Face amount. Presence-required and must be > 0 (a bare double would\ndefault to a silent zero face)."
               },
         "notionals" : {
                 "type" : "array", "items" : {"type" : "number"},

--- a/flatbuffers/json/price_fra_request.schema.json
+++ b/flatbuffers/json/price_fra_request.schema.json
@@ -647,13 +647,15 @@
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
               },
         "face_amount" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Bond face amount. Presence-required and must be > 0 (a bare double would\ndefault to a silent zero face)."
               },
         "schedule" : {
                 "$ref" : "#/definitions/quantra_Schedule"
               },
         "coupon_rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Coupon rate. Presence-required (a bare double would default to a silent\nzero coupon); may be negative, only a missing or non-finite value is rejected."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter"
@@ -662,7 +664,8 @@
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention"
               },
         "redemption" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Redemption as a percentage of face. Presence-required and must be > 0\n(a bare double would default to a silent zero redemption that destroys\nthe helper)."
               },
         "issue_date" : {
                 "type" : "string"
@@ -1403,7 +1406,8 @@
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention"
               },
         "volatility" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Constant optionlet volatility. Presence-required (a bare double would\ndefault to a silent zero) and must be finite and non-negative. A genuine\n0 is valid: for a coupon leg without caps/floors the Black pricer with\nzero vol reproduces the deterministic forward, so 0 is accepted while an\nomitted value is rejected."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter"
@@ -1445,7 +1449,8 @@
                 "$ref" : "#/definitions/quantra_QuoteKind"
               },
         "value" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Quote value. Presence-required (a bare double would default to 0 and\nsilently bootstrap every referencing helper off a zero rate). May be\nnegative (rates/spreads); only a missing or non-finite value is rejected."
               },
         "quote_type" : {
                 "$ref" : "#/definitions/quantra_QuoteType"
@@ -1710,7 +1715,8 @@
                 "$ref" : "#/definitions/quantra_Period"
               },
         "quote_type" : {
-                "$ref" : "#/definitions/quantra_enums_CdsQuoteType"
+                "$ref" : "#/definitions/quantra_enums_CdsQuoteType",
+                "description" : "Quote convention (ParSpread / Upfront). Presence-required: an omitted\nvalue is a 400, never the alphabetical-0 default (ParSpread)."
               },
         "quote_id" : {
                 "type" : "string",
@@ -1879,7 +1885,8 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -1892,10 +1899,12 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               },
         "cash" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Cash payout on exercise. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -1908,7 +1917,8 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -2036,7 +2046,7 @@
               },
         "quote_value" : {
                 "type" : "number",
-                "description" : "Inline quote value used when quote_id is empty."
+                "description" : "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
               },
         "swap_observation_lag" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -2080,7 +2090,7 @@
               },
         "quote_value" : {
                 "type" : "number",
-                "description" : "Inline quote value used when quote_id is empty."
+                "description" : "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
               },
         "swap_observation_lag" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -2316,7 +2326,8 @@
                 "$ref" : "#/definitions/quantra_enums_FRAType"
               },
         "notional" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Notional. Presence-required and must be > 0."
               },
         "start_date" : {
                 "type" : "string",
@@ -2328,7 +2339,7 @@
               },
         "strike" : {
                 "type" : "number",
-                "description" : "The agreed forward rate (e.g., 0.035 for 3.5%)."
+                "description" : "The agreed forward rate (e.g., 0.035 for 3.5%). Presence-required; may be\nnegative, only a missing or non-finite value is rejected."
               },
         "index" : {
                 "$ref" : "#/definitions/quantra_IndexRef",

--- a/flatbuffers/json/price_ois_swap_request.schema.json
+++ b/flatbuffers/json/price_ois_swap_request.schema.json
@@ -647,13 +647,15 @@
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
               },
         "face_amount" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Bond face amount. Presence-required and must be > 0 (a bare double would\ndefault to a silent zero face)."
               },
         "schedule" : {
                 "$ref" : "#/definitions/quantra_Schedule"
               },
         "coupon_rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Coupon rate. Presence-required (a bare double would default to a silent\nzero coupon); may be negative, only a missing or non-finite value is rejected."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter"
@@ -662,7 +664,8 @@
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention"
               },
         "redemption" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Redemption as a percentage of face. Presence-required and must be > 0\n(a bare double would default to a silent zero redemption that destroys\nthe helper)."
               },
         "issue_date" : {
                 "type" : "string"
@@ -1403,7 +1406,8 @@
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention"
               },
         "volatility" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Constant optionlet volatility. Presence-required (a bare double would\ndefault to a silent zero) and must be finite and non-negative. A genuine\n0 is valid: for a coupon leg without caps/floors the Black pricer with\nzero vol reproduces the deterministic forward, so 0 is accepted while an\nomitted value is rejected."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter"
@@ -1445,7 +1449,8 @@
                 "$ref" : "#/definitions/quantra_QuoteKind"
               },
         "value" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Quote value. Presence-required (a bare double would default to 0 and\nsilently bootstrap every referencing helper off a zero rate). May be\nnegative (rates/spreads); only a missing or non-finite value is rejected."
               },
         "quote_type" : {
                 "$ref" : "#/definitions/quantra_QuoteType"
@@ -1710,7 +1715,8 @@
                 "$ref" : "#/definitions/quantra_Period"
               },
         "quote_type" : {
-                "$ref" : "#/definitions/quantra_enums_CdsQuoteType"
+                "$ref" : "#/definitions/quantra_enums_CdsQuoteType",
+                "description" : "Quote convention (ParSpread / Upfront). Presence-required: an omitted\nvalue is a 400, never the alphabetical-0 default (ParSpread)."
               },
         "quote_id" : {
                 "type" : "string",
@@ -1879,7 +1885,8 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -1892,10 +1899,12 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               },
         "cash" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Cash payout on exercise. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -1908,7 +1917,8 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -2036,7 +2046,7 @@
               },
         "quote_value" : {
                 "type" : "number",
-                "description" : "Inline quote value used when quote_id is empty."
+                "description" : "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
               },
         "swap_observation_lag" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -2080,7 +2090,7 @@
               },
         "quote_value" : {
                 "type" : "number",
-                "description" : "Inline quote value used when quote_id is empty."
+                "description" : "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
               },
         "swap_observation_lag" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -2316,7 +2326,8 @@
                 "$ref" : "#/definitions/quantra_Schedule"
               },
         "notional" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Constant notional. Presence-required and must be > 0 (unless the\nper-period `notionals` vector is supplied). A bare double would default\nto a silent zero notional."
               },
         "notionals" : {
                 "type" : "array", "items" : {"type" : "number"},
@@ -2342,7 +2353,8 @@
                 "$ref" : "#/definitions/quantra_Schedule"
               },
         "notional" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Constant notional. Presence-required and must be > 0 (unless the\nper-period `notionals` vector is supplied). A bare double would default\nto a silent zero notional."
               },
         "notionals" : {
                 "type" : "array", "items" : {"type" : "number"},
@@ -2416,7 +2428,7 @@
               },
         "notional" : {
                 "type" : "number",
-                "description" : "Coupon notional."
+                "description" : "Coupon notional. Presence-required and must be > 0."
               },
         "swap_index_id" : {
                 "type" : "string",
@@ -2496,7 +2508,8 @@
                 "$ref" : "#/definitions/quantra_Schedule"
               },
         "notional" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Notional. Presence-required and must be > 0 (a bare double would default\nto a silent zero notional)."
               },
         "index" : {
                 "$ref" : "#/definitions/quantra_IndexRef",

--- a/flatbuffers/json/price_swaption_request.schema.json
+++ b/flatbuffers/json/price_swaption_request.schema.json
@@ -651,13 +651,15 @@
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
               },
         "face_amount" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Bond face amount. Presence-required and must be > 0 (a bare double would\ndefault to a silent zero face)."
               },
         "schedule" : {
                 "$ref" : "#/definitions/quantra_Schedule"
               },
         "coupon_rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Coupon rate. Presence-required (a bare double would default to a silent\nzero coupon); may be negative, only a missing or non-finite value is rejected."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter"
@@ -666,7 +668,8 @@
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention"
               },
         "redemption" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Redemption as a percentage of face. Presence-required and must be > 0\n(a bare double would default to a silent zero redemption that destroys\nthe helper)."
               },
         "issue_date" : {
                 "type" : "string"
@@ -1407,7 +1410,8 @@
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention"
               },
         "volatility" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Constant optionlet volatility. Presence-required (a bare double would\ndefault to a silent zero) and must be finite and non-negative. A genuine\n0 is valid: for a coupon leg without caps/floors the Black pricer with\nzero vol reproduces the deterministic forward, so 0 is accepted while an\nomitted value is rejected."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter"
@@ -1449,7 +1453,8 @@
                 "$ref" : "#/definitions/quantra_QuoteKind"
               },
         "value" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Quote value. Presence-required (a bare double would default to 0 and\nsilently bootstrap every referencing helper off a zero rate). May be\nnegative (rates/spreads); only a missing or non-finite value is rejected."
               },
         "quote_type" : {
                 "$ref" : "#/definitions/quantra_QuoteType"
@@ -1714,7 +1719,8 @@
                 "$ref" : "#/definitions/quantra_Period"
               },
         "quote_type" : {
-                "$ref" : "#/definitions/quantra_enums_CdsQuoteType"
+                "$ref" : "#/definitions/quantra_enums_CdsQuoteType",
+                "description" : "Quote convention (ParSpread / Upfront). Presence-required: an omitted\nvalue is a 400, never the alphabetical-0 default (ParSpread)."
               },
         "quote_id" : {
                 "type" : "string",
@@ -1883,7 +1889,8 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -1896,10 +1903,12 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               },
         "cash" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Cash payout on exercise. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -1912,7 +1921,8 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -2040,7 +2050,7 @@
               },
         "quote_value" : {
                 "type" : "number",
-                "description" : "Inline quote value used when quote_id is empty."
+                "description" : "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
               },
         "swap_observation_lag" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -2084,7 +2094,7 @@
               },
         "quote_value" : {
                 "type" : "number",
-                "description" : "Inline quote value used when quote_id is empty."
+                "description" : "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
               },
         "swap_observation_lag" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -2320,7 +2330,8 @@
                 "$ref" : "#/definitions/quantra_Schedule"
               },
         "notional" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Constant notional. Presence-required and must be > 0 (unless the\nper-period `notionals` vector is supplied). A bare double would default\nto a silent zero notional."
               },
         "notionals" : {
                 "type" : "array", "items" : {"type" : "number"},
@@ -2346,7 +2357,8 @@
                 "$ref" : "#/definitions/quantra_Schedule"
               },
         "notional" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Constant notional. Presence-required and must be > 0 (unless the\nper-period `notionals` vector is supplied). A bare double would default\nto a silent zero notional."
               },
         "notionals" : {
                 "type" : "array", "items" : {"type" : "number"},
@@ -2420,7 +2432,7 @@
               },
         "notional" : {
                 "type" : "number",
-                "description" : "Coupon notional."
+                "description" : "Coupon notional. Presence-required and must be > 0."
               },
         "swap_index_id" : {
                 "type" : "string",
@@ -2500,7 +2512,8 @@
                 "$ref" : "#/definitions/quantra_Schedule"
               },
         "notional" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Notional. Presence-required and must be > 0 (a bare double would default\nto a silent zero notional)."
               },
         "index" : {
                 "$ref" : "#/definitions/quantra_IndexRef",

--- a/flatbuffers/json/price_vanilla_swap_request.schema.json
+++ b/flatbuffers/json/price_vanilla_swap_request.schema.json
@@ -647,13 +647,15 @@
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
               },
         "face_amount" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Bond face amount. Presence-required and must be > 0 (a bare double would\ndefault to a silent zero face)."
               },
         "schedule" : {
                 "$ref" : "#/definitions/quantra_Schedule"
               },
         "coupon_rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Coupon rate. Presence-required (a bare double would default to a silent\nzero coupon); may be negative, only a missing or non-finite value is rejected."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter"
@@ -662,7 +664,8 @@
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention"
               },
         "redemption" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Redemption as a percentage of face. Presence-required and must be > 0\n(a bare double would default to a silent zero redemption that destroys\nthe helper)."
               },
         "issue_date" : {
                 "type" : "string"
@@ -1403,7 +1406,8 @@
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention"
               },
         "volatility" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Constant optionlet volatility. Presence-required (a bare double would\ndefault to a silent zero) and must be finite and non-negative. A genuine\n0 is valid: for a coupon leg without caps/floors the Black pricer with\nzero vol reproduces the deterministic forward, so 0 is accepted while an\nomitted value is rejected."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter"
@@ -1445,7 +1449,8 @@
                 "$ref" : "#/definitions/quantra_QuoteKind"
               },
         "value" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Quote value. Presence-required (a bare double would default to 0 and\nsilently bootstrap every referencing helper off a zero rate). May be\nnegative (rates/spreads); only a missing or non-finite value is rejected."
               },
         "quote_type" : {
                 "$ref" : "#/definitions/quantra_QuoteType"
@@ -1710,7 +1715,8 @@
                 "$ref" : "#/definitions/quantra_Period"
               },
         "quote_type" : {
-                "$ref" : "#/definitions/quantra_enums_CdsQuoteType"
+                "$ref" : "#/definitions/quantra_enums_CdsQuoteType",
+                "description" : "Quote convention (ParSpread / Upfront). Presence-required: an omitted\nvalue is a 400, never the alphabetical-0 default (ParSpread)."
               },
         "quote_id" : {
                 "type" : "string",
@@ -1879,7 +1885,8 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -1892,10 +1899,12 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               },
         "cash" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Cash payout on exercise. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -1908,7 +1917,8 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -2036,7 +2046,7 @@
               },
         "quote_value" : {
                 "type" : "number",
-                "description" : "Inline quote value used when quote_id is empty."
+                "description" : "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
               },
         "swap_observation_lag" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -2080,7 +2090,7 @@
               },
         "quote_value" : {
                 "type" : "number",
-                "description" : "Inline quote value used when quote_id is empty."
+                "description" : "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
               },
         "swap_observation_lag" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -2316,7 +2326,8 @@
                 "$ref" : "#/definitions/quantra_Schedule"
               },
         "notional" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Constant notional. Presence-required and must be > 0 (unless the\nper-period `notionals` vector is supplied). A bare double would default\nto a silent zero notional."
               },
         "notionals" : {
                 "type" : "array", "items" : {"type" : "number"},
@@ -2342,7 +2353,8 @@
                 "$ref" : "#/definitions/quantra_Schedule"
               },
         "notional" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Constant notional. Presence-required and must be > 0 (unless the\nper-period `notionals` vector is supplied). A bare double would default\nto a silent zero notional."
               },
         "notionals" : {
                 "type" : "array", "items" : {"type" : "number"},
@@ -2416,7 +2428,7 @@
               },
         "notional" : {
                 "type" : "number",
-                "description" : "Coupon notional."
+                "description" : "Coupon notional. Presence-required and must be > 0."
               },
         "swap_index_id" : {
                 "type" : "string",

--- a/flatbuffers/json/price_year_on_year_inflation_cap_floor_request.schema.json
+++ b/flatbuffers/json/price_year_on_year_inflation_cap_floor_request.schema.json
@@ -647,13 +647,15 @@
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
               },
         "face_amount" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Bond face amount. Presence-required and must be > 0 (a bare double would\ndefault to a silent zero face)."
               },
         "schedule" : {
                 "$ref" : "#/definitions/quantra_Schedule"
               },
         "coupon_rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Coupon rate. Presence-required (a bare double would default to a silent\nzero coupon); may be negative, only a missing or non-finite value is rejected."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter"
@@ -662,7 +664,8 @@
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention"
               },
         "redemption" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Redemption as a percentage of face. Presence-required and must be > 0\n(a bare double would default to a silent zero redemption that destroys\nthe helper)."
               },
         "issue_date" : {
                 "type" : "string"
@@ -1403,7 +1406,8 @@
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention"
               },
         "volatility" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Constant optionlet volatility. Presence-required (a bare double would\ndefault to a silent zero) and must be finite and non-negative. A genuine\n0 is valid: for a coupon leg without caps/floors the Black pricer with\nzero vol reproduces the deterministic forward, so 0 is accepted while an\nomitted value is rejected."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter"
@@ -1445,7 +1449,8 @@
                 "$ref" : "#/definitions/quantra_QuoteKind"
               },
         "value" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Quote value. Presence-required (a bare double would default to 0 and\nsilently bootstrap every referencing helper off a zero rate). May be\nnegative (rates/spreads); only a missing or non-finite value is rejected."
               },
         "quote_type" : {
                 "$ref" : "#/definitions/quantra_QuoteType"
@@ -1710,7 +1715,8 @@
                 "$ref" : "#/definitions/quantra_Period"
               },
         "quote_type" : {
-                "$ref" : "#/definitions/quantra_enums_CdsQuoteType"
+                "$ref" : "#/definitions/quantra_enums_CdsQuoteType",
+                "description" : "Quote convention (ParSpread / Upfront). Presence-required: an omitted\nvalue is a 400, never the alphabetical-0 default (ParSpread)."
               },
         "quote_id" : {
                 "type" : "string",
@@ -1879,7 +1885,8 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -1892,10 +1899,12 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               },
         "cash" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Cash payout on exercise. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -1908,7 +1917,8 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -2036,7 +2046,7 @@
               },
         "quote_value" : {
                 "type" : "number",
-                "description" : "Inline quote value used when quote_id is empty."
+                "description" : "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
               },
         "swap_observation_lag" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -2080,7 +2090,7 @@
               },
         "quote_value" : {
                 "type" : "number",
-                "description" : "Inline quote value used when quote_id is empty."
+                "description" : "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
               },
         "swap_observation_lag" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -2318,7 +2328,7 @@
               },
         "notional" : {
                 "type" : "number",
-                "description" : "Notional per optionlet."
+                "description" : "Notional per optionlet. Presence-required and must be > 0."
               },
         "schedule" : {
                 "$ref" : "#/definitions/quantra_Schedule",

--- a/flatbuffers/json/price_year_on_year_inflation_swap_request.schema.json
+++ b/flatbuffers/json/price_year_on_year_inflation_swap_request.schema.json
@@ -647,13 +647,15 @@
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
               },
         "face_amount" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Bond face amount. Presence-required and must be > 0 (a bare double would\ndefault to a silent zero face)."
               },
         "schedule" : {
                 "$ref" : "#/definitions/quantra_Schedule"
               },
         "coupon_rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Coupon rate. Presence-required (a bare double would default to a silent\nzero coupon); may be negative, only a missing or non-finite value is rejected."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter"
@@ -662,7 +664,8 @@
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention"
               },
         "redemption" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Redemption as a percentage of face. Presence-required and must be > 0\n(a bare double would default to a silent zero redemption that destroys\nthe helper)."
               },
         "issue_date" : {
                 "type" : "string"
@@ -1403,7 +1406,8 @@
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention"
               },
         "volatility" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Constant optionlet volatility. Presence-required (a bare double would\ndefault to a silent zero) and must be finite and non-negative. A genuine\n0 is valid: for a coupon leg without caps/floors the Black pricer with\nzero vol reproduces the deterministic forward, so 0 is accepted while an\nomitted value is rejected."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter"
@@ -1445,7 +1449,8 @@
                 "$ref" : "#/definitions/quantra_QuoteKind"
               },
         "value" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Quote value. Presence-required (a bare double would default to 0 and\nsilently bootstrap every referencing helper off a zero rate). May be\nnegative (rates/spreads); only a missing or non-finite value is rejected."
               },
         "quote_type" : {
                 "$ref" : "#/definitions/quantra_QuoteType"
@@ -1710,7 +1715,8 @@
                 "$ref" : "#/definitions/quantra_Period"
               },
         "quote_type" : {
-                "$ref" : "#/definitions/quantra_enums_CdsQuoteType"
+                "$ref" : "#/definitions/quantra_enums_CdsQuoteType",
+                "description" : "Quote convention (ParSpread / Upfront). Presence-required: an omitted\nvalue is a 400, never the alphabetical-0 default (ParSpread)."
               },
         "quote_id" : {
                 "type" : "string",
@@ -1879,7 +1885,8 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -1892,10 +1899,12 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               },
         "cash" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Cash payout on exercise. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -1908,7 +1917,8 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -2036,7 +2046,7 @@
               },
         "quote_value" : {
                 "type" : "number",
-                "description" : "Inline quote value used when quote_id is empty."
+                "description" : "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
               },
         "swap_observation_lag" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -2080,7 +2090,7 @@
               },
         "quote_value" : {
                 "type" : "number",
-                "description" : "Inline quote value used when quote_id is empty."
+                "description" : "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
               },
         "swap_observation_lag" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -2317,7 +2327,8 @@
                 "description" : "\"Payer\" pays the fixed leg and receives the YoY inflation leg;\n\"Receiver\" is the reverse (receives fixed, pays YoY inflation).\nPresence-required: an omitted type is a 400, never the alphabetical-0\ndefault (Payer)."
               },
         "notional" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Notional. Presence-required and must be > 0."
               },
         "fixed_schedule" : {
                 "$ref" : "#/definitions/quantra_Schedule"

--- a/flatbuffers/json/price_zero_coupon_bond_request.schema.json
+++ b/flatbuffers/json/price_zero_coupon_bond_request.schema.json
@@ -647,13 +647,15 @@
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
               },
         "face_amount" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Bond face amount. Presence-required and must be > 0 (a bare double would\ndefault to a silent zero face)."
               },
         "schedule" : {
                 "$ref" : "#/definitions/quantra_Schedule"
               },
         "coupon_rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Coupon rate. Presence-required (a bare double would default to a silent\nzero coupon); may be negative, only a missing or non-finite value is rejected."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter"
@@ -662,7 +664,8 @@
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention"
               },
         "redemption" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Redemption as a percentage of face. Presence-required and must be > 0\n(a bare double would default to a silent zero redemption that destroys\nthe helper)."
               },
         "issue_date" : {
                 "type" : "string"
@@ -1403,7 +1406,8 @@
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention"
               },
         "volatility" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Constant optionlet volatility. Presence-required (a bare double would\ndefault to a silent zero) and must be finite and non-negative. A genuine\n0 is valid: for a coupon leg without caps/floors the Black pricer with\nzero vol reproduces the deterministic forward, so 0 is accepted while an\nomitted value is rejected."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter"
@@ -1445,7 +1449,8 @@
                 "$ref" : "#/definitions/quantra_QuoteKind"
               },
         "value" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Quote value. Presence-required (a bare double would default to 0 and\nsilently bootstrap every referencing helper off a zero rate). May be\nnegative (rates/spreads); only a missing or non-finite value is rejected."
               },
         "quote_type" : {
                 "$ref" : "#/definitions/quantra_QuoteType"
@@ -1710,7 +1715,8 @@
                 "$ref" : "#/definitions/quantra_Period"
               },
         "quote_type" : {
-                "$ref" : "#/definitions/quantra_enums_CdsQuoteType"
+                "$ref" : "#/definitions/quantra_enums_CdsQuoteType",
+                "description" : "Quote convention (ParSpread / Upfront). Presence-required: an omitted\nvalue is a 400, never the alphabetical-0 default (ParSpread)."
               },
         "quote_id" : {
                 "type" : "string",
@@ -1879,7 +1885,8 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -1892,10 +1899,12 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               },
         "cash" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Cash payout on exercise. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -1908,7 +1917,8 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -2036,7 +2046,7 @@
               },
         "quote_value" : {
                 "type" : "number",
-                "description" : "Inline quote value used when quote_id is empty."
+                "description" : "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
               },
         "swap_observation_lag" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -2080,7 +2090,7 @@
               },
         "quote_value" : {
                 "type" : "number",
-                "description" : "Inline quote value used when quote_id is empty."
+                "description" : "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
               },
         "swap_observation_lag" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -2322,7 +2332,7 @@
               },
         "face_amount" : {
                 "type" : "number",
-                "description" : "Notional / face amount the redemption percentage applies to."
+                "description" : "Notional / face amount the redemption percentage applies to.\nPresence-required and must be > 0 (a bare double would default to a\nsilent zero face)."
               },
         "maturity_date" : {
                 "type" : "string",

--- a/flatbuffers/json/price_zero_coupon_inflation_swap_request.schema.json
+++ b/flatbuffers/json/price_zero_coupon_inflation_swap_request.schema.json
@@ -647,13 +647,15 @@
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
               },
         "face_amount" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Bond face amount. Presence-required and must be > 0 (a bare double would\ndefault to a silent zero face)."
               },
         "schedule" : {
                 "$ref" : "#/definitions/quantra_Schedule"
               },
         "coupon_rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Coupon rate. Presence-required (a bare double would default to a silent\nzero coupon); may be negative, only a missing or non-finite value is rejected."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter"
@@ -662,7 +664,8 @@
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention"
               },
         "redemption" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Redemption as a percentage of face. Presence-required and must be > 0\n(a bare double would default to a silent zero redemption that destroys\nthe helper)."
               },
         "issue_date" : {
                 "type" : "string"
@@ -1403,7 +1406,8 @@
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention"
               },
         "volatility" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Constant optionlet volatility. Presence-required (a bare double would\ndefault to a silent zero) and must be finite and non-negative. A genuine\n0 is valid: for a coupon leg without caps/floors the Black pricer with\nzero vol reproduces the deterministic forward, so 0 is accepted while an\nomitted value is rejected."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter"
@@ -1445,7 +1449,8 @@
                 "$ref" : "#/definitions/quantra_QuoteKind"
               },
         "value" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Quote value. Presence-required (a bare double would default to 0 and\nsilently bootstrap every referencing helper off a zero rate). May be\nnegative (rates/spreads); only a missing or non-finite value is rejected."
               },
         "quote_type" : {
                 "$ref" : "#/definitions/quantra_QuoteType"
@@ -1710,7 +1715,8 @@
                 "$ref" : "#/definitions/quantra_Period"
               },
         "quote_type" : {
-                "$ref" : "#/definitions/quantra_enums_CdsQuoteType"
+                "$ref" : "#/definitions/quantra_enums_CdsQuoteType",
+                "description" : "Quote convention (ParSpread / Upfront). Presence-required: an omitted\nvalue is a 400, never the alphabetical-0 default (ParSpread)."
               },
         "quote_id" : {
                 "type" : "string",
@@ -1879,7 +1885,8 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -1892,10 +1899,12 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               },
         "cash" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Cash payout on exercise. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -1908,7 +1917,8 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -2036,7 +2046,7 @@
               },
         "quote_value" : {
                 "type" : "number",
-                "description" : "Inline quote value used when quote_id is empty."
+                "description" : "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
               },
         "swap_observation_lag" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -2080,7 +2090,7 @@
               },
         "quote_value" : {
                 "type" : "number",
-                "description" : "Inline quote value used when quote_id is empty."
+                "description" : "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
               },
         "swap_observation_lag" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -2317,7 +2327,8 @@
                 "description" : "\"Payer\" / \"Receiver\" refers to the inflation leg. Presence-required: an\nomitted type is a 400, never the alphabetical-0 default (Payer)."
               },
         "notional" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Notional. Presence-required and must be > 0."
               },
         "start_date" : {
                 "type" : "string"

--- a/flatbuffers/json/price_zero_coupon_swap_request.schema.json
+++ b/flatbuffers/json/price_zero_coupon_swap_request.schema.json
@@ -647,13 +647,15 @@
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
               },
         "face_amount" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Bond face amount. Presence-required and must be > 0 (a bare double would\ndefault to a silent zero face)."
               },
         "schedule" : {
                 "$ref" : "#/definitions/quantra_Schedule"
               },
         "coupon_rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Coupon rate. Presence-required (a bare double would default to a silent\nzero coupon); may be negative, only a missing or non-finite value is rejected."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter"
@@ -662,7 +664,8 @@
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention"
               },
         "redemption" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Redemption as a percentage of face. Presence-required and must be > 0\n(a bare double would default to a silent zero redemption that destroys\nthe helper)."
               },
         "issue_date" : {
                 "type" : "string"
@@ -1403,7 +1406,8 @@
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention"
               },
         "volatility" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Constant optionlet volatility. Presence-required (a bare double would\ndefault to a silent zero) and must be finite and non-negative. A genuine\n0 is valid: for a coupon leg without caps/floors the Black pricer with\nzero vol reproduces the deterministic forward, so 0 is accepted while an\nomitted value is rejected."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter"
@@ -1445,7 +1449,8 @@
                 "$ref" : "#/definitions/quantra_QuoteKind"
               },
         "value" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Quote value. Presence-required (a bare double would default to 0 and\nsilently bootstrap every referencing helper off a zero rate). May be\nnegative (rates/spreads); only a missing or non-finite value is rejected."
               },
         "quote_type" : {
                 "$ref" : "#/definitions/quantra_QuoteType"
@@ -1710,7 +1715,8 @@
                 "$ref" : "#/definitions/quantra_Period"
               },
         "quote_type" : {
-                "$ref" : "#/definitions/quantra_enums_CdsQuoteType"
+                "$ref" : "#/definitions/quantra_enums_CdsQuoteType",
+                "description" : "Quote convention (ParSpread / Upfront). Presence-required: an omitted\nvalue is a 400, never the alphabetical-0 default (ParSpread)."
               },
         "quote_id" : {
                 "type" : "string",
@@ -1879,7 +1885,8 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -1892,10 +1899,12 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               },
         "cash" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Cash payout on exercise. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -1908,7 +1917,8 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -2036,7 +2046,7 @@
               },
         "quote_value" : {
                 "type" : "number",
-                "description" : "Inline quote value used when quote_id is empty."
+                "description" : "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
               },
         "swap_observation_lag" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -2080,7 +2090,7 @@
               },
         "quote_value" : {
                 "type" : "number",
-                "description" : "Inline quote value used when quote_id is empty."
+                "description" : "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
               },
         "swap_observation_lag" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -2318,7 +2328,7 @@
               },
         "base_nominal" : {
                 "type" : "number",
-                "description" : "Base notional prior to compounding."
+                "description" : "Base notional prior to compounding. Presence-required and must be > 0\n(a bare double would default to a silent zero notional)."
               },
         "start_date" : {
                 "type" : "string",

--- a/flatbuffers/json/sample_vol_surfaces_request.schema.json
+++ b/flatbuffers/json/sample_vol_surfaces_request.schema.json
@@ -667,13 +667,15 @@
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
               },
         "face_amount" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Bond face amount. Presence-required and must be > 0 (a bare double would\ndefault to a silent zero face)."
               },
         "schedule" : {
                 "$ref" : "#/definitions/quantra_Schedule"
               },
         "coupon_rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Coupon rate. Presence-required (a bare double would default to a silent\nzero coupon); may be negative, only a missing or non-finite value is rejected."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter"
@@ -682,7 +684,8 @@
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention"
               },
         "redemption" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Redemption as a percentage of face. Presence-required and must be > 0\n(a bare double would default to a silent zero redemption that destroys\nthe helper)."
               },
         "issue_date" : {
                 "type" : "string"
@@ -1423,7 +1426,8 @@
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention"
               },
         "volatility" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Constant optionlet volatility. Presence-required (a bare double would\ndefault to a silent zero) and must be finite and non-negative. A genuine\n0 is valid: for a coupon leg without caps/floors the Black pricer with\nzero vol reproduces the deterministic forward, so 0 is accepted while an\nomitted value is rejected."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter"
@@ -1465,7 +1469,8 @@
                 "$ref" : "#/definitions/quantra_QuoteKind"
               },
         "value" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Quote value. Presence-required (a bare double would default to 0 and\nsilently bootstrap every referencing helper off a zero rate). May be\nnegative (rates/spreads); only a missing or non-finite value is rejected."
               },
         "quote_type" : {
                 "$ref" : "#/definitions/quantra_QuoteType"
@@ -1730,7 +1735,8 @@
                 "$ref" : "#/definitions/quantra_Period"
               },
         "quote_type" : {
-                "$ref" : "#/definitions/quantra_enums_CdsQuoteType"
+                "$ref" : "#/definitions/quantra_enums_CdsQuoteType",
+                "description" : "Quote convention (ParSpread / Upfront). Presence-required: an omitted\nvalue is a 400, never the alphabetical-0 default (ParSpread)."
               },
         "quote_id" : {
                 "type" : "string",
@@ -1899,7 +1905,8 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -1912,10 +1919,12 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               },
         "cash" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Cash payout on exercise. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -1928,7 +1937,8 @@
                 "$ref" : "#/definitions/quantra_enums_EquityOptionType"
               },
         "strike" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Strike price. Presence-required and must be > 0."
               }
       },
       "additionalProperties" : false
@@ -2056,7 +2066,7 @@
               },
         "quote_value" : {
                 "type" : "number",
-                "description" : "Inline quote value used when quote_id is empty."
+                "description" : "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
               },
         "swap_observation_lag" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -2100,7 +2110,7 @@
               },
         "quote_value" : {
                 "type" : "number",
-                "description" : "Inline quote value used when quote_id is empty."
+                "description" : "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
               },
         "swap_observation_lag" : {
                 "$ref" : "#/definitions/quantra_Period"

--- a/flatbuffers/json/swaption.schema.json
+++ b/flatbuffers/json/swaption.schema.json
@@ -430,7 +430,8 @@
                 "$ref" : "#/definitions/quantra_Schedule"
               },
         "notional" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Constant notional. Presence-required and must be > 0 (unless the\nper-period `notionals` vector is supplied). A bare double would default\nto a silent zero notional."
               },
         "notionals" : {
                 "type" : "array", "items" : {"type" : "number"},
@@ -456,7 +457,8 @@
                 "$ref" : "#/definitions/quantra_Schedule"
               },
         "notional" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Constant notional. Presence-required and must be > 0 (unless the\nper-period `notionals` vector is supplied). A bare double would default\nto a silent zero notional."
               },
         "notionals" : {
                 "type" : "array", "items" : {"type" : "number"},
@@ -530,7 +532,7 @@
               },
         "notional" : {
                 "type" : "number",
-                "description" : "Coupon notional."
+                "description" : "Coupon notional. Presence-required and must be > 0."
               },
         "swap_index_id" : {
                 "type" : "string",
@@ -610,7 +612,8 @@
                 "$ref" : "#/definitions/quantra_Schedule"
               },
         "notional" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Notional. Presence-required and must be > 0 (a bare double would default\nto a silent zero notional)."
               },
         "index" : {
                 "$ref" : "#/definitions/quantra_IndexRef",

--- a/flatbuffers/json/term_structure.schema.json
+++ b/flatbuffers/json/term_structure.schema.json
@@ -611,13 +611,15 @@
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
               },
         "face_amount" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Bond face amount. Presence-required and must be > 0 (a bare double would\ndefault to a silent zero face)."
               },
         "schedule" : {
                 "$ref" : "#/definitions/quantra_Schedule"
               },
         "coupon_rate" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Coupon rate. Presence-required (a bare double would default to a silent\nzero coupon); may be negative, only a missing or non-finite value is rejected."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter"
@@ -626,7 +628,8 @@
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention"
               },
         "redemption" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Redemption as a percentage of face. Presence-required and must be > 0\n(a bare double would default to a silent zero redemption that destroys\nthe helper)."
               },
         "issue_date" : {
                 "type" : "string"

--- a/flatbuffers/json/vanilla_swap.schema.json
+++ b/flatbuffers/json/vanilla_swap.schema.json
@@ -426,7 +426,8 @@
                 "$ref" : "#/definitions/quantra_Schedule"
               },
         "notional" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Constant notional. Presence-required and must be > 0 (unless the\nper-period `notionals` vector is supplied). A bare double would default\nto a silent zero notional."
               },
         "notionals" : {
                 "type" : "array", "items" : {"type" : "number"},
@@ -452,7 +453,8 @@
                 "$ref" : "#/definitions/quantra_Schedule"
               },
         "notional" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Constant notional. Presence-required and must be > 0 (unless the\nper-period `notionals` vector is supplied). A bare double would default\nto a silent zero notional."
               },
         "notionals" : {
                 "type" : "array", "items" : {"type" : "number"},
@@ -526,7 +528,7 @@
               },
         "notional" : {
                 "type" : "number",
-                "description" : "Coupon notional."
+                "description" : "Coupon notional. Presence-required and must be > 0."
               },
         "swap_index_id" : {
                 "type" : "string",

--- a/flatbuffers/json/year_on_year_inflation_cap_floor.schema.json
+++ b/flatbuffers/json/year_on_year_inflation_cap_floor.schema.json
@@ -347,7 +347,7 @@
               },
         "notional" : {
                 "type" : "number",
-                "description" : "Notional per optionlet."
+                "description" : "Notional per optionlet. Presence-required and must be > 0."
               },
         "schedule" : {
                 "$ref" : "#/definitions/quantra_Schedule",

--- a/flatbuffers/json/year_on_year_inflation_swap.schema.json
+++ b/flatbuffers/json/year_on_year_inflation_swap.schema.json
@@ -488,7 +488,7 @@
               },
         "quote_value" : {
                 "type" : "number",
-                "description" : "Inline quote value used when quote_id is empty."
+                "description" : "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
               },
         "swap_observation_lag" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -532,7 +532,7 @@
               },
         "quote_value" : {
                 "type" : "number",
-                "description" : "Inline quote value used when quote_id is empty."
+                "description" : "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
               },
         "swap_observation_lag" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -634,7 +634,8 @@
                 "description" : "\"Payer\" pays the fixed leg and receives the YoY inflation leg;\n\"Receiver\" is the reverse (receives fixed, pays YoY inflation).\nPresence-required: an omitted type is a 400, never the alphabetical-0\ndefault (Payer)."
               },
         "notional" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Notional. Presence-required and must be > 0."
               },
         "fixed_schedule" : {
                 "$ref" : "#/definitions/quantra_Schedule"

--- a/flatbuffers/json/zero_coupon_bond.schema.json
+++ b/flatbuffers/json/zero_coupon_bond.schema.json
@@ -187,7 +187,7 @@
               },
         "face_amount" : {
                 "type" : "number",
-                "description" : "Notional / face amount the redemption percentage applies to."
+                "description" : "Notional / face amount the redemption percentage applies to.\nPresence-required and must be > 0 (a bare double would default to a\nsilent zero face)."
               },
         "maturity_date" : {
                 "type" : "string",

--- a/flatbuffers/json/zero_coupon_inflation_swap.schema.json
+++ b/flatbuffers/json/zero_coupon_inflation_swap.schema.json
@@ -488,7 +488,7 @@
               },
         "quote_value" : {
                 "type" : "number",
-                "description" : "Inline quote value used when quote_id is empty."
+                "description" : "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
               },
         "swap_observation_lag" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -532,7 +532,7 @@
               },
         "quote_value" : {
                 "type" : "number",
-                "description" : "Inline quote value used when quote_id is empty."
+                "description" : "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
               },
         "swap_observation_lag" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -634,7 +634,8 @@
                 "description" : "\"Payer\" / \"Receiver\" refers to the inflation leg. Presence-required: an\nomitted type is a 400, never the alphabetical-0 default (Payer)."
               },
         "notional" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Notional. Presence-required and must be > 0."
               },
         "start_date" : {
                 "type" : "string"

--- a/flatbuffers/json/zero_coupon_swap.schema.json
+++ b/flatbuffers/json/zero_coupon_swap.schema.json
@@ -389,7 +389,7 @@
               },
         "base_nominal" : {
                 "type" : "number",
-                "description" : "Base notional prior to compounding."
+                "description" : "Base notional prior to compounding. Presence-required and must be > 0\n(a bare double would default to a silent zero notional)."
               },
         "start_date" : {
                 "type" : "string",

--- a/flatbuffers/python/quantra/BondHelper.py
+++ b/flatbuffers/python/quantra/BondHelper.py
@@ -41,12 +41,14 @@ class BondHelper(object):
             return self._tab.Get(flatbuffers.number_types.Int32Flags, o + self._tab.Pos)
         return 0
 
+    # Bond face amount. Presence-required and must be > 0 (a bare double would
+    # default to a silent zero face).
     # BondHelper
     def FaceAmount(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(8))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return 0.0
+        return None
 
     # BondHelper
     def Schedule(self):
@@ -59,12 +61,14 @@ class BondHelper(object):
             return obj
         return None
 
+    # Coupon rate. Presence-required (a bare double would default to a silent
+    # zero coupon); may be negative, only a missing or non-finite value is rejected.
     # BondHelper
     def CouponRate(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(12))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return 0.0
+        return None
 
     # BondHelper
     def DayCounter(self):
@@ -80,12 +84,15 @@ class BondHelper(object):
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
         return None
 
+    # Redemption as a percentage of face. Presence-required and must be > 0
+    # (a bare double would default to a silent zero redemption that destroys
+    # the helper).
     # BondHelper
     def Redemption(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(18))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return 0.0
+        return None
 
     # BondHelper
     def IssueDate(self):
@@ -128,7 +135,7 @@ def AddSettlementDays(builder, settlementDays):
     BondHelperAddSettlementDays(builder, settlementDays)
 
 def BondHelperAddFaceAmount(builder, faceAmount):
-    builder.PrependFloat64Slot(2, faceAmount, 0.0)
+    builder.PrependFloat64Slot(2, faceAmount, None)
 
 def AddFaceAmount(builder, faceAmount):
     BondHelperAddFaceAmount(builder, faceAmount)
@@ -140,7 +147,7 @@ def AddSchedule(builder, schedule):
     BondHelperAddSchedule(builder, schedule)
 
 def BondHelperAddCouponRate(builder, couponRate):
-    builder.PrependFloat64Slot(4, couponRate, 0.0)
+    builder.PrependFloat64Slot(4, couponRate, None)
 
 def AddCouponRate(builder, couponRate):
     BondHelperAddCouponRate(builder, couponRate)
@@ -158,7 +165,7 @@ def AddBusinessDayConvention(builder, businessDayConvention):
     BondHelperAddBusinessDayConvention(builder, businessDayConvention)
 
 def BondHelperAddRedemption(builder, redemption):
-    builder.PrependFloat64Slot(7, redemption, 0.0)
+    builder.PrependFloat64Slot(7, redemption, None)
 
 def AddRedemption(builder, redemption):
     BondHelperAddRedemption(builder, redemption)
@@ -198,12 +205,12 @@ class BondHelperT(object):
     def __init__(self):
         self.rate = None  # type: Optional[float]
         self.settlementDays = 0  # type: int
-        self.faceAmount = 0.0  # type: float
+        self.faceAmount = None  # type: Optional[float]
         self.schedule = None  # type: Optional[ScheduleT]
-        self.couponRate = 0.0  # type: float
+        self.couponRate = None  # type: Optional[float]
         self.dayCounter = None  # type: Optional[int]
         self.businessDayConvention = None  # type: Optional[int]
-        self.redemption = 0.0  # type: float
+        self.redemption = None  # type: Optional[float]
         self.issueDate = None  # type: str
         self.price = None  # type: Optional[float]
         self.quoteId = None  # type: str

--- a/flatbuffers/python/quantra/CDS.py
+++ b/flatbuffers/python/quantra/CDS.py
@@ -32,12 +32,13 @@ class CDS(object):
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
         return None
 
+    # Notional. Presence-required and must be > 0.
     # CDS
     def Notional(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return 0.0
+        return None
 
     # Running coupon in decimal (0.01 = 100bps). Required; presence-driven
     # (a genuine 0 is a valid zero-coupon CDS, an absent value is rejected).
@@ -152,7 +153,7 @@ def AddSide(builder, side):
     CDSAddSide(builder, side)
 
 def CDSAddNotional(builder, notional):
-    builder.PrependFloat64Slot(1, notional, 0.0)
+    builder.PrependFloat64Slot(1, notional, None)
 
 def AddNotional(builder, notional):
     CDSAddNotional(builder, notional)
@@ -251,7 +252,7 @@ class CDST(object):
     # CDST
     def __init__(self):
         self.side = None  # type: Optional[int]
-        self.notional = 0.0  # type: float
+        self.notional = None  # type: Optional[float]
         self.runningCoupon = None  # type: Optional[float]
         self.schedule = None  # type: Optional[ScheduleT]
         self.upfront = None  # type: Optional[float]

--- a/flatbuffers/python/quantra/CallableFixedRateBond.py
+++ b/flatbuffers/python/quantra/CallableFixedRateBond.py
@@ -38,12 +38,14 @@ class CallableFixedRateBond(object):
             return self._tab.Get(flatbuffers.number_types.Int32Flags, o + self._tab.Pos)
         return 0
 
+    # Face amount. Presence-required and must be > 0 (a bare double would
+    # default to a silent zero face).
     # CallableFixedRateBond
     def FaceAmount(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return 0.0
+        return None
 
     # CallableFixedRateBond
     def Rate(self):
@@ -131,7 +133,7 @@ def AddSettlementDays(builder, settlementDays):
     CallableFixedRateBondAddSettlementDays(builder, settlementDays)
 
 def CallableFixedRateBondAddFaceAmount(builder, faceAmount):
-    builder.PrependFloat64Slot(1, faceAmount, 0.0)
+    builder.PrependFloat64Slot(1, faceAmount, None)
 
 def AddFaceAmount(builder, faceAmount):
     CallableFixedRateBondAddFaceAmount(builder, faceAmount)
@@ -200,7 +202,7 @@ class CallableFixedRateBondT(object):
     # CallableFixedRateBondT
     def __init__(self):
         self.settlementDays = 0  # type: int
-        self.faceAmount = 0.0  # type: float
+        self.faceAmount = None  # type: Optional[float]
         self.rate = 0.0  # type: float
         self.accrualDayCounter = None  # type: Optional[int]
         self.paymentConvention = None  # type: Optional[int]

--- a/flatbuffers/python/quantra/CapFloor.py
+++ b/flatbuffers/python/quantra/CapFloor.py
@@ -32,20 +32,22 @@ class CapFloor(object):
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
         return None
 
+    # Notional. Presence-required and must be > 0.
     # CapFloor
     def Notional(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return 0.0
+        return None
 
-    # Strike rate (e.g., 0.04 for 4%).
+    # Strike rate (e.g., 0.04 for 4%). Presence-required; may be negative, only
+    # a missing or non-finite value is rejected.
     # CapFloor
     def Strike(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(8))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return 0.0
+        return None
 
     # CapFloor
     def Schedule(self):
@@ -97,13 +99,13 @@ def AddCapFloorType(builder, capFloorType):
     CapFloorAddCapFloorType(builder, capFloorType)
 
 def CapFloorAddNotional(builder, notional):
-    builder.PrependFloat64Slot(1, notional, 0.0)
+    builder.PrependFloat64Slot(1, notional, None)
 
 def AddNotional(builder, notional):
     CapFloorAddNotional(builder, notional)
 
 def CapFloorAddStrike(builder, strike):
-    builder.PrependFloat64Slot(2, strike, 0.0)
+    builder.PrependFloat64Slot(2, strike, None)
 
 def AddStrike(builder, strike):
     CapFloorAddStrike(builder, strike)
@@ -148,8 +150,8 @@ class CapFloorT(object):
     # CapFloorT
     def __init__(self):
         self.capFloorType = None  # type: Optional[int]
-        self.notional = 0.0  # type: float
-        self.strike = 0.0  # type: float
+        self.notional = None  # type: Optional[float]
+        self.strike = None  # type: Optional[float]
         self.schedule = None  # type: Optional[ScheduleT]
         self.index = None  # type: Optional[IndexRefT]
         self.dayCounter = None  # type: Optional[int]

--- a/flatbuffers/python/quantra/CdsQuote.py
+++ b/flatbuffers/python/quantra/CdsQuote.py
@@ -36,12 +36,14 @@ class CdsQuote(object):
             return obj
         return None
 
+    # Quote convention (ParSpread / Upfront). Presence-required: an omitted
+    # value is a 400, never the alphabetical-0 default (ParSpread).
     # CdsQuote
     def QuoteType(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # Optional; resolves from Pricing.quotes (QuoteType=Credit).
     # CdsQuote
@@ -90,7 +92,7 @@ def AddTenor(builder, tenor):
     CdsQuoteAddTenor(builder, tenor)
 
 def CdsQuoteAddQuoteType(builder, quoteType):
-    builder.PrependInt8Slot(1, quoteType, 0)
+    builder.PrependInt8Slot(1, quoteType, None)
 
 def AddQuoteType(builder, quoteType):
     CdsQuoteAddQuoteType(builder, quoteType)
@@ -135,7 +137,7 @@ class CdsQuoteT(object):
     # CdsQuoteT
     def __init__(self):
         self.tenor = None  # type: Optional[PeriodT]
-        self.quoteType = 0  # type: int
+        self.quoteType = None  # type: Optional[int]
         self.quoteId = None  # type: str
         self.quotedParSpread = 0.0  # type: float
         self.quotedUpfront = 0.0  # type: float

--- a/flatbuffers/python/quantra/ConstantOptionletVolatility.py
+++ b/flatbuffers/python/quantra/ConstantOptionletVolatility.py
@@ -46,12 +46,17 @@ class ConstantOptionletVolatility(object):
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
         return None
 
+    # Constant optionlet volatility. Presence-required (a bare double would
+    # default to a silent zero) and must be finite and non-negative. A genuine
+    # 0 is valid: for a coupon leg without caps/floors the Black pricer with
+    # zero vol reproduces the deterministic forward, so 0 is accepted while an
+    # omitted value is rejected.
     # ConstantOptionletVolatility
     def Volatility(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(10))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return 0.0
+        return None
 
     # ConstantOptionletVolatility
     def DayCounter(self):
@@ -85,7 +90,7 @@ def AddBusinessDayConvention(builder, businessDayConvention):
     ConstantOptionletVolatilityAddBusinessDayConvention(builder, businessDayConvention)
 
 def ConstantOptionletVolatilityAddVolatility(builder, volatility):
-    builder.PrependFloat64Slot(3, volatility, 0.0)
+    builder.PrependFloat64Slot(3, volatility, None)
 
 def AddVolatility(builder, volatility):
     ConstantOptionletVolatilityAddVolatility(builder, volatility)
@@ -110,7 +115,7 @@ class ConstantOptionletVolatilityT(object):
         self.settlementDays = 0  # type: int
         self.calendar = None  # type: Optional[int]
         self.businessDayConvention = None  # type: Optional[int]
-        self.volatility = 0.0  # type: float
+        self.volatility = None  # type: Optional[float]
         self.dayCounter = None  # type: Optional[int]
 
     @classmethod

--- a/flatbuffers/python/quantra/EquityAssetOrNothingPayoff.py
+++ b/flatbuffers/python/quantra/EquityAssetOrNothingPayoff.py
@@ -32,12 +32,13 @@ class EquityAssetOrNothingPayoff(object):
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
         return 0
 
+    # Strike price. Presence-required and must be > 0.
     # EquityAssetOrNothingPayoff
     def Strike(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return 0.0
+        return None
 
 def EquityAssetOrNothingPayoffStart(builder):
     builder.StartObject(2)
@@ -52,7 +53,7 @@ def AddOptionType(builder, optionType):
     EquityAssetOrNothingPayoffAddOptionType(builder, optionType)
 
 def EquityAssetOrNothingPayoffAddStrike(builder, strike):
-    builder.PrependFloat64Slot(1, strike, 0.0)
+    builder.PrependFloat64Slot(1, strike, None)
 
 def AddStrike(builder, strike):
     EquityAssetOrNothingPayoffAddStrike(builder, strike)
@@ -69,7 +70,7 @@ class EquityAssetOrNothingPayoffT(object):
     # EquityAssetOrNothingPayoffT
     def __init__(self):
         self.optionType = 0  # type: int
-        self.strike = 0.0  # type: float
+        self.strike = None  # type: Optional[float]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):

--- a/flatbuffers/python/quantra/EquityCashOrNothingPayoff.py
+++ b/flatbuffers/python/quantra/EquityCashOrNothingPayoff.py
@@ -32,19 +32,21 @@ class EquityCashOrNothingPayoff(object):
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
         return 0
 
+    # Strike price. Presence-required and must be > 0.
     # EquityCashOrNothingPayoff
     def Strike(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return 0.0
+        return None
 
+    # Cash payout on exercise. Presence-required and must be > 0.
     # EquityCashOrNothingPayoff
     def Cash(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(8))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return 0.0
+        return None
 
 def EquityCashOrNothingPayoffStart(builder):
     builder.StartObject(3)
@@ -59,13 +61,13 @@ def AddOptionType(builder, optionType):
     EquityCashOrNothingPayoffAddOptionType(builder, optionType)
 
 def EquityCashOrNothingPayoffAddStrike(builder, strike):
-    builder.PrependFloat64Slot(1, strike, 0.0)
+    builder.PrependFloat64Slot(1, strike, None)
 
 def AddStrike(builder, strike):
     EquityCashOrNothingPayoffAddStrike(builder, strike)
 
 def EquityCashOrNothingPayoffAddCash(builder, cash):
-    builder.PrependFloat64Slot(2, cash, 0.0)
+    builder.PrependFloat64Slot(2, cash, None)
 
 def AddCash(builder, cash):
     EquityCashOrNothingPayoffAddCash(builder, cash)
@@ -82,8 +84,8 @@ class EquityCashOrNothingPayoffT(object):
     # EquityCashOrNothingPayoffT
     def __init__(self):
         self.optionType = 0  # type: int
-        self.strike = 0.0  # type: float
-        self.cash = 0.0  # type: float
+        self.strike = None  # type: Optional[float]
+        self.cash = None  # type: Optional[float]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):

--- a/flatbuffers/python/quantra/EquityPlainVanillaPayoff.py
+++ b/flatbuffers/python/quantra/EquityPlainVanillaPayoff.py
@@ -32,12 +32,13 @@ class EquityPlainVanillaPayoff(object):
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
         return 0
 
+    # Strike price. Presence-required and must be > 0.
     # EquityPlainVanillaPayoff
     def Strike(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return 0.0
+        return None
 
 def EquityPlainVanillaPayoffStart(builder):
     builder.StartObject(2)
@@ -52,7 +53,7 @@ def AddOptionType(builder, optionType):
     EquityPlainVanillaPayoffAddOptionType(builder, optionType)
 
 def EquityPlainVanillaPayoffAddStrike(builder, strike):
-    builder.PrependFloat64Slot(1, strike, 0.0)
+    builder.PrependFloat64Slot(1, strike, None)
 
 def AddStrike(builder, strike):
     EquityPlainVanillaPayoffAddStrike(builder, strike)
@@ -69,7 +70,7 @@ class EquityPlainVanillaPayoffT(object):
     # EquityPlainVanillaPayoffT
     def __init__(self):
         self.optionType = 0  # type: int
-        self.strike = 0.0  # type: float
+        self.strike = None  # type: Optional[float]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):

--- a/flatbuffers/python/quantra/FRA.py
+++ b/flatbuffers/python/quantra/FRA.py
@@ -32,12 +32,13 @@ class FRA(object):
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
         return None
 
+    # Notional. Presence-required and must be > 0.
     # FRA
     def Notional(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return 0.0
+        return None
 
     # When the FRA period starts.
     # FRA
@@ -55,13 +56,14 @@ class FRA(object):
             return self._tab.String(o + self._tab.Pos)
         return None
 
-    # The agreed forward rate (e.g., 0.035 for 3.5%).
+    # The agreed forward rate (e.g., 0.035 for 3.5%). Presence-required; may be
+    # negative, only a missing or non-finite value is rejected.
     # FRA
     def Strike(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(12))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return 0.0
+        return None
 
     # Reference to an IndexDef by id (e.g., "EUR_3M").
     # FRA
@@ -109,7 +111,7 @@ def AddFraType(builder, fraType):
     FRAAddFraType(builder, fraType)
 
 def FRAAddNotional(builder, notional):
-    builder.PrependFloat64Slot(1, notional, 0.0)
+    builder.PrependFloat64Slot(1, notional, None)
 
 def AddNotional(builder, notional):
     FRAAddNotional(builder, notional)
@@ -127,7 +129,7 @@ def AddMaturityDate(builder, maturityDate):
     FRAAddMaturityDate(builder, maturityDate)
 
 def FRAAddStrike(builder, strike):
-    builder.PrependFloat64Slot(4, strike, 0.0)
+    builder.PrependFloat64Slot(4, strike, None)
 
 def AddStrike(builder, strike):
     FRAAddStrike(builder, strike)
@@ -172,10 +174,10 @@ class FRAT(object):
     # FRAT
     def __init__(self):
         self.fraType = None  # type: Optional[int]
-        self.notional = 0.0  # type: float
+        self.notional = None  # type: Optional[float]
         self.startDate = None  # type: str
         self.maturityDate = None  # type: str
-        self.strike = 0.0  # type: float
+        self.strike = None  # type: Optional[float]
         self.index = None  # type: Optional[IndexRefT]
         self.dayCounter = None  # type: Optional[int]
         self.calendar = None  # type: Optional[int]

--- a/flatbuffers/python/quantra/FixedRateBond.py
+++ b/flatbuffers/python/quantra/FixedRateBond.py
@@ -32,12 +32,14 @@ class FixedRateBond(object):
             return self._tab.Get(flatbuffers.number_types.Int32Flags, o + self._tab.Pos)
         return 0
 
+    # Face amount. Presence-required and must be > 0 (a bare double would
+    # default to a silent zero face).
     # FixedRateBond
     def FaceAmount(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return 0.0
+        return None
 
     # Optional per-period notionals, one entry per coupon period in schedule
     # order. Present => amortizing/step-up bond (overrides `face_amount`,
@@ -129,7 +131,7 @@ def AddSettlementDays(builder, settlementDays):
     FixedRateBondAddSettlementDays(builder, settlementDays)
 
 def FixedRateBondAddFaceAmount(builder, faceAmount):
-    builder.PrependFloat64Slot(1, faceAmount, 0.0)
+    builder.PrependFloat64Slot(1, faceAmount, None)
 
 def AddFaceAmount(builder, faceAmount):
     FixedRateBondAddFaceAmount(builder, faceAmount)
@@ -198,7 +200,7 @@ class FixedRateBondT(object):
     # FixedRateBondT
     def __init__(self):
         self.settlementDays = 0  # type: int
-        self.faceAmount = 0.0  # type: float
+        self.faceAmount = None  # type: Optional[float]
         self.notionals = None  # type: List[float]
         self.rate = 0.0  # type: float
         self.accrualDayCounter = None  # type: Optional[int]

--- a/flatbuffers/python/quantra/FloatingRateBond.py
+++ b/flatbuffers/python/quantra/FloatingRateBond.py
@@ -32,12 +32,14 @@ class FloatingRateBond(object):
             return self._tab.Get(flatbuffers.number_types.Int32Flags, o + self._tab.Pos)
         return 0
 
+    # Face amount. Presence-required and must be > 0 (a bare double would
+    # default to a silent zero face).
     # FloatingRateBond
     def FaceAmount(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return 0.0
+        return None
 
     # Optional per-period notionals, one entry per coupon period in schedule
     # order. Present => amortizing/step-up bond (overrides `face_amount`,
@@ -155,7 +157,7 @@ def AddSettlementDays(builder, settlementDays):
     FloatingRateBondAddSettlementDays(builder, settlementDays)
 
 def FloatingRateBondAddFaceAmount(builder, faceAmount):
-    builder.PrependFloat64Slot(1, faceAmount, 0.0)
+    builder.PrependFloat64Slot(1, faceAmount, None)
 
 def AddFaceAmount(builder, faceAmount):
     FloatingRateBondAddFaceAmount(builder, faceAmount)
@@ -242,7 +244,7 @@ class FloatingRateBondT(object):
     # FloatingRateBondT
     def __init__(self):
         self.settlementDays = 0  # type: int
-        self.faceAmount = 0.0  # type: float
+        self.faceAmount = None  # type: Optional[float]
         self.notionals = None  # type: List[float]
         self.schedule = None  # type: Optional[ScheduleT]
         self.index = None  # type: Optional[IndexRefT]

--- a/flatbuffers/python/quantra/OisFloatingLeg.py
+++ b/flatbuffers/python/quantra/OisFloatingLeg.py
@@ -36,12 +36,14 @@ class OisFloatingLeg(object):
             return obj
         return None
 
+    # Notional. Presence-required and must be > 0 (a bare double would default
+    # to a silent zero notional).
     # OisFloatingLeg
     def Notional(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return 0.0
+        return None
 
     # Reference to an overnight IndexDef by id (e.g., "USD_SOFR").
     # OisFloatingLeg
@@ -140,7 +142,7 @@ def AddSchedule(builder, schedule):
     OisFloatingLegAddSchedule(builder, schedule)
 
 def OisFloatingLegAddNotional(builder, notional):
-    builder.PrependFloat64Slot(1, notional, 0.0)
+    builder.PrependFloat64Slot(1, notional, None)
 
 def AddNotional(builder, notional):
     OisFloatingLegAddNotional(builder, notional)
@@ -227,7 +229,7 @@ class OisFloatingLegT(object):
     # OisFloatingLegT
     def __init__(self):
         self.schedule = None  # type: Optional[ScheduleT]
-        self.notional = 0.0  # type: float
+        self.notional = None  # type: Optional[float]
         self.index = None  # type: Optional[IndexRefT]
         self.spread = 0.0  # type: float
         self.dayCounter = 0  # type: int

--- a/flatbuffers/python/quantra/QuoteSpec.py
+++ b/flatbuffers/python/quantra/QuoteSpec.py
@@ -39,12 +39,15 @@ class QuoteSpec(object):
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
         return 0
 
+    # Quote value. Presence-required (a bare double would default to 0 and
+    # silently bootstrap every referencing helper off a zero rate). May be
+    # negative (rates/spreads); only a missing or non-finite value is rejected.
     # QuoteSpec
     def Value(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(8))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return 0.0
+        return None
 
     # QuoteSpec
     def QuoteType(self):
@@ -72,7 +75,7 @@ def AddKind(builder, kind):
     QuoteSpecAddKind(builder, kind)
 
 def QuoteSpecAddValue(builder, value):
-    builder.PrependFloat64Slot(2, value, 0.0)
+    builder.PrependFloat64Slot(2, value, None)
 
 def AddValue(builder, value):
     QuoteSpecAddValue(builder, value)
@@ -96,7 +99,7 @@ class QuoteSpecT(object):
     def __init__(self):
         self.id = None  # type: str
         self.kind = 0  # type: int
-        self.value = 0.0  # type: float
+        self.value = None  # type: Optional[float]
         self.quoteType = 0  # type: int
 
     @classmethod

--- a/flatbuffers/python/quantra/SwapCmsLeg.py
+++ b/flatbuffers/python/quantra/SwapCmsLeg.py
@@ -38,13 +38,13 @@ class SwapCmsLeg(object):
             return obj
         return None
 
-    # Coupon notional.
+    # Coupon notional. Presence-required and must be > 0.
     # SwapCmsLeg
     def Notional(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return 0.0
+        return None
 
     # Swap index conventions id from Pricing.swap_indices (e.g. "EUR_SWAP_6M").
     # SwapCmsLeg
@@ -158,7 +158,7 @@ def AddSchedule(builder, schedule):
     SwapCmsLegAddSchedule(builder, schedule)
 
 def SwapCmsLegAddNotional(builder, notional):
-    builder.PrependFloat64Slot(1, notional, 0.0)
+    builder.PrependFloat64Slot(1, notional, None)
 
 def AddNotional(builder, notional):
     SwapCmsLegAddNotional(builder, notional)
@@ -245,7 +245,7 @@ class SwapCmsLegT(object):
     # SwapCmsLegT
     def __init__(self):
         self.schedule = None  # type: Optional[ScheduleT]
-        self.notional = 0.0  # type: float
+        self.notional = None  # type: Optional[float]
         self.swapIndexId = None  # type: str
         self.swapTenor = None  # type: Optional[PeriodT]
         self.swaptionVolId = None  # type: str

--- a/flatbuffers/python/quantra/SwapFixedLeg.py
+++ b/flatbuffers/python/quantra/SwapFixedLeg.py
@@ -36,12 +36,15 @@ class SwapFixedLeg(object):
             return obj
         return None
 
+    # Constant notional. Presence-required and must be > 0 (unless the
+    # per-period `notionals` vector is supplied). A bare double would default
+    # to a silent zero notional.
     # SwapFixedLeg
     def Notional(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return 0.0
+        return None
 
     # Optional per-period notionals, one entry per coupon period in schedule
     # order. Present => amortizing/step-up leg (overrides `notional`); absent
@@ -108,7 +111,7 @@ def AddSchedule(builder, schedule):
     SwapFixedLegAddSchedule(builder, schedule)
 
 def SwapFixedLegAddNotional(builder, notional):
-    builder.PrependFloat64Slot(1, notional, 0.0)
+    builder.PrependFloat64Slot(1, notional, None)
 
 def AddNotional(builder, notional):
     SwapFixedLegAddNotional(builder, notional)
@@ -159,7 +162,7 @@ class SwapFixedLegT(object):
     # SwapFixedLegT
     def __init__(self):
         self.schedule = None  # type: Optional[ScheduleT]
-        self.notional = 0.0  # type: float
+        self.notional = None  # type: Optional[float]
         self.notionals = None  # type: List[float]
         self.rate = 0.0  # type: float
         self.dayCounter = None  # type: Optional[int]

--- a/flatbuffers/python/quantra/SwapFloatingLeg.py
+++ b/flatbuffers/python/quantra/SwapFloatingLeg.py
@@ -36,12 +36,15 @@ class SwapFloatingLeg(object):
             return obj
         return None
 
+    # Constant notional. Presence-required and must be > 0 (unless the
+    # per-period `notionals` vector is supplied). A bare double would default
+    # to a silent zero notional.
     # SwapFloatingLeg
     def Notional(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return 0.0
+        return None
 
     # Optional per-period notionals, one entry per coupon period in schedule
     # order. Present => amortizing/step-up leg (overrides `notional`); absent
@@ -135,7 +138,7 @@ def AddSchedule(builder, schedule):
     SwapFloatingLegAddSchedule(builder, schedule)
 
 def SwapFloatingLegAddNotional(builder, notional):
-    builder.PrependFloat64Slot(1, notional, 0.0)
+    builder.PrependFloat64Slot(1, notional, None)
 
 def AddNotional(builder, notional):
     SwapFloatingLegAddNotional(builder, notional)
@@ -204,7 +207,7 @@ class SwapFloatingLegT(object):
     # SwapFloatingLegT
     def __init__(self):
         self.schedule = None  # type: Optional[ScheduleT]
-        self.notional = 0.0  # type: float
+        self.notional = None  # type: Optional[float]
         self.notionals = None  # type: List[float]
         self.index = None  # type: Optional[IndexRefT]
         self.spread = 0.0  # type: float

--- a/flatbuffers/python/quantra/YearOnYearInflationSwap.py
+++ b/flatbuffers/python/quantra/YearOnYearInflationSwap.py
@@ -36,12 +36,13 @@ class YearOnYearInflationSwap(object):
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
         return None
 
+    # Notional. Presence-required and must be > 0.
     # YearOnYearInflationSwap
     def Notional(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return 0.0
+        return None
 
     # YearOnYearInflationSwap
     def FixedSchedule(self):
@@ -145,7 +146,7 @@ def AddSwapType(builder, swapType):
     YearOnYearInflationSwapAddSwapType(builder, swapType)
 
 def YearOnYearInflationSwapAddNotional(builder, notional):
-    builder.PrependFloat64Slot(1, notional, 0.0)
+    builder.PrependFloat64Slot(1, notional, None)
 
 def AddNotional(builder, notional):
     YearOnYearInflationSwapAddNotional(builder, notional)
@@ -232,7 +233,7 @@ class YearOnYearInflationSwapT(object):
     # YearOnYearInflationSwapT
     def __init__(self):
         self.swapType = None  # type: Optional[int]
-        self.notional = 0.0  # type: float
+        self.notional = None  # type: Optional[float]
         self.fixedSchedule = None  # type: Optional[ScheduleT]
         self.fixedRate = 0.0  # type: float
         self.fixedDayCounter = 1  # type: int

--- a/flatbuffers/python/quantra/YearOnYearInflationSwapHelper.py
+++ b/flatbuffers/python/quantra/YearOnYearInflationSwapHelper.py
@@ -33,13 +33,15 @@ class YearOnYearInflationSwapHelper(object):
             return self._tab.String(o + self._tab.Pos)
         return None
 
-    # Inline quote value used when quote_id is empty.
+    # Inline quote value used when quote_id is empty. Presence-required on the
+    # inline path (a bare double would default to a silent zero quote); may be
+    # negative, only a missing or non-finite value is rejected.
     # YearOnYearInflationSwapHelper
     def QuoteValue(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return 0.0
+        return None
 
     # YearOnYearInflationSwapHelper
     def SwapObservationLag(self):
@@ -125,7 +127,7 @@ def AddQuoteId(builder, quoteId):
     YearOnYearInflationSwapHelperAddQuoteId(builder, quoteId)
 
 def YearOnYearInflationSwapHelperAddQuoteValue(builder, quoteValue):
-    builder.PrependFloat64Slot(1, quoteValue, 0.0)
+    builder.PrependFloat64Slot(1, quoteValue, None)
 
 def AddQuoteValue(builder, quoteValue):
     YearOnYearInflationSwapHelperAddQuoteValue(builder, quoteValue)
@@ -200,7 +202,7 @@ class YearOnYearInflationSwapHelperT(object):
     # YearOnYearInflationSwapHelperT
     def __init__(self):
         self.quoteId = None  # type: str
-        self.quoteValue = 0.0  # type: float
+        self.quoteValue = None  # type: Optional[float]
         self.swapObservationLag = None  # type: Optional[PeriodT]
         self.tenor = None  # type: Optional[PeriodT]
         self.startDate = None  # type: str

--- a/flatbuffers/python/quantra/YoYInflationCapFloor.py
+++ b/flatbuffers/python/quantra/YoYInflationCapFloor.py
@@ -41,13 +41,13 @@ class YoYInflationCapFloor(object):
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
         return None
 
-    # Notional per optionlet.
+    # Notional per optionlet. Presence-required and must be > 0.
     # YoYInflationCapFloor
     def Notional(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return 0.0
+        return None
 
     # Coupon schedule for the year-on-year optionlet strip.
     # YoYInflationCapFloor
@@ -148,7 +148,7 @@ def AddCapFloorType(builder, capFloorType):
     YoYInflationCapFloorAddCapFloorType(builder, capFloorType)
 
 def YoYInflationCapFloorAddNotional(builder, notional):
-    builder.PrependFloat64Slot(1, notional, 0.0)
+    builder.PrependFloat64Slot(1, notional, None)
 
 def AddNotional(builder, notional):
     YoYInflationCapFloorAddNotional(builder, notional)
@@ -223,7 +223,7 @@ class YoYInflationCapFloorT(object):
     # YoYInflationCapFloorT
     def __init__(self):
         self.capFloorType = None  # type: Optional[int]
-        self.notional = 0.0  # type: float
+        self.notional = None  # type: Optional[float]
         self.schedule = None  # type: Optional[ScheduleT]
         self.inflationIndexId = None  # type: str
         self.observationLag = None  # type: Optional[PeriodT]

--- a/flatbuffers/python/quantra/ZeroCouponBond.py
+++ b/flatbuffers/python/quantra/ZeroCouponBond.py
@@ -44,12 +44,14 @@ class ZeroCouponBond(object):
         return None
 
     # Notional / face amount the redemption percentage applies to.
+    # Presence-required and must be > 0 (a bare double would default to a
+    # silent zero face).
     # ZeroCouponBond
     def FaceAmount(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(8))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return 0.0
+        return None
 
     # Single redemption/maturity date (ISO yyyy-mm-dd).
     # ZeroCouponBond
@@ -104,7 +106,7 @@ def AddCalendar(builder, calendar):
     ZeroCouponBondAddCalendar(builder, calendar)
 
 def ZeroCouponBondAddFaceAmount(builder, faceAmount):
-    builder.PrependFloat64Slot(2, faceAmount, 0.0)
+    builder.PrependFloat64Slot(2, faceAmount, None)
 
 def AddFaceAmount(builder, faceAmount):
     ZeroCouponBondAddFaceAmount(builder, faceAmount)
@@ -146,7 +148,7 @@ class ZeroCouponBondT(object):
     def __init__(self):
         self.settlementDays = 0  # type: int
         self.calendar = None  # type: Optional[int]
-        self.faceAmount = 0.0  # type: float
+        self.faceAmount = None  # type: Optional[float]
         self.maturityDate = None  # type: str
         self.paymentConvention = None  # type: Optional[int]
         self.redemption = None  # type: Optional[float]

--- a/flatbuffers/python/quantra/ZeroCouponInflationSwap.py
+++ b/flatbuffers/python/quantra/ZeroCouponInflationSwap.py
@@ -34,12 +34,13 @@ class ZeroCouponInflationSwap(object):
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
         return None
 
+    # Notional. Presence-required and must be > 0.
     # ZeroCouponInflationSwap
     def Notional(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return 0.0
+        return None
 
     # ZeroCouponInflationSwap
     def StartDate(self):
@@ -148,7 +149,7 @@ def AddSwapType(builder, swapType):
     ZeroCouponInflationSwapAddSwapType(builder, swapType)
 
 def ZeroCouponInflationSwapAddNotional(builder, notional):
-    builder.PrependFloat64Slot(1, notional, 0.0)
+    builder.PrependFloat64Slot(1, notional, None)
 
 def AddNotional(builder, notional):
     ZeroCouponInflationSwapAddNotional(builder, notional)
@@ -241,7 +242,7 @@ class ZeroCouponInflationSwapT(object):
     # ZeroCouponInflationSwapT
     def __init__(self):
         self.swapType = None  # type: Optional[int]
-        self.notional = 0.0  # type: float
+        self.notional = None  # type: Optional[float]
         self.startDate = None  # type: str
         self.maturityDate = None  # type: str
         self.fixedCalendar = 32  # type: int

--- a/flatbuffers/python/quantra/ZeroCouponInflationSwapHelper.py
+++ b/flatbuffers/python/quantra/ZeroCouponInflationSwapHelper.py
@@ -33,13 +33,15 @@ class ZeroCouponInflationSwapHelper(object):
             return self._tab.String(o + self._tab.Pos)
         return None
 
-    # Inline quote value used when quote_id is empty.
+    # Inline quote value used when quote_id is empty. Presence-required on the
+    # inline path (a bare double would default to a silent zero quote); may be
+    # negative, only a missing or non-finite value is rejected.
     # ZeroCouponInflationSwapHelper
     def QuoteValue(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return 0.0
+        return None
 
     # Lag applied when observing the CPI index in the swap.
     # ZeroCouponInflationSwapHelper
@@ -121,7 +123,7 @@ def AddQuoteId(builder, quoteId):
     ZeroCouponInflationSwapHelperAddQuoteId(builder, quoteId)
 
 def ZeroCouponInflationSwapHelperAddQuoteValue(builder, quoteValue):
-    builder.PrependFloat64Slot(1, quoteValue, 0.0)
+    builder.PrependFloat64Slot(1, quoteValue, None)
 
 def AddQuoteValue(builder, quoteValue):
     ZeroCouponInflationSwapHelperAddQuoteValue(builder, quoteValue)
@@ -190,7 +192,7 @@ class ZeroCouponInflationSwapHelperT(object):
     # ZeroCouponInflationSwapHelperT
     def __init__(self):
         self.quoteId = None  # type: str
-        self.quoteValue = 0.0  # type: float
+        self.quoteValue = None  # type: Optional[float]
         self.swapObservationLag = None  # type: Optional[PeriodT]
         self.tenor = None  # type: Optional[PeriodT]
         self.startDate = None  # type: str

--- a/flatbuffers/python/quantra/ZeroCouponSwap.py
+++ b/flatbuffers/python/quantra/ZeroCouponSwap.py
@@ -37,13 +37,14 @@ class ZeroCouponSwap(object):
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
         return None
 
-    # Base notional prior to compounding.
+    # Base notional prior to compounding. Presence-required and must be > 0
+    # (a bare double would default to a silent zero notional).
     # ZeroCouponSwap
     def BaseNominal(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return 0.0
+        return None
 
     # Contract start date (ISO yyyy-mm-dd).
     # ZeroCouponSwap
@@ -142,7 +143,7 @@ def AddSwapType(builder, swapType):
     ZeroCouponSwapAddSwapType(builder, swapType)
 
 def ZeroCouponSwapAddBaseNominal(builder, baseNominal):
-    builder.PrependFloat64Slot(1, baseNominal, 0.0)
+    builder.PrependFloat64Slot(1, baseNominal, None)
 
 def AddBaseNominal(builder, baseNominal):
     ZeroCouponSwapAddBaseNominal(builder, baseNominal)
@@ -217,7 +218,7 @@ class ZeroCouponSwapT(object):
     # ZeroCouponSwapT
     def __init__(self):
         self.swapType = None  # type: Optional[int]
-        self.baseNominal = 0.0  # type: float
+        self.baseNominal = None  # type: Optional[float]
         self.startDate = None  # type: str
         self.maturityDate = None  # type: str
         self.fixedPayment = None  # type: Optional[float]

--- a/jsonserver/openapi/openapi3.json
+++ b/jsonserver/openapi/openapi3.json
@@ -2334,7 +2334,8 @@
             "$ref": "#/components/schemas/quantra_Schedule"
           },
           "notional": {
-            "type": "number"
+            "type": "number",
+            "description": "Constant notional. Presence-required and must be > 0 (unless the\nper-period `notionals` vector is supplied). A bare double would default\nto a silent zero notional."
           },
           "notionals": {
             "type": "array",
@@ -2363,7 +2364,8 @@
             "$ref": "#/components/schemas/quantra_Schedule"
           },
           "notional": {
-            "type": "number"
+            "type": "number",
+            "description": "Constant notional. Presence-required and must be > 0 (unless the\nper-period `notionals` vector is supplied). A bare double would default\nto a silent zero notional."
           },
           "notionals": {
             "type": "array",
@@ -2440,7 +2442,7 @@
           },
           "notional": {
             "type": "number",
-            "description": "Coupon notional."
+            "description": "Coupon notional. Presence-required and must be > 0."
           },
           "swap_index_id": {
             "type": "string",
@@ -3070,13 +3072,15 @@
             "maximum": 2147483647
           },
           "face_amount": {
-            "type": "number"
+            "type": "number",
+            "description": "Bond face amount. Presence-required and must be > 0 (a bare double would\ndefault to a silent zero face)."
           },
           "schedule": {
             "$ref": "#/components/schemas/quantra_Schedule"
           },
           "coupon_rate": {
-            "type": "number"
+            "type": "number",
+            "description": "Coupon rate. Presence-required (a bare double would default to a silent\nzero coupon); may be negative, only a missing or non-finite value is rejected."
           },
           "day_counter": {
             "$ref": "#/components/schemas/quantra_enums_DayCounter"
@@ -3085,7 +3089,8 @@
             "$ref": "#/components/schemas/quantra_enums_BusinessDayConvention"
           },
           "redemption": {
-            "type": "number"
+            "type": "number",
+            "description": "Redemption as a percentage of face. Presence-required and must be > 0\n(a bare double would default to a silent zero redemption that destroys\nthe helper)."
           },
           "issue_date": {
             "type": "string"
@@ -3957,7 +3962,8 @@
             "$ref": "#/components/schemas/quantra_enums_BusinessDayConvention"
           },
           "volatility": {
-            "type": "number"
+            "type": "number",
+            "description": "Constant optionlet volatility. Presence-required (a bare double would\ndefault to a silent zero) and must be finite and non-negative. A genuine\n0 is valid: for a coupon leg without caps/floors the Black pricer with\nzero vol reproduces the deterministic forward, so 0 is accepted while an\nomitted value is rejected."
           },
           "day_counter": {
             "$ref": "#/components/schemas/quantra_enums_DayCounter"
@@ -3999,7 +4005,8 @@
             "$ref": "#/components/schemas/quantra_QuoteKind"
           },
           "value": {
-            "type": "number"
+            "type": "number",
+            "description": "Quote value. Presence-required (a bare double would default to 0 and\nsilently bootstrap every referencing helper off a zero rate). May be\nnegative (rates/spreads); only a missing or non-finite value is rejected."
           },
           "quote_type": {
             "$ref": "#/components/schemas/quantra_QuoteType"
@@ -4485,7 +4492,8 @@
             "$ref": "#/components/schemas/quantra_enums_EquityOptionType"
           },
           "strike": {
-            "type": "number"
+            "type": "number",
+            "description": "Strike price. Presence-required and must be > 0."
           }
         },
         "additionalProperties": false
@@ -4498,10 +4506,12 @@
             "$ref": "#/components/schemas/quantra_enums_EquityOptionType"
           },
           "strike": {
-            "type": "number"
+            "type": "number",
+            "description": "Strike price. Presence-required and must be > 0."
           },
           "cash": {
-            "type": "number"
+            "type": "number",
+            "description": "Cash payout on exercise. Presence-required and must be > 0."
           }
         },
         "additionalProperties": false
@@ -4514,7 +4524,8 @@
             "$ref": "#/components/schemas/quantra_enums_EquityOptionType"
           },
           "strike": {
-            "type": "number"
+            "type": "number",
+            "description": "Strike price. Presence-required and must be > 0."
           }
         },
         "additionalProperties": false
@@ -4671,7 +4682,7 @@
           },
           "quote_value": {
             "type": "number",
-            "description": "Inline quote value used when quote_id is empty."
+            "description": "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
           },
           "swap_observation_lag": {
             "$ref": "#/components/schemas/quantra_Period"
@@ -4715,7 +4726,7 @@
           },
           "quote_value": {
             "type": "number",
-            "description": "Inline quote value used when quote_id is empty."
+            "description": "Inline quote value used when quote_id is empty. Presence-required on the\ninline path (a bare double would default to a silent zero quote); may be\nnegative, only a missing or non-finite value is rejected."
           },
           "swap_observation_lag": {
             "$ref": "#/components/schemas/quantra_Period"
@@ -5847,7 +5858,8 @@
             "maximum": 2147483647
           },
           "face_amount": {
-            "type": "number"
+            "type": "number",
+            "description": "Face amount. Presence-required and must be > 0 (a bare double would\ndefault to a silent zero face)."
           },
           "rate": {
             "type": "number"
@@ -5923,11 +5935,12 @@
             "$ref": "#/components/schemas/quantra_enums_CapFloorType"
           },
           "notional": {
-            "type": "number"
+            "type": "number",
+            "description": "Notional. Presence-required and must be > 0."
           },
           "strike": {
             "type": "number",
-            "description": "Strike rate (e.g., 0.04 for 4%)."
+            "description": "Strike rate (e.g., 0.04 for 4%). Presence-required; may be negative, only\na missing or non-finite value is rejected."
           },
           "schedule": {
             "$ref": "#/components/schemas/quantra_Schedule"
@@ -6027,7 +6040,8 @@
             "$ref": "#/components/schemas/quantra_enums_ProtectionSide"
           },
           "notional": {
-            "type": "number"
+            "type": "number",
+            "description": "Notional. Presence-required and must be > 0."
           },
           "running_coupon": {
             "type": "number",
@@ -6186,7 +6200,8 @@
             "maximum": 2147483647
           },
           "face_amount": {
-            "type": "number"
+            "type": "number",
+            "description": "Face amount. Presence-required and must be > 0 (a bare double would\ndefault to a silent zero face)."
           },
           "notionals": {
             "type": "array",
@@ -6285,7 +6300,8 @@
             "maximum": 2147483647
           },
           "face_amount": {
-            "type": "number"
+            "type": "number",
+            "description": "Face amount. Presence-required and must be > 0 (a bare double would\ndefault to a silent zero face)."
           },
           "notionals": {
             "type": "array",
@@ -6396,7 +6412,8 @@
             "$ref": "#/components/schemas/quantra_enums_FRAType"
           },
           "notional": {
-            "type": "number"
+            "type": "number",
+            "description": "Notional. Presence-required and must be > 0."
           },
           "start_date": {
             "type": "string",
@@ -6408,7 +6425,7 @@
           },
           "strike": {
             "type": "number",
-            "description": "The agreed forward rate (e.g., 0.035 for 3.5%)."
+            "description": "The agreed forward rate (e.g., 0.035 for 3.5%). Presence-required; may be\nnegative, only a missing or non-finite value is rejected."
           },
           "index": {
             "$ref": "#/components/schemas/quantra_IndexRef"
@@ -6834,7 +6851,8 @@
             "$ref": "#/components/schemas/quantra_Schedule"
           },
           "notional": {
-            "type": "number"
+            "type": "number",
+            "description": "Notional. Presence-required and must be > 0 (a bare double would default\nto a silent zero notional)."
           },
           "index": {
             "$ref": "#/components/schemas/quantra_IndexRef"
@@ -7074,7 +7092,7 @@
           },
           "notional": {
             "type": "number",
-            "description": "Notional per optionlet."
+            "description": "Notional per optionlet. Presence-required and must be > 0."
           },
           "schedule": {
             "$ref": "#/components/schemas/quantra_Schedule"
@@ -7161,7 +7179,8 @@
             "$ref": "#/components/schemas/quantra_enums_SwapType"
           },
           "notional": {
-            "type": "number"
+            "type": "number",
+            "description": "Notional. Presence-required and must be > 0."
           },
           "fixed_schedule": {
             "$ref": "#/components/schemas/quantra_Schedule"
@@ -7259,7 +7278,7 @@
           },
           "face_amount": {
             "type": "number",
-            "description": "Notional / face amount the redemption percentage applies to."
+            "description": "Notional / face amount the redemption percentage applies to.\nPresence-required and must be > 0 (a bare double would default to a\nsilent zero face)."
           },
           "maturity_date": {
             "type": "string",
@@ -7320,7 +7339,8 @@
             "$ref": "#/components/schemas/quantra_enums_SwapType"
           },
           "notional": {
-            "type": "number"
+            "type": "number",
+            "description": "Notional. Presence-required and must be > 0."
           },
           "start_date": {
             "type": "string"
@@ -7417,7 +7437,7 @@
           },
           "base_nominal": {
             "type": "number",
-            "description": "Base notional prior to compounding."
+            "description": "Base notional prior to compounding. Presence-required and must be > 0\n(a bare double would default to a silent zero notional)."
           },
           "start_date": {
             "type": "string",

--- a/jsonserver/openapi/openapi3.yaml
+++ b/jsonserver/openapi/openapi3.yaml
@@ -1622,6 +1622,12 @@ components:
           $ref: '#/components/schemas/quantra_Schedule'
         notional:
           type: number
+          description: 'Constant notional. Presence-required and must be > 0 (unless
+            the
+
+            per-period `notionals` vector is supplied). A bare double would default
+
+            to a silent zero notional.'
         notionals:
           type: array
           description: 'Optional per-period notionals, one entry per coupon period
@@ -1649,6 +1655,12 @@ components:
           $ref: '#/components/schemas/quantra_Schedule'
         notional:
           type: number
+          description: 'Constant notional. Presence-required and must be > 0 (unless
+            the
+
+            per-period `notionals` vector is supplied). A bare double would default
+
+            to a silent zero notional.'
         notionals:
           type: array
           description: 'Optional per-period notionals, one entry per coupon period
@@ -1718,7 +1730,7 @@ components:
           $ref: '#/components/schemas/quantra_Schedule'
         notional:
           type: number
-          description: Coupon notional.
+          description: Coupon notional. Presence-required and must be > 0.
         swap_index_id:
           type: string
           description: Swap index conventions id from Pricing.swap_indices (e.g. "EUR_SWAP_6M").
@@ -2198,16 +2210,30 @@ components:
           maximum: 2147483647
         face_amount:
           type: number
+          description: 'Bond face amount. Presence-required and must be > 0 (a bare
+            double would
+
+            default to a silent zero face).'
         schedule:
           $ref: '#/components/schemas/quantra_Schedule'
         coupon_rate:
           type: number
+          description: 'Coupon rate. Presence-required (a bare double would default
+            to a silent
+
+            zero coupon); may be negative, only a missing or non-finite value is rejected.'
         day_counter:
           $ref: '#/components/schemas/quantra_enums_DayCounter'
         business_day_convention:
           $ref: '#/components/schemas/quantra_enums_BusinessDayConvention'
         redemption:
           type: number
+          description: 'Redemption as a percentage of face. Presence-required and
+            must be > 0
+
+            (a bare double would default to a silent zero redemption that destroys
+
+            the helper).'
         issue_date:
           type: string
         price:
@@ -2864,6 +2890,17 @@ components:
           $ref: '#/components/schemas/quantra_enums_BusinessDayConvention'
         volatility:
           type: number
+          description: 'Constant optionlet volatility. Presence-required (a bare double
+            would
+
+            default to a silent zero) and must be finite and non-negative. A genuine
+
+            0 is valid: for a coupon leg without caps/floors the Black pricer with
+
+            zero vol reproduces the deterministic forward, so 0 is accepted while
+            an
+
+            omitted value is rejected.'
         day_counter:
           $ref: '#/components/schemas/quantra_enums_DayCounter'
       additionalProperties: false
@@ -2894,6 +2931,12 @@ components:
           $ref: '#/components/schemas/quantra_QuoteKind'
         value:
           type: number
+          description: 'Quote value. Presence-required (a bare double would default
+            to 0 and
+
+            silently bootstrap every referencing helper off a zero rate). May be
+
+            negative (rates/spreads); only a missing or non-finite value is rejected.'
         quote_type:
           $ref: '#/components/schemas/quantra_QuoteType'
       required:
@@ -3248,6 +3291,7 @@ components:
           $ref: '#/components/schemas/quantra_enums_EquityOptionType'
         strike:
           type: number
+          description: Strike price. Presence-required and must be > 0.
       additionalProperties: false
     quantra_EquityCashOrNothingPayoff:
       type: object
@@ -3257,8 +3301,10 @@ components:
           $ref: '#/components/schemas/quantra_enums_EquityOptionType'
         strike:
           type: number
+          description: Strike price. Presence-required and must be > 0.
         cash:
           type: number
+          description: Cash payout on exercise. Presence-required and must be > 0.
       additionalProperties: false
     quantra_EquityAssetOrNothingPayoff:
       type: object
@@ -3268,6 +3314,7 @@ components:
           $ref: '#/components/schemas/quantra_enums_EquityOptionType'
         strike:
           type: number
+          description: Strike price. Presence-required and must be > 0.
       additionalProperties: false
     quantra_EquityBarrierFeature:
       type: object
@@ -3372,7 +3419,13 @@ components:
           description: 'Optional: resolve quote from pricing.quotes (QuoteType=Curve).'
         quote_value:
           type: number
-          description: Inline quote value used when quote_id is empty.
+          description: 'Inline quote value used when quote_id is empty. Presence-required
+            on the
+
+            inline path (a bare double would default to a silent zero quote); may
+            be
+
+            negative, only a missing or non-finite value is rejected.'
         swap_observation_lag:
           $ref: '#/components/schemas/quantra_Period'
         tenor:
@@ -3403,7 +3456,13 @@ components:
           description: 'Optional: resolve quote from pricing.quotes (QuoteType=Curve).'
         quote_value:
           type: number
-          description: Inline quote value used when quote_id is empty.
+          description: 'Inline quote value used when quote_id is empty. Presence-required
+            on the
+
+            inline path (a bare double would default to a silent zero quote); may
+            be
+
+            negative, only a missing or non-finite value is rejected.'
         swap_observation_lag:
           $ref: '#/components/schemas/quantra_Period'
         tenor:
@@ -4302,6 +4361,10 @@ components:
           maximum: 2147483647
         face_amount:
           type: number
+          description: 'Face amount. Presence-required and must be > 0 (a bare double
+            would
+
+            default to a silent zero face).'
         rate:
           type: number
         accrual_day_counter:
@@ -4366,9 +4429,13 @@ components:
           $ref: '#/components/schemas/quantra_enums_CapFloorType'
         notional:
           type: number
+          description: Notional. Presence-required and must be > 0.
         strike:
           type: number
-          description: Strike rate (e.g., 0.04 for 4%).
+          description: 'Strike rate (e.g., 0.04 for 4%). Presence-required; may be
+            negative, only
+
+            a missing or non-finite value is rejected.'
         schedule:
           $ref: '#/components/schemas/quantra_Schedule'
         index:
@@ -4438,6 +4505,7 @@ components:
           $ref: '#/components/schemas/quantra_enums_ProtectionSide'
         notional:
           type: number
+          description: Notional. Presence-required and must be > 0.
         running_coupon:
           type: number
           description: 'Running coupon in decimal (0.01 = 100bps). Required; presence-driven
@@ -4558,6 +4626,10 @@ components:
           maximum: 2147483647
         face_amount:
           type: number
+          description: 'Face amount. Presence-required and must be > 0 (a bare double
+            would
+
+            default to a silent zero face).'
         notionals:
           type: array
           description: 'Optional per-period notionals, one entry per coupon period
@@ -4633,6 +4705,10 @@ components:
           maximum: 2147483647
         face_amount:
           type: number
+          description: 'Face amount. Presence-required and must be > 0 (a bare double
+            would
+
+            default to a silent zero face).'
         notionals:
           type: array
           description: 'Optional per-period notionals, one entry per coupon period
@@ -4716,6 +4792,7 @@ components:
           $ref: '#/components/schemas/quantra_enums_FRAType'
         notional:
           type: number
+          description: Notional. Presence-required and must be > 0.
         start_date:
           type: string
           description: When the FRA period starts.
@@ -4724,7 +4801,10 @@ components:
           description: When the FRA period ends.
         strike:
           type: number
-          description: The agreed forward rate (e.g., 0.035 for 3.5%).
+          description: 'The agreed forward rate (e.g., 0.035 for 3.5%). Presence-required;
+            may be
+
+            negative, only a missing or non-finite value is rejected.'
         index:
           $ref: '#/components/schemas/quantra_IndexRef'
         day_counter:
@@ -5054,6 +5134,10 @@ components:
           $ref: '#/components/schemas/quantra_Schedule'
         notional:
           type: number
+          description: 'Notional. Presence-required and must be > 0 (a bare double
+            would default
+
+            to a silent zero notional).'
         index:
           $ref: '#/components/schemas/quantra_IndexRef'
         spread:
@@ -5239,7 +5323,7 @@ components:
           $ref: '#/components/schemas/quantra_enums_CapFloorType'
         notional:
           type: number
-          description: Notional per optionlet.
+          description: Notional per optionlet. Presence-required and must be > 0.
         schedule:
           $ref: '#/components/schemas/quantra_Schedule'
         inflation_index_id:
@@ -5326,6 +5410,7 @@ components:
           $ref: '#/components/schemas/quantra_enums_SwapType'
         notional:
           type: number
+          description: Notional. Presence-required and must be > 0.
         fixed_schedule:
           $ref: '#/components/schemas/quantra_Schedule'
         fixed_rate:
@@ -5398,7 +5483,11 @@ components:
           $ref: '#/components/schemas/quantra_enums_Calendar'
         face_amount:
           type: number
-          description: Notional / face amount the redemption percentage applies to.
+          description: 'Notional / face amount the redemption percentage applies to.
+
+            Presence-required and must be > 0 (a bare double would default to a
+
+            silent zero face).'
         maturity_date:
           type: string
           description: Single redemption/maturity date (ISO yyyy-mm-dd).
@@ -5445,6 +5534,7 @@ components:
           $ref: '#/components/schemas/quantra_enums_SwapType'
         notional:
           type: number
+          description: Notional. Presence-required and must be > 0.
         start_date:
           type: string
         maturity_date:
@@ -5528,7 +5618,10 @@ components:
           $ref: '#/components/schemas/quantra_enums_SwapType'
         base_nominal:
           type: number
-          description: Base notional prior to compounding.
+          description: 'Base notional prior to compounding. Presence-required and
+            must be > 0
+
+            (a bare double would default to a silent zero notional).'
         start_date:
           type: string
           description: Contract start date (ISO yyyy-mm-dd).

--- a/src/common/require_scalar.h
+++ b/src/common/require_scalar.h
@@ -1,0 +1,62 @@
+#ifndef QUANTRA_REQUIRE_SCALAR_H
+#define QUANTRA_REQUIRE_SCALAR_H
+
+/**
+ * Shared presence/finiteness validation for request scalars that are declared
+ * optional on the FlatBuffers wire (`field:double = null;`). A bare double
+ * defaults to 0 when omitted, so a forgotten value would silently price as
+ * zero (or a first-enum) instead of erroring; these helpers turn an omitted or
+ * non-finite value into a named 400 (QuantraInvalidArgument).
+ *
+ * This header stays FlatBuffers-aware on purpose: it is only ever included from
+ * the parsers/mappers layer (never from the FB-free evaluators), which lift the
+ * validated plain double into the domain structs.
+ */
+
+#include <cmath>
+#include <string>
+
+#include "flatbuffers/flatbuffers.h"
+
+#include "error.h"
+
+namespace quantra {
+
+/**
+ * Require a presence-optional scalar to be provided and finite. Used for
+ * RATE-like values (quote values, coupon rates, FRA/cap-floor strikes,
+ * inflation helper quotes) that may legitimately be negative in some markets,
+ * so only a missing or non-finite value is rejected — no positivity bound.
+ */
+inline double requireFinite(flatbuffers::Optional<double> v, const std::string& name) {
+    if (!v.has_value()) {
+        QUANTRA_INVALID_ARGUMENT(name + " is required");
+    }
+    if (!std::isfinite(v.value())) {
+        QUANTRA_INVALID_ARGUMENT(name + " must be finite");
+    }
+    return v.value();
+}
+
+/**
+ * Require a presence-optional scalar to be provided, finite and strictly
+ * positive. Used for notionals / face amounts / base nominals / redemptions /
+ * equity strikes (prices) / cash payouts / volatilities — quantities that are
+ * meaningless at or below zero.
+ */
+inline double requirePositive(flatbuffers::Optional<double> v, const std::string& name) {
+    if (!v.has_value()) {
+        QUANTRA_INVALID_ARGUMENT(name + " is required");
+    }
+    if (!std::isfinite(v.value())) {
+        QUANTRA_INVALID_ARGUMENT(name + " must be finite");
+    }
+    if (!(v.value() > 0.0)) {
+        QUANTRA_INVALID_ARGUMENT(name + " must be positive");
+    }
+    return v.value();
+}
+
+} // namespace quantra
+
+#endif // QUANTRA_REQUIRE_SCALAR_H

--- a/src/mappers/basis_swap_mapper.cpp
+++ b/src/mappers/basis_swap_mapper.cpp
@@ -6,6 +6,7 @@
 #include "enum_convert.h"
 #include "error.h"
 #include "leg_notionals.h"
+#include "require_scalar.h"
 
 namespace quantra {
 
@@ -26,7 +27,7 @@ BasisSwapFloatingLegData extractLeg(const quantra::SwapFloatingLeg* fb,
                                std::string("BasisSwap ") + legName);
     auto schedule = scheduleParser.parse(fb->schedule());
     leg.schedule = *schedule;
-    leg.notional = fb->notional();
+    leg.notional = requirePositive(fb->notional(), "SwapFloatingLeg.notional");
     leg.indexId = fb->index()->id()->str();
     leg.spread = fb->spread();
     leg.dayCounter = DayCounterToQL(fb->day_counter().value());

--- a/src/mappers/cap_floor_mapper.cpp
+++ b/src/mappers/cap_floor_mapper.cpp
@@ -4,6 +4,7 @@
 #include "schedule_parser.h"
 #include "enum_convert.h"
 #include "error.h"
+#include "require_scalar.h"
 
 namespace quantra {
 
@@ -51,8 +52,8 @@ CapFloorTrade extractTrade(const quantra::PriceCapFloor* pricing) {
     CapFloorTrade trade;
     trade.capFloorType = CapFloorTypeToQL(capFloor->cap_floor_type().value());
     trade.schedule = *schedule;
-    trade.notional = capFloor->notional();
-    trade.strike = capFloor->strike();
+    trade.notional = requirePositive(capFloor->notional(), "CapFloor.notional");
+    trade.strike = requireFinite(capFloor->strike(), "CapFloor.strike");
     trade.dayCounter = DayCounterToQL(capFloor->day_counter().value());
     trade.businessDayConvention = ConventionToQL(capFloor->business_day_convention().value());
     trade.includeDetails = pricing->include_details();

--- a/src/mappers/cds_mapper.cpp
+++ b/src/mappers/cds_mapper.cpp
@@ -6,6 +6,7 @@
 #include "schedule_parser.h"
 #include "enum_convert.h"
 #include "error.h"
+#include "require_scalar.h"
 
 namespace quantra {
 
@@ -41,7 +42,7 @@ CdsTrade extractTrade(const quantra::PriceCDS* pricing) {
     }
     CdsTrade trade;
     trade.side = ProtectionSideToQL(cds->side().value());
-    trade.notional = cds->notional();
+    trade.notional = requirePositive(cds->notional(), "CDS.notional");
     if (!cds->running_coupon().has_value()) {
         QUANTRA_INVALID_ARGUMENT("CDS.running_coupon is required");
     }

--- a/src/mappers/floating_rate_bond_mapper.cpp
+++ b/src/mappers/floating_rate_bond_mapper.cpp
@@ -10,6 +10,7 @@
 #include "enum_convert.h"
 #include "error.h"
 #include "leg_notionals.h"
+#include "require_scalar.h"
 
 namespace quantra {
 
@@ -50,7 +51,7 @@ FloatingRateBondTrade extractTrade(const quantra::PriceFloatingRateBond* pricing
 
     FloatingRateBondTrade trade;
     trade.settlement_days = fbBond->settlement_days();
-    trade.face_amount = fbBond->face_amount();
+    trade.face_amount = requirePositive(fbBond->face_amount(), "FloatingRateBond.face_amount");
     trade.schedule = *scheduleParser.parse(fbBond->schedule());
     // Optional per-period notionals: present => amortizing/step-up bond.
     parseOptionalNotionals(fbBond->notionals(), trade.schedule.size() - 1,

--- a/src/mappers/fra_mapper.cpp
+++ b/src/mappers/fra_mapper.cpp
@@ -3,6 +3,7 @@
 #include "date_convert.h"
 #include "enum_convert.h"
 #include "error.h"
+#include "require_scalar.h"
 
 namespace quantra {
 
@@ -49,8 +50,8 @@ FraTrade extractTrade(const quantra::PriceFRA* pricing) {
     trade.startDate = DateToQL(fra->start_date()->str());
     trade.maturityDate = DateToQL(fra->maturity_date()->str());
     trade.position = FRATypeToQL(fra->fra_type().value());
-    trade.notional = fra->notional();
-    trade.strike = fra->strike();
+    trade.notional = requirePositive(fra->notional(), "FRA.notional");
+    trade.strike = requireFinite(fra->strike(), "FRA.strike");
     trade.discountingCurveId = pricing->discounting_curve()->str();
     trade.forwardingCurveId = pricing->forwarding_curve()->str();
     trade.indexId = fra->index()->id()->str();

--- a/src/mappers/ois_swap_mapper.cpp
+++ b/src/mappers/ois_swap_mapper.cpp
@@ -6,6 +6,7 @@
 #include "enum_convert.h"
 #include "error.h"
 #include "leg_notionals.h"
+#include "require_scalar.h"
 
 namespace quantra {
 
@@ -63,13 +64,13 @@ OisSwapTrade extractTrade(const quantra::PriceOisSwap* pricing) {
 
     auto fixedSchedule = scheduleParser.parse(fixedFb->schedule());
     trade.fixed.schedule = *fixedSchedule;
-    trade.fixed.notional = fixedFb->notional();
+    trade.fixed.notional = requirePositive(fixedFb->notional(), "SwapFixedLeg.notional");
     trade.fixed.rate = fixedFb->rate();
     trade.fixed.dayCounter = DayCounterToQL(fixedFb->day_counter().value());
 
     auto overnightSchedule = scheduleParser.parse(overnightFb->schedule());
     trade.overnight.schedule = *overnightSchedule;
-    trade.overnight.notional = overnightFb->notional();
+    trade.overnight.notional = requirePositive(overnightFb->notional(), "OisFloatingLeg.notional");
     trade.overnight.indexId = overnightFb->index()->id()->str();
     trade.overnight.spread = overnightFb->spread();
     trade.overnight.paymentConvention = ConventionToQL(overnightFb->payment_convention());

--- a/src/mappers/swaption_mapper.cpp
+++ b/src/mappers/swaption_mapper.cpp
@@ -10,6 +10,7 @@
 #include "curve_bootstrapper.h"
 #include "enum_convert.h"
 #include "error.h"
+#include "require_scalar.h"
 #include "leg_notionals.h"
 #include "eval_date_guard.h"
 #include "index_registry_builder.h"
@@ -108,7 +109,7 @@ VanillaSwapTrade extractVanillaUnderlying(const quantra::VanillaSwap* swap) {
     rejectUnsupportedNotionals(fixedLeg->notionals(),
                                "Swaption underlying VanillaSwap fixed leg");
     trade.fixed.schedule = *scheduleParser.parse(fixedLeg->schedule());
-    trade.fixed.notional = fixedLeg->notional();
+    trade.fixed.notional = requirePositive(fixedLeg->notional(), "SwapFixedLeg.notional");
     trade.fixed.rate = fixedLeg->rate();
     trade.fixed.dayCounter = DayCounterToQL(fixedLeg->day_counter().value());
 
@@ -122,7 +123,7 @@ VanillaSwapTrade extractVanillaUnderlying(const quantra::VanillaSwap* swap) {
     rejectUnsupportedNotionals(floatingLeg->notionals(),
                                "Swaption underlying VanillaSwap floating leg");
     trade.ibor.schedule = *scheduleParser.parse(floatingLeg->schedule());
-    trade.ibor.notional = floatingLeg->notional();
+    trade.ibor.notional = requirePositive(floatingLeg->notional(), "SwapFloatingLeg.notional");
     trade.ibor.indexId = floatingLeg->index()->id()->str();
     trade.ibor.spread = floatingLeg->spread();
     trade.ibor.dayCounter = DayCounterToQL(floatingLeg->day_counter().value());
@@ -167,7 +168,7 @@ OisSwapTrade extractOisUnderlying(const quantra::OisSwap* swap) {
     rejectUnsupportedNotionals(fixedLeg->notionals(),
                                "Swaption underlying OisSwap fixed leg");
     trade.fixed.schedule = *scheduleParser.parse(fixedLeg->schedule());
-    trade.fixed.notional = fixedLeg->notional();
+    trade.fixed.notional = requirePositive(fixedLeg->notional(), "SwapFixedLeg.notional");
     trade.fixed.rate = fixedLeg->rate();
     trade.fixed.dayCounter = DayCounterToQL(fixedLeg->day_counter().value());
 
@@ -177,7 +178,7 @@ OisSwapTrade extractOisUnderlying(const quantra::OisSwap* swap) {
     if (!overnightLeg->index() || !overnightLeg->index()->id())
         QUANTRA_INVALID_ARGUMENT("OisSwap overnight_leg index.id is required");
     trade.overnight.schedule = *scheduleParser.parse(overnightLeg->schedule());
-    trade.overnight.notional = overnightLeg->notional();
+    trade.overnight.notional = requirePositive(overnightLeg->notional(), "OisFloatingLeg.notional");
     trade.overnight.indexId = overnightLeg->index()->id()->str();
     trade.overnight.spread = overnightLeg->spread();
     trade.overnight.paymentConvention = ConventionToQL(overnightLeg->payment_convention());

--- a/src/mappers/vanilla_swap_mapper.cpp
+++ b/src/mappers/vanilla_swap_mapper.cpp
@@ -6,6 +6,7 @@
 #include "enum_convert.h"
 #include "error.h"
 #include "leg_notionals.h"
+#include "require_scalar.h"
 
 namespace quantra {
 
@@ -75,7 +76,7 @@ VanillaSwapTrade extractTrade(const quantra::PriceVanillaSwap* pricing) {
 
     auto fixedSchedule = scheduleParser.parse(fixedFb->schedule());
     trade.fixed.schedule = *fixedSchedule;
-    trade.fixed.notional = fixedFb->notional();
+    trade.fixed.notional = requirePositive(fixedFb->notional(), "SwapFixedLeg.notional");
     trade.fixed.rate = fixedFb->rate();
     trade.fixed.dayCounter = DayCounterToQL(fixedFb->day_counter().value());
     trade.fixed.paymentConvention = ConventionToQL(fixedFb->payment_convention().value());
@@ -94,7 +95,7 @@ VanillaSwapTrade extractTrade(const quantra::PriceVanillaSwap* pricing) {
         trade.branch = VanillaSwapTrade::Branch::Ibor;
         auto floatSchedule = scheduleParser.parse(floatFb->schedule());
         trade.ibor.schedule = *floatSchedule;
-        trade.ibor.notional = floatFb->notional();
+        trade.ibor.notional = requirePositive(floatFb->notional(), "SwapFloatingLeg.notional");
         trade.ibor.indexId = floatFb->index()->id()->str();
         trade.ibor.spread = floatFb->spread();
         trade.ibor.dayCounter = DayCounterToQL(floatFb->day_counter().value());
@@ -138,7 +139,7 @@ VanillaSwapTrade extractTrade(const quantra::PriceVanillaSwap* pricing) {
     trade.branch = VanillaSwapTrade::Branch::Cms;
     auto cmsSchedule = scheduleParser.parse(cmsFb->schedule());
     trade.cms.schedule = *cmsSchedule;
-    trade.cms.notional = cmsFb->notional();
+    trade.cms.notional = requirePositive(cmsFb->notional(), "SwapCmsLeg.notional");
     trade.cms.swapIndexId = cmsFb->swap_index_id()->str();
     trade.cms.swapTenor = QuantLib::Period(
         cmsFb->swap_tenor()->n(), TimeUnitToQL(cmsFb->swap_tenor()->unit()));

--- a/src/mappers/year_on_year_inflation_cap_floor_mapper.cpp
+++ b/src/mappers/year_on_year_inflation_cap_floor_mapper.cpp
@@ -4,6 +4,7 @@
 #include "enum_convert.h"
 #include "schedule_parser.h"
 #include "error.h"
+#include "require_scalar.h"
 
 namespace quantra {
 
@@ -85,7 +86,7 @@ YoYInflationCapFloorTrade extractTrade(const quantra::PriceYoYInflationCapFloor*
 
     YoYInflationCapFloorTrade trade;
     trade.capFloorType = static_cast<QuantLib::YoYInflationCapFloor::Type>(capFloorType);
-    trade.notional = cf->notional();
+    trade.notional = requirePositive(cf->notional(), "YoYInflationCapFloor.notional");
     trade.schedule = *schedule;
     trade.inflationIndexId = cf->inflation_index_id()->str();
     trade.observationLag = QuantLib::Period(

--- a/src/mappers/year_on_year_inflation_swap_mapper.cpp
+++ b/src/mappers/year_on_year_inflation_swap_mapper.cpp
@@ -6,6 +6,7 @@
 #include "schedule_parser.h"
 #include "enum_convert.h"
 #include "error.h"
+#include "require_scalar.h"
 
 namespace quantra {
 
@@ -52,7 +53,7 @@ YearOnYearInflationSwapTrade extractTrade(const quantra::PriceYearOnYearInflatio
 
     YearOnYearInflationSwapTrade trade;
     trade.swapType = YearOnYearInflationSwapTypeToQL(swap->swap_type().value());
-    trade.notional = swap->notional();
+    trade.notional = requirePositive(swap->notional(), "YearOnYearInflationSwap.notional");
     trade.fixedSchedule = *fixedSchedule;
     trade.fixedRate = swap->fixed_rate();
     trade.fixedDayCounter = DayCounterToQL(swap->fixed_day_counter());

--- a/src/mappers/zero_coupon_inflation_swap_mapper.cpp
+++ b/src/mappers/zero_coupon_inflation_swap_mapper.cpp
@@ -5,6 +5,7 @@
 #include "date_convert.h"
 #include "enum_convert.h"
 #include "error.h"
+#include "require_scalar.h"
 
 namespace quantra {
 
@@ -47,7 +48,7 @@ ZeroCouponInflationSwapTrade extractTrade(const quantra::PriceZeroCouponInflatio
 
     ZeroCouponInflationSwapTrade trade;
     trade.swapType = ZeroCouponInflationSwapTypeToQL(swap->swap_type().value());
-    trade.notional = swap->notional();
+    trade.notional = requirePositive(swap->notional(), "ZeroCouponInflationSwap.notional");
     trade.startDate = DateToQL(swap->start_date()->str());
     trade.maturityDate = DateToQL(swap->maturity_date()->str());
     trade.fixedCalendar = CalendarToQL(swap->fixed_calendar());

--- a/src/mappers/zero_coupon_swap_mapper.cpp
+++ b/src/mappers/zero_coupon_swap_mapper.cpp
@@ -3,6 +3,7 @@
 #include "date_convert.h"
 #include "enum_convert.h"
 #include "error.h"
+#include "require_scalar.h"
 
 namespace quantra {
 
@@ -54,7 +55,7 @@ ZeroCouponSwapTrade extractTrade(const quantra::PriceZeroCouponSwap* pricing) {
 
     ZeroCouponSwapTrade trade;
     trade.swapType = ZeroCouponSwapTypeToQL(swap->swap_type().value());
-    trade.baseNominal = swap->base_nominal();
+    trade.baseNominal = requirePositive(swap->base_nominal(), "ZeroCouponSwap.base_nominal");
     trade.startDate = DateToQL(swap->start_date()->str());
     trade.maturityDate = DateToQL(swap->maturity_date()->str());
     if (trade.maturityDate <= trade.startDate) {

--- a/src/market/curve_bootstrapper.cpp
+++ b/src/market/curve_bootstrapper.cpp
@@ -11,6 +11,7 @@
 #include "curve_cache.h"
 #include "curve_cache_key.h"
 #include "curve_serializer.h"
+#include "require_scalar.h"
 
 namespace quantra {
 
@@ -199,7 +200,7 @@ BootstrappedCurves CurveBootstrapper::bootstrapAll(
         for (flatbuffers::uoffset_t i = 0; i < quotes->size(); i++) {
             auto q = quotes->Get(i);
             if (!q->id()) QUANTRA_INVALID_ARGUMENT("QuoteSpec.id is required");
-            double v = q->value();
+            double v = requireFinite(q->value(), "QuoteSpec.value");
             if (q->quote_type() == quantra::QuoteType_Curve) {
                 v += curveBump;
             }

--- a/src/market/curve_cache_key.cpp
+++ b/src/market/curve_cache_key.cpp
@@ -263,12 +263,12 @@ std::vector<uint8_t> CurveKeyBuilder::serializePoint(
         buf.writeU8(p->rate().has_value() ? 1 : 0);
         buf.writeDouble(p->rate().value_or(0.0));
         buf.writeI32(p->settlement_days());
-        buf.writeDouble(p->face_amount());
+        buf.writeDouble(p->face_amount().value_or(0.0));
         writeSchedule(buf, p->schedule());
-        buf.writeDouble(p->coupon_rate());
+        buf.writeDouble(p->coupon_rate().value_or(0.0));
         writeOptEnum(p->day_counter());
         writeOptEnum(p->business_day_convention());
-        buf.writeDouble(p->redemption());
+        buf.writeDouble(p->redemption().value_or(0.0));
         buf.writeFbString(p->issue_date());
         break;
     }

--- a/src/market/curve_cache_key.h
+++ b/src/market/curve_cache_key.h
@@ -111,7 +111,11 @@ struct KeyContext {
             for (flatbuffers::uoffset_t i = 0; i < quotes->size(); i++) {
                 auto q = quotes->Get(i);
                 if (q->id() && q->quote_type() == quantra::QuoteType_Curve) {
-                    ctx.quoteValues[q->id()->str()] = q->value();
+                    // Presence-optional on the wire; the parser rejects an
+                    // absent value, so an invalid request never reaches a cache
+                    // hit. For a valid request the value is present and this
+                    // records the real resolved quote value.
+                    ctx.quoteValues[q->id()->str()] = q->value().value_or(0.0);
                 }
             }
         }

--- a/src/market/pricing_registry.cpp
+++ b/src/market/pricing_registry.cpp
@@ -18,8 +18,11 @@
 #include "swap_index_registry.h"
 #include "enum_convert.h"
 #include "date_convert.h"
+#include <cmath>
+
 #include "quote_registry.h"
 #include "inflation_curve_parsers.h"
+#include "require_scalar.h"
 
 namespace quantra {
 
@@ -51,8 +54,8 @@ PricingRegistry PricingRegistryBuilder::build(const quantra::Pricing* pricing,
                 QUANTRA_INVALID_ARGUMENT("QuoteSpec.id is required");
             }
             std::string id = it->id()->str();
-            auto sq = std::make_shared<QuantLib::SimpleQuote>(it->value());
-            quoteRegistry.upsert(id, it->value(), it->quote_type());
+            const double quoteValue = requireFinite(it->value(), "QuoteSpec.value");
+            quoteRegistry.upsert(id, quoteValue, it->quote_type());
         }
     }
     reg.quoteRegistry = quoteRegistry;
@@ -360,7 +363,10 @@ PricingRegistry PricingRegistryBuilder::build(const quantra::Pricing* pricing,
                         q.tenor = QuantLib::Period(qit->tenor()->n(),
                                                    TimeUnitToQL(qit->tenor()->unit()));
                     }
-                    q.quote_type = static_cast<CdsQuoteTypeKind>(qit->quote_type());
+                    if (!qit->quote_type().has_value()) {
+                        QUANTRA_INVALID_ARGUMENT("CdsQuote.quote_type is required");
+                    }
+                    q.quote_type = static_cast<CdsQuoteTypeKind>(qit->quote_type().value());
                     if (qit->quote_id()) q.quote_id = qit->quote_id()->str();
                     q.quoted_par_spread = qit->quoted_par_spread();
                     q.quoted_upfront = qit->quoted_upfront();
@@ -415,7 +421,17 @@ PricingRegistry PricingRegistryBuilder::build(const quantra::Pricing* pricing,
             d.settlement_days = ov->settlement_days();
             d.calendar = CalendarToQL(ov->calendar().value());
             d.business_day_convention = ConventionToQL(ov->business_day_convention().value());
-            d.volatility = ov->volatility();
+            // Presence-required and finite; a genuine 0 is valid (a leg without
+            // caps/floors reproduces the deterministic forward), so only a
+            // missing, non-finite or negative volatility is rejected.
+            if (!ov->volatility().has_value()) {
+                QUANTRA_INVALID_ARGUMENT("ConstantOptionletVolatility.volatility is required");
+            }
+            if (!std::isfinite(ov->volatility().value()) || ov->volatility().value() < 0.0) {
+                QUANTRA_INVALID_ARGUMENT(
+                    "ConstantOptionletVolatility.volatility must be finite and non-negative");
+            }
+            d.volatility = ov->volatility().value();
             d.day_counter = DayCounterToQL(ov->day_counter().value());
             domain.payload = std::move(d);
             reg.rates.couponPricerDomains.emplace(id, std::move(domain));

--- a/src/parsers/callable_fixed_rate_bond_parser.cpp
+++ b/src/parsers/callable_fixed_rate_bond_parser.cpp
@@ -5,6 +5,7 @@
 #include <ql/time/date.hpp>
 
 #include "error.h"
+#include "require_scalar.h"
 
 std::shared_ptr<QuantLib::CallableFixedRateBond> CallableFixedRateBondParser::parse(
     const quantra::CallableFixedRateBond *bond)
@@ -76,7 +77,7 @@ std::shared_ptr<QuantLib::CallableFixedRateBond> CallableFixedRateBondParser::pa
 
     return std::make_shared<QuantLib::CallableFixedRateBond>(
         bond->settlement_days(),
-        bond->face_amount(),
+        quantra::requirePositive(bond->face_amount(), "CallableFixedRateBond.face_amount"),
         *schedule,
         std::vector<QuantLib::Rate>(1, bond->rate()),
         dayCounter,

--- a/src/parsers/cms_leg_parser.cpp
+++ b/src/parsers/cms_leg_parser.cpp
@@ -3,6 +3,8 @@
 #include <cmath>
 #include <limits>
 
+#include "require_scalar.h"
+
 #include "vanilla_swap_generated.h"
 
 #include <ql/cashflows/cmscoupon.hpp>
@@ -79,7 +81,7 @@ QuantLib::Leg CmsLegParser::parse(
         swapIndexId, cmsTenor, indices, forwardingCurve, discountCurve);
 
     QuantLib::CmsLeg cmsBuilder(*schedule, swapIndex);
-    cmsBuilder.withNotionals(leg->notional());
+    cmsBuilder.withNotionals(requirePositive(leg->notional(), "SwapCmsLeg.notional"));
     cmsBuilder.withPaymentDayCounter(DayCounterToQL(leg->day_counter().value()));
     cmsBuilder.withPaymentAdjustment(ConventionToQL(leg->payment_convention().value()));
     cmsBuilder.withGearings(leg->gear());

--- a/src/parsers/equity_option_parser.cpp
+++ b/src/parsers/equity_option_parser.cpp
@@ -6,6 +6,7 @@
 #include "date_convert.h"
 #include "enum_convert.h"
 #include "error.h"
+#include "require_scalar.h"
 
 namespace quantra {
 
@@ -84,7 +85,7 @@ ParsedEquityOption EquityOptionParser::parse(const quantra::EquityOption* option
             }
             parsed.payoffKind = EquityPayoffKind::PlainVanilla;
             parsed.optionType = EquityOptionTypeToQL(po->option_type());
-            parsed.strike = po->strike();
+            parsed.strike = requirePositive(po->strike(), "EquityPlainVanillaPayoff.strike");
             break;
         }
         case quantra::EquityPayoff_EquityCashOrNothingPayoff: {
@@ -94,8 +95,8 @@ ParsedEquityOption EquityOptionParser::parse(const quantra::EquityOption* option
             }
             parsed.payoffKind = EquityPayoffKind::CashOrNothing;
             parsed.optionType = EquityOptionTypeToQL(po->option_type());
-            parsed.strike = po->strike();
-            parsed.cash = po->cash();
+            parsed.strike = requirePositive(po->strike(), "EquityCashOrNothingPayoff.strike");
+            parsed.cash = requirePositive(po->cash(), "EquityCashOrNothingPayoff.cash");
             break;
         }
         case quantra::EquityPayoff_EquityAssetOrNothingPayoff: {
@@ -105,7 +106,7 @@ ParsedEquityOption EquityOptionParser::parse(const quantra::EquityOption* option
             }
             parsed.payoffKind = EquityPayoffKind::AssetOrNothing;
             parsed.optionType = EquityOptionTypeToQL(po->option_type());
-            parsed.strike = po->strike();
+            parsed.strike = requirePositive(po->strike(), "EquityAssetOrNothingPayoff.strike");
             break;
         }
         default:

--- a/src/parsers/fixed_rate_bond_parser.cpp
+++ b/src/parsers/fixed_rate_bond_parser.cpp
@@ -1,5 +1,7 @@
 #include "fixed_rate_bond_parser.h"
 
+#include "require_scalar.h"
+
 std::shared_ptr<QuantLib::Bond> FixedRateBondParser::parse(const quantra::FixedRateBond *bond)
 {
     if (bond == NULL)
@@ -43,7 +45,7 @@ std::shared_ptr<QuantLib::Bond> FixedRateBondParser::parse(const quantra::FixedR
 
     return std::make_shared<QuantLib::FixedRateBond>(
         bond->settlement_days(),
-        bond->face_amount(),
+        quantra::requirePositive(bond->face_amount(), "FixedRateBond.face_amount"),
         *schedule,
         std::vector<Rate>(1, bond->rate()),
         dayCounter,

--- a/src/parsers/inflation_curve_parsers.cpp
+++ b/src/parsers/inflation_curve_parsers.cpp
@@ -22,6 +22,7 @@
 #include "date_convert.h"
 #include "enum_convert.h"
 #include "error.h"
+#include "require_scalar.h"
 #include "index_registry_builder.h" // CurrencyFromString
 
 namespace quantra {
@@ -96,7 +97,7 @@ double resolveQuoteOrInline(
         }
         return quotes->getValue(helper->quote_id()->str(), quantra::QuoteType_Curve);
     }
-    return helper->quote_value();
+    return requireFinite(helper->quote_value(), helperLabel + ".quote_value");
 }
 
 QuantLib::Date parseDateReq(const flatbuffers::String* s, const std::string& label) {

--- a/src/parsers/term_structure_point_parser.cpp
+++ b/src/parsers/term_structure_point_parser.cpp
@@ -6,6 +6,8 @@
 #include <ql/instruments/makeois.hpp>
 #include <ql/settings.hpp>
 
+#include "require_scalar.h"
+
 using namespace QuantLib;
 
 namespace quantra {
@@ -319,15 +321,19 @@ std::shared_ptr<RateHelper> TermStructurePointParser::parse(
         if (!point->business_day_convention().has_value())
             QUANTRA_INVALID_ARGUMENT("BondHelper.business_day_convention is required");
 
+        const double faceAmount = requirePositive(point->face_amount(), "BondHelper.face_amount");
+        const double couponRate = requireFinite(point->coupon_rate(), "BondHelper.coupon_rate");
+        const double redemption = requirePositive(point->redemption(), "BondHelper.redemption");
+
         return std::make_shared<FixedRateBondHelper>(
             q,
             point->settlement_days(),
-            point->face_amount(),
+            faceAmount,
             *schedule_parser.parse(point->schedule()),
-            std::vector<Rate>(1, point->coupon_rate()),
+            std::vector<Rate>(1, couponRate),
             DayCounterToQL(point->day_counter().value()),
             ConventionToQL(point->business_day_convention().value()),
-            point->redemption(),
+            redemption,
             DateToQL(point->issue_date()->str()));
     }
 

--- a/src/parsers/zero_coupon_bond_parser.cpp
+++ b/src/parsers/zero_coupon_bond_parser.cpp
@@ -1,6 +1,7 @@
 #include "zero_coupon_bond_parser.h"
 
 #include "error.h"
+#include "require_scalar.h"
 
 std::shared_ptr<QuantLib::Bond> ZeroCouponBondParser::parse(const quantra::ZeroCouponBond *bond)
 {
@@ -32,7 +33,7 @@ std::shared_ptr<QuantLib::Bond> ZeroCouponBondParser::parse(const quantra::ZeroC
     return std::make_shared<QuantLib::ZeroCouponBond>(
         bond->settlement_days(),
         calendar,
-        bond->face_amount(),
+        quantra::requirePositive(bond->face_amount(), "ZeroCouponBond.face_amount"),
         maturityDate,
         paymentConvention,
         redemption,

--- a/tests/contract/error_contract_test.py
+++ b/tests/contract/error_contract_test.py
@@ -552,16 +552,39 @@ def _ec_swaption_rebump_without_rates():
     return f
 
 
-def _ec_basis_swap_zero_notional():
-    """Zero both basis-swap leg notionals so each leg BPS collapses to 0.
+def _ec_basis_swap_negative_notional():
+    """Set a basis-swap leg notional to a negative value.
 
-    The fair spread is npv - spread/BPS; a zero BPS makes it NaN. NaN has no
-    JSON representation, so the response mapper must omit the field, keeping the
-    HTTP-200 body valid JSON rather than emitting a bare `nan` token."""
+    A notional is a strictly-positive quantity; an omitted-or-nonpositive value
+    must be a named 400, never a silently-priced zero (a bare double on the wire
+    would default to 0)."""
     def f(req):
         bs = req["swaps"][0]["basis_swap"]
-        bs["leg1"]["notional"] = 0.0
-        bs["leg2"]["notional"] = 0.0
+        bs["leg1"]["notional"] = -1000000.0
+        return req
+    return f
+
+
+def _ec_del_quote_value():
+    """Drop the inline `value` from the first shared market quote (QuoteSpec).
+
+    A bare double on the wire defaults to 0, so an omitted quote value would
+    silently bootstrap every referencing helper off a zero rate. It must be a
+    named 400 instead."""
+    def f(req):
+        req["pricing"]["quotes"][0].pop("value", None)
+        return req
+    return f
+
+
+def _ec_del_cds_quote_type():
+    """Drop the presence-required `quote_type` from the first CDS market quote.
+
+    Without it a bare enum defaults to the alphabetical-0 value (ParSpread);
+    an omitted discriminator must be a named 400."""
+    def f(req):
+        req["pricing"]["credit"]["credit_curves"][0]["quotes"][0].pop(
+            "quote_type", None)
         return req
     return f
 
@@ -880,6 +903,34 @@ SCENARIOS = [
      "floating_rate_bond_request.json", 400,
      _ec_del_optionlet_vol_field("day_counter"),
      _ec_body_contains("ConstantOptionletVolatility.day_counter is required")),
+    # ---- 400 INVALID_ARGUMENT: request value scalars are presence-required ----
+    # A bare double/enum on the wire defaults to 0/first-enum when omitted, so a
+    # forgotten value would silently price as zero instead of erroring. Each of
+    # these must now be a named 400.
+    ("ec:400 coupon pricer optionlet vol missing volatility", "floating_rate_bond",
+     "floating_rate_bond_request.json", 400,
+     _ec_del_optionlet_vol_field("volatility"),
+     _ec_body_contains("ConstantOptionletVolatility.volatility is required")),
+    ("ec:400 quote spec missing value", "cds",
+     "cds_complex_request.json", 400,
+     _ec_del_quote_value(),
+     _ec_body_contains("QuoteSpec.value is required")),
+    ("ec:400 cds quote missing quote_type", "cds",
+     "cds_complex_request.json", 400,
+     _ec_del_cds_quote_type(),
+     _ec_body_contains("CdsQuote.quote_type is required")),
+    ("ec:400 bond helper missing redemption", "fixed_rate_bond",
+     "fixed_rate_bond_request.json", 400,
+     _ec_del_curve_point_field("BondHelper", "redemption"),
+     _ec_body_contains("BondHelper.redemption is required")),
+    ("ec:400 fra missing strike", "fra",
+     "fra_request.json", 400,
+     _ec_del_instrument_field("fras", "fra", "strike"),
+     _ec_body_contains("FRA.strike is required")),
+    ("ec:400 cap_floor missing strike", "cap_floor",
+     "cap_floor_request.json", 400,
+     _ec_del_instrument_field("cap_floors", "cap_floor", "strike"),
+     _ec_body_contains("CapFloor.strike is required")),
     # ---- 400 INVALID_ARGUMENT: fail-closed enum handling ----
     # The CDS credit-curve bootstrap supports LogLinear only; ForwardFlat
     # and LogCubic used to be silently priced as LogLinear. The complex request
@@ -948,13 +999,11 @@ SCENARIOS = [
      "swaption_request.json", 400,
      _ec_swaption_rebump_without_rates(),
      _ec_body_contains("Swaption rebump pricing requires pricing.rates.curves")),
-    # ---- 200 OK: non-finite outputs are omitted, never serialized as `nan` ----
-    # A zero-notional basis swap collapses each leg BPS to 0, making the fair
-    # spread NaN. The response must stay valid JSON with the field omitted.
-    ("ec:200 basis_swap zero notional omits non-finite fair spread", "basis_swap",
-     "basis_swap_request.json", 200,
-     _ec_basis_swap_zero_notional(),
-     _ec_body_valid_json_without("fair_spread_leg1", "fair_spread_leg2")),
+    # ---- 400 INVALID_ARGUMENT: a notional must be present and strictly positive ----
+    ("ec:400 basis_swap negative notional rejected", "basis_swap",
+     "basis_swap_request.json", 400,
+     _ec_basis_swap_negative_notional(),
+     _ec_body_contains("SwapFloatingLeg.notional must be positive")),
     # ---- 501 UNIMPLEMENTED: valid request, feature not built yet ----
     ("ec:501 swaption curve uses unimplemented helper", "swaption",
      "swaption_request.json", 501, _ec_unimplemented_curve_point()),


### PR DESCRIPTION
**Silent-zero request scalars eliminated** (0.5.0 batch). Bare `double`/enum request fields defaulted to zero/first-enum when omitted, so a forgotten notional, strike, quote value, redemption, coupon rate, optionlet vol or CDS quote type silently priced as zero. All now optional-with-presence, validated on read:

- **amounts** (notional, base_nominal, face_amount, redemption, equity strike price, digital cash) → present, finite, **> 0**;
- **rates that can be negative** (quote values, coupon rate, FRA & cap/floor strikes, inflation helper quotes) → present + finite;
- **optionlet volatility** → present + non-negative (a genuine 0 still prices a cap-free coupon leg — seven FRN examples rely on it); **CdsQuote.quote_type** → presence-required.

Validation centralized in a small `require_scalar.h` helper. **No example needed a value added and no priced result moved** — implicit zeros weren't being relied on except the explicit zero-vol coupon case, which is preserved. Cache keys read the present value unchanged (no under-keying).

Seven error-contract scenarios. Full suite green (668 cases). Wire-breaking; part of 0.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
