### PR TITLE
Require explicit market conventions on every request

### DIFF
--- a/examples/data/basis_swap_request.json
+++ b/examples/data/basis_swap_request.json
@@ -108,7 +108,8 @@
             "frequency": "Quarterly",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "index": {
             "id": "EUR_3M"
@@ -126,7 +127,8 @@
             "frequency": "Semiannual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "index": {
             "id": "EUR_6M"

--- a/examples/data/bonds/frb_eur_10y_zero_coupon.json
+++ b/examples/data/bonds/frb_eur_10y_zero_coupon.json
@@ -135,7 +135,8 @@
           "frequency": "Annual",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         }
       },
       "discounting_curve": "discount",

--- a/examples/data/bonds/frb_eur_2y_settlement_t3_annual_30360.json
+++ b/examples/data/bonds/frb_eur_2y_settlement_t3_annual_30360.json
@@ -135,7 +135,8 @@
           "frequency": "Annual",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         }
       },
       "discounting_curve": "discount",

--- a/examples/data/bonds/frb_eur_30y_long_dated_annual_30360.json
+++ b/examples/data/bonds/frb_eur_30y_long_dated_annual_30360.json
@@ -192,7 +192,8 @@
           "frequency": "Annual",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         }
       },
       "discounting_curve": "discount",

--- a/examples/data/bonds/frb_eur_5y_amortizing_linear.json
+++ b/examples/data/bonds/frb_eur_5y_amortizing_linear.json
@@ -135,7 +135,8 @@
           "frequency": "Annual",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         },
         "notionals": [
           1000000.0,

--- a/examples/data/bonds/frb_eur_5y_at_par_annual_30360.json
+++ b/examples/data/bonds/frb_eur_5y_at_par_annual_30360.json
@@ -135,7 +135,8 @@
           "frequency": "Annual",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         }
       },
       "discounting_curve": "discount",

--- a/examples/data/bonds/frb_eur_5y_constant_via_notionals.json
+++ b/examples/data/bonds/frb_eur_5y_constant_via_notionals.json
@@ -135,7 +135,8 @@
           "frequency": "Annual",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         },
         "notionals": [
           1000000.0,

--- a/examples/data/bonds/frb_eur_5y_discount_quarterly_act365f.json
+++ b/examples/data/bonds/frb_eur_5y_discount_quarterly_act365f.json
@@ -135,7 +135,8 @@
           "frequency": "Quarterly",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         }
       },
       "discounting_curve": "discount",

--- a/examples/data/bonds/frb_eur_5y_long_first_coupon.json
+++ b/examples/data/bonds/frb_eur_5y_long_first_coupon.json
@@ -136,7 +136,8 @@
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
           "date_generation_rule": "Backward",
-          "first_date": "2026-07-17"
+          "first_date": "2026-07-17",
+          "end_of_month": false
         }
       },
       "discounting_curve": "discount",

--- a/examples/data/bonds/frb_eur_5y_short_first_coupon.json
+++ b/examples/data/bonds/frb_eur_5y_short_first_coupon.json
@@ -136,7 +136,8 @@
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
           "date_generation_rule": "Backward",
-          "first_date": "2025-03-17"
+          "first_date": "2025-03-17",
+          "end_of_month": false
         }
       },
       "discounting_curve": "discount",

--- a/examples/data/bonds/frb_eur_5y_short_last_coupon.json
+++ b/examples/data/bonds/frb_eur_5y_short_last_coupon.json
@@ -136,7 +136,8 @@
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
           "date_generation_rule": "Forward",
-          "next_to_last_date": "2029-10-17"
+          "next_to_last_date": "2029-10-17",
+          "end_of_month": false
         }
       },
       "discounting_curve": "discount",

--- a/examples/data/bonds/frb_eur_5y_stub_on_grid_control.json
+++ b/examples/data/bonds/frb_eur_5y_stub_on_grid_control.json
@@ -137,7 +137,8 @@
           "termination_date_convention": "ModifiedFollowing",
           "date_generation_rule": "Forward",
           "first_date": "2026-01-17",
-          "next_to_last_date": "2029-01-17"
+          "next_to_last_date": "2029-01-17",
+          "end_of_month": false
         }
       },
       "discounting_curve": "discount",

--- a/examples/data/bonds/frb_eur_6y_redemption_101_5_preceding_payments.json
+++ b/examples/data/bonds/frb_eur_6y_redemption_101_5_preceding_payments.json
@@ -135,7 +135,8 @@
           "frequency": "Annual",
           "convention": "Unadjusted",
           "termination_date_convention": "Unadjusted",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         }
       },
       "discounting_curve": "discount",

--- a/examples/data/bonds/frb_eur_7y_premium_semiannual_actactbond.json
+++ b/examples/data/bonds/frb_eur_7y_premium_semiannual_actactbond.json
@@ -135,7 +135,8 @@
           "frequency": "Semiannual",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         }
       },
       "discounting_curve": "discount",

--- a/examples/data/bonds/frb_usd_10y_treasury_semiannual_zero_curve.json
+++ b/examples/data/bonds/frb_usd_10y_treasury_semiannual_zero_curve.json
@@ -156,7 +156,8 @@
           "frequency": "Semiannual",
           "convention": "Unadjusted",
           "termination_date_convention": "Unadjusted",
-          "date_generation_rule": "Backward"
+          "date_generation_rule": "Backward",
+          "end_of_month": false
         }
       },
       "discounting_curve": "usd_zero_curve",

--- a/examples/data/bonds/frb_usd_5y_on_discount_factor_curve.json
+++ b/examples/data/bonds/frb_usd_5y_on_discount_factor_curve.json
@@ -25,7 +25,7 @@
               "point_type": "DiscountFactorPoint",
               "point": {
                 "date": "2026-01-15",
-                "discount_factor": 0.9700,
+                "discount_factor": 0.97,
                 "calendar": "TARGET",
                 "business_day_convention": "ModifiedFollowing"
               }
@@ -34,7 +34,7 @@
               "point_type": "DiscountFactorPoint",
               "point": {
                 "date": "2027-01-15",
-                "discount_factor": 0.9400,
+                "discount_factor": 0.94,
                 "calendar": "TARGET",
                 "business_day_convention": "ModifiedFollowing"
               }
@@ -43,7 +43,7 @@
               "point_type": "DiscountFactorPoint",
               "point": {
                 "date": "2028-01-15",
-                "discount_factor": 0.9100,
+                "discount_factor": 0.91,
                 "calendar": "TARGET",
                 "business_day_convention": "ModifiedFollowing"
               }
@@ -52,7 +52,7 @@
               "point_type": "DiscountFactorPoint",
               "point": {
                 "date": "2029-01-15",
-                "discount_factor": 0.8800,
+                "discount_factor": 0.88,
                 "calendar": "TARGET",
                 "business_day_convention": "ModifiedFollowing"
               }
@@ -61,7 +61,7 @@
               "point_type": "DiscountFactorPoint",
               "point": {
                 "date": "2030-01-15",
-                "discount_factor": 0.8500,
+                "discount_factor": 0.85,
                 "calendar": "TARGET",
                 "business_day_convention": "ModifiedFollowing"
               }
@@ -70,7 +70,7 @@
               "point_type": "DiscountFactorPoint",
               "point": {
                 "date": "2031-01-15",
-                "discount_factor": 0.8200,
+                "discount_factor": 0.82,
                 "calendar": "TARGET",
                 "business_day_convention": "ModifiedFollowing"
               }
@@ -97,7 +97,8 @@
           "frequency": "Annual",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         }
       },
       "discounting_curve": "discount",

--- a/examples/data/bonds/frb_usd_5y_on_forward_rate_curve.json
+++ b/examples/data/bonds/frb_usd_5y_on_forward_rate_curve.json
@@ -16,7 +16,7 @@
               "point_type": "ForwardRatePoint",
               "point": {
                 "date": "2025-01-15",
-                "forward_rate": 0.0300,
+                "forward_rate": 0.03,
                 "calendar": "TARGET",
                 "business_day_convention": "ModifiedFollowing"
               }
@@ -25,7 +25,7 @@
               "point_type": "ForwardRatePoint",
               "point": {
                 "date": "2026-01-15",
-                "forward_rate": 0.0320,
+                "forward_rate": 0.032,
                 "calendar": "TARGET",
                 "business_day_convention": "ModifiedFollowing"
               }
@@ -43,7 +43,7 @@
               "point_type": "ForwardRatePoint",
               "point": {
                 "date": "2029-01-15",
-                "forward_rate": 0.0350,
+                "forward_rate": 0.035,
                 "calendar": "TARGET",
                 "business_day_convention": "ModifiedFollowing"
               }
@@ -52,7 +52,7 @@
               "point_type": "ForwardRatePoint",
               "point": {
                 "date": "2032-01-15",
-                "forward_rate": 0.0360,
+                "forward_rate": 0.036,
                 "calendar": "TARGET",
                 "business_day_convention": "ModifiedFollowing"
               }
@@ -88,7 +88,8 @@
           "frequency": "Annual",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         }
       },
       "discounting_curve": "discount",

--- a/examples/data/bonds/frn_eur_2y_euribor6m_same_day_fixing.json
+++ b/examples/data/bonds/frn_eur_2y_euribor6m_same_day_fixing.json
@@ -144,7 +144,8 @@
           "frequency": "Semiannual",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         },
         "index": {
           "id": "EUR_6M"

--- a/examples/data/bonds/frn_eur_3y_euribor6m_act365f_accrual.json
+++ b/examples/data/bonds/frn_eur_3y_euribor6m_act365f_accrual.json
@@ -144,7 +144,8 @@
           "frequency": "Semiannual",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         },
         "index": {
           "id": "EUR_6M"

--- a/examples/data/bonds/frn_eur_4y_euribor3m_quarterly_spread40bp.json
+++ b/examples/data/bonds/frn_eur_4y_euribor3m_quarterly_spread40bp.json
@@ -144,7 +144,8 @@
           "frequency": "Quarterly",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         },
         "index": {
           "id": "EUR_3M"

--- a/examples/data/bonds/frn_eur_5y_amortizing_linear.json
+++ b/examples/data/bonds/frn_eur_5y_amortizing_linear.json
@@ -144,7 +144,8 @@
           "frequency": "Semiannual",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         },
         "index": {
           "id": "EUR_6M"

--- a/examples/data/bonds/frn_eur_5y_euribor6m_flat_semiannual.json
+++ b/examples/data/bonds/frn_eur_5y_euribor6m_flat_semiannual.json
@@ -144,7 +144,8 @@
           "frequency": "Semiannual",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         },
         "index": {
           "id": "EUR_6M"

--- a/examples/data/bonds/frn_eur_5y_euribor6m_ois_discounted_multicurve.json
+++ b/examples/data/bonds/frn_eur_5y_euribor6m_ois_discounted_multicurve.json
@@ -30,7 +30,9 @@
           },
           "fixing_days": 0,
           "calendar": "TARGET",
-          "day_counter": "Actual360"
+          "day_counter": "Actual360",
+          "business_day_convention": "ModifiedFollowing",
+          "end_of_month": true
         }
       ],
       "curves": [
@@ -52,7 +54,11 @@
                 "tenor": {
                   "n": 1,
                   "unit": "Years"
-                }
+                },
+                "calendar": "TARGET",
+                "fixed_leg_convention": "ModifiedFollowing",
+                "fixed_leg_day_counter": "Actual360",
+                "fixed_leg_frequency": "Annual"
               }
             },
             {
@@ -66,7 +72,11 @@
                 "tenor": {
                   "n": 2,
                   "unit": "Years"
-                }
+                },
+                "calendar": "TARGET",
+                "fixed_leg_convention": "ModifiedFollowing",
+                "fixed_leg_day_counter": "Actual360",
+                "fixed_leg_frequency": "Annual"
               }
             },
             {
@@ -80,7 +90,11 @@
                 "tenor": {
                   "n": 5,
                   "unit": "Years"
-                }
+                },
+                "calendar": "TARGET",
+                "fixed_leg_convention": "ModifiedFollowing",
+                "fixed_leg_day_counter": "Actual360",
+                "fixed_leg_frequency": "Annual"
               }
             },
             {
@@ -94,7 +108,11 @@
                 "tenor": {
                   "n": 10,
                   "unit": "Years"
-                }
+                },
+                "calendar": "TARGET",
+                "fixed_leg_convention": "ModifiedFollowing",
+                "fixed_leg_day_counter": "Actual360",
+                "fixed_leg_frequency": "Annual"
               }
             }
           ]
@@ -222,7 +240,8 @@
           "frequency": "Semiannual",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         },
         "index": {
           "id": "EUR_6M"

--- a/examples/data/callable_bonds/cfrb_eur_8y_2pct_put_98.json
+++ b/examples/data/callable_bonds/cfrb_eur_8y_2pct_put_98.json
@@ -169,7 +169,8 @@
           "frequency": "Annual",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         },
         "call_schedule": [
           {

--- a/examples/data/callable_bonds/cfrb_eur_8y_5pct_call_100_itm.json
+++ b/examples/data/callable_bonds/cfrb_eur_8y_5pct_call_100_itm.json
@@ -169,7 +169,8 @@
           "frequency": "Annual",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         },
         "call_schedule": [
           {

--- a/examples/data/callable_bonds/cfrb_eur_8y_5pct_call_115_otm.json
+++ b/examples/data/callable_bonds/cfrb_eur_8y_5pct_call_115_otm.json
@@ -169,7 +169,8 @@
           "frequency": "Annual",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         },
         "call_schedule": [
           {

--- a/examples/data/callable_bonds/cfrb_eur_8y_5pct_multi_call_step.json
+++ b/examples/data/callable_bonds/cfrb_eur_8y_5pct_multi_call_step.json
@@ -169,7 +169,8 @@
           "frequency": "Annual",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         },
         "call_schedule": [
           {

--- a/examples/data/callable_fixed_rate_bond_request.json
+++ b/examples/data/callable_fixed_rate_bond_request.json
@@ -169,7 +169,8 @@
           "frequency": "Annual",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         },
         "call_schedule": [
           {

--- a/examples/data/cap_floor/cap_eur_10y_euribor6m_semiannual.json
+++ b/examples/data/cap_floor/cap_eur_10y_euribor6m_semiannual.json
@@ -159,7 +159,8 @@
           "frequency": "Semiannual",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         },
         "index": {
           "id": "EUR_6M"

--- a/examples/data/cap_floor/cap_eur_5y_atm_quarterly_euribor3m.json
+++ b/examples/data/cap_floor/cap_eur_5y_atm_quarterly_euribor3m.json
@@ -174,7 +174,8 @@
           "frequency": "Quarterly",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         },
         "index": {
           "id": "EUR_3M"

--- a/examples/data/cap_floor/cap_eur_5y_bachelier_normal_vol_80bp.json
+++ b/examples/data/cap_floor/cap_eur_5y_bachelier_normal_vol_80bp.json
@@ -174,7 +174,8 @@
           "frequency": "Quarterly",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         },
         "index": {
           "id": "EUR_3M"

--- a/examples/data/cap_floor/cap_eur_5y_euribor6m_ois_discounted_multicurve.json
+++ b/examples/data/cap_floor/cap_eur_5y_euribor6m_ois_discounted_multicurve.json
@@ -30,7 +30,9 @@
           },
           "fixing_days": 0,
           "calendar": "TARGET",
-          "day_counter": "Actual360"
+          "day_counter": "Actual360",
+          "business_day_convention": "ModifiedFollowing",
+          "end_of_month": true
         }
       ],
       "curves": [
@@ -52,7 +54,11 @@
                 "tenor": {
                   "n": 1,
                   "unit": "Years"
-                }
+                },
+                "calendar": "TARGET",
+                "fixed_leg_convention": "ModifiedFollowing",
+                "fixed_leg_day_counter": "Actual360",
+                "fixed_leg_frequency": "Annual"
               }
             },
             {
@@ -66,7 +72,11 @@
                 "tenor": {
                   "n": 2,
                   "unit": "Years"
-                }
+                },
+                "calendar": "TARGET",
+                "fixed_leg_convention": "ModifiedFollowing",
+                "fixed_leg_day_counter": "Actual360",
+                "fixed_leg_frequency": "Annual"
               }
             },
             {
@@ -80,7 +90,11 @@
                 "tenor": {
                   "n": 5,
                   "unit": "Years"
-                }
+                },
+                "calendar": "TARGET",
+                "fixed_leg_convention": "ModifiedFollowing",
+                "fixed_leg_day_counter": "Actual360",
+                "fixed_leg_frequency": "Annual"
               }
             },
             {
@@ -94,7 +108,11 @@
                 "tenor": {
                   "n": 10,
                   "unit": "Years"
-                }
+                },
+                "calendar": "TARGET",
+                "fixed_leg_convention": "ModifiedFollowing",
+                "fixed_leg_day_counter": "Actual360",
+                "fixed_leg_frequency": "Annual"
               }
             }
           ]
@@ -237,7 +255,8 @@
           "frequency": "Semiannual",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         },
         "index": {
           "id": "EUR_6M"

--- a/examples/data/cap_floor/cap_eur_5y_itm_strike_2pct.json
+++ b/examples/data/cap_floor/cap_eur_5y_itm_strike_2pct.json
@@ -174,7 +174,8 @@
           "frequency": "Quarterly",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         },
         "index": {
           "id": "EUR_3M"

--- a/examples/data/cap_floor/cap_eur_5y_otm_strike_5pct.json
+++ b/examples/data/cap_floor/cap_eur_5y_otm_strike_5pct.json
@@ -174,7 +174,8 @@
           "frequency": "Quarterly",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         },
         "index": {
           "id": "EUR_3M"

--- a/examples/data/cap_floor/cap_eur_5y_shifted_black_displacement_2pct.json
+++ b/examples/data/cap_floor/cap_eur_5y_shifted_black_displacement_2pct.json
@@ -174,7 +174,8 @@
           "frequency": "Quarterly",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         },
         "index": {
           "id": "EUR_3M"

--- a/examples/data/cap_floor/floor_eur_2y_act365f_vol_30pct.json
+++ b/examples/data/cap_floor/floor_eur_2y_act365f_vol_30pct.json
@@ -174,7 +174,8 @@
           "frequency": "Quarterly",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         },
         "index": {
           "id": "EUR_3M"

--- a/examples/data/cap_floor/floor_eur_5y_itm_strike_4pct.json
+++ b/examples/data/cap_floor/floor_eur_5y_itm_strike_4pct.json
@@ -174,7 +174,8 @@
           "frequency": "Quarterly",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         },
         "index": {
           "id": "EUR_3M"

--- a/examples/data/cap_floor/floor_eur_5y_otm_strike_2pct.json
+++ b/examples/data/cap_floor/floor_eur_5y_otm_strike_2pct.json
@@ -174,7 +174,8 @@
           "frequency": "Quarterly",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         },
         "index": {
           "id": "EUR_3M"

--- a/examples/data/cap_floor_request.json
+++ b/examples/data/cap_floor_request.json
@@ -155,7 +155,8 @@
           "frequency": "Quarterly",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         },
         "index": {
           "id": "EUR_3M"

--- a/examples/data/cds/cds_eur_10y_buyer_100bp_spread_curve.json
+++ b/examples/data/cds/cds_eur_10y_buyer_100bp_spread_curve.json
@@ -239,7 +239,8 @@
           "frequency": "Quarterly",
           "convention": "Following",
           "termination_date_convention": "Unadjusted",
-          "date_generation_rule": "TwentiethIMM"
+          "date_generation_rule": "TwentiethIMM",
+          "end_of_month": false
         },
         "day_counter": "Actual360",
         "business_day_convention": "Following",

--- a/examples/data/cds/cds_eur_3y_buyer_100bp_spread_curve.json
+++ b/examples/data/cds/cds_eur_3y_buyer_100bp_spread_curve.json
@@ -239,7 +239,8 @@
           "frequency": "Quarterly",
           "convention": "Following",
           "termination_date_convention": "Unadjusted",
-          "date_generation_rule": "TwentiethIMM"
+          "date_generation_rule": "TwentiethIMM",
+          "end_of_month": false
         },
         "day_counter": "Actual360",
         "business_day_convention": "Following",

--- a/examples/data/cds/cds_eur_5y_buyer_100bp_spread_curve.json
+++ b/examples/data/cds/cds_eur_5y_buyer_100bp_spread_curve.json
@@ -239,7 +239,8 @@
           "frequency": "Quarterly",
           "convention": "Following",
           "termination_date_convention": "Unadjusted",
-          "date_generation_rule": "TwentiethIMM"
+          "date_generation_rule": "TwentiethIMM",
+          "end_of_month": false
         },
         "day_counter": "Actual360",
         "business_day_convention": "Following",

--- a/examples/data/cds/cds_eur_5y_buyer_100bp_upfront_2pct.json
+++ b/examples/data/cds/cds_eur_5y_buyer_100bp_upfront_2pct.json
@@ -239,7 +239,8 @@
           "frequency": "Quarterly",
           "convention": "Following",
           "termination_date_convention": "Unadjusted",
-          "date_generation_rule": "TwentiethIMM"
+          "date_generation_rule": "TwentiethIMM",
+          "end_of_month": false
         },
         "day_counter": "Actual360",
         "business_day_convention": "Following",

--- a/examples/data/cds/cds_eur_5y_buyer_500bp_running_coupon.json
+++ b/examples/data/cds/cds_eur_5y_buyer_500bp_running_coupon.json
@@ -239,7 +239,8 @@
           "frequency": "Quarterly",
           "convention": "Following",
           "termination_date_convention": "Unadjusted",
-          "date_generation_rule": "TwentiethIMM"
+          "date_generation_rule": "TwentiethIMM",
+          "end_of_month": false
         },
         "day_counter": "Actual360",
         "business_day_convention": "Following",

--- a/examples/data/cds/cds_eur_5y_buyer_flat_hazard_2pct.json
+++ b/examples/data/cds/cds_eur_5y_buyer_flat_hazard_2pct.json
@@ -187,7 +187,8 @@
           "frequency": "Quarterly",
           "convention": "Following",
           "termination_date_convention": "Unadjusted",
-          "date_generation_rule": "TwentiethIMM"
+          "date_generation_rule": "TwentiethIMM",
+          "end_of_month": false
         },
         "day_counter": "Actual360",
         "business_day_convention": "Following",

--- a/examples/data/cds/cds_eur_5y_buyer_isda_engine.json
+++ b/examples/data/cds/cds_eur_5y_buyer_isda_engine.json
@@ -243,7 +243,8 @@
           "frequency": "Quarterly",
           "convention": "Following",
           "termination_date_convention": "Unadjusted",
-          "date_generation_rule": "TwentiethIMM"
+          "date_generation_rule": "TwentiethIMM",
+          "end_of_month": false
         },
         "day_counter": "Actual360",
         "business_day_convention": "Following",

--- a/examples/data/cds/cds_eur_5y_buyer_recovery_20pct.json
+++ b/examples/data/cds/cds_eur_5y_buyer_recovery_20pct.json
@@ -239,7 +239,8 @@
           "frequency": "Quarterly",
           "convention": "Following",
           "termination_date_convention": "Unadjusted",
-          "date_generation_rule": "TwentiethIMM"
+          "date_generation_rule": "TwentiethIMM",
+          "end_of_month": false
         },
         "day_counter": "Actual360",
         "business_day_convention": "Following",

--- a/examples/data/cds/cds_eur_5y_buyer_semiannual_act365f.json
+++ b/examples/data/cds/cds_eur_5y_buyer_semiannual_act365f.json
@@ -239,7 +239,8 @@
           "frequency": "Semiannual",
           "convention": "Following",
           "termination_date_convention": "Unadjusted",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         },
         "day_counter": "Actual365Fixed",
         "business_day_convention": "Following",

--- a/examples/data/cds/cds_eur_5y_seller_100bp_spread_curve.json
+++ b/examples/data/cds/cds_eur_5y_seller_100bp_spread_curve.json
@@ -239,7 +239,8 @@
           "frequency": "Quarterly",
           "convention": "Following",
           "termination_date_convention": "Unadjusted",
-          "date_generation_rule": "TwentiethIMM"
+          "date_generation_rule": "TwentiethIMM",
+          "end_of_month": false
         },
         "day_counter": "Actual360",
         "business_day_convention": "Following",

--- a/examples/data/cds/cds_upfront_zero_running_coupon.json
+++ b/examples/data/cds/cds_upfront_zero_running_coupon.json
@@ -204,12 +204,18 @@
           "frequency": "Quarterly",
           "convention": "Following",
           "termination_date_convention": "Unadjusted",
-          "date_generation_rule": "TwentiethIMM"
+          "date_generation_rule": "TwentiethIMM",
+          "end_of_month": false
         },
         "day_counter": "Actual360",
         "business_day_convention": "Following",
         "protection_start": "2025-01-15",
-        "upfront_date": "2025-01-20"
+        "upfront_date": "2025-01-20",
+        "settles_accrual": true,
+        "pays_at_default_time": true,
+        "rebates_accrual": true,
+        "last_period_day_counter": "Actual360",
+        "cash_settlement_days": 3
       },
       "discounting_curve": "discount",
       "credit_curve_id": "eur_upfront",

--- a/examples/data/cds_complex_request.json
+++ b/examples/data/cds_complex_request.json
@@ -307,7 +307,8 @@
           "frequency": "Quarterly",
           "convention": "Following",
           "termination_date_convention": "Unadjusted",
-          "date_generation_rule": "TwentiethIMM"
+          "date_generation_rule": "TwentiethIMM",
+          "end_of_month": false
         },
         "day_counter": "Actual360",
         "business_day_convention": "Following",

--- a/examples/data/cds_request.json
+++ b/examples/data/cds_request.json
@@ -194,10 +194,16 @@
           "frequency": "Quarterly",
           "convention": "Following",
           "termination_date_convention": "Unadjusted",
-          "date_generation_rule": "TwentiethIMM"
+          "date_generation_rule": "TwentiethIMM",
+          "end_of_month": false
         },
         "day_counter": "Actual360",
-        "business_day_convention": "Following"
+        "business_day_convention": "Following",
+        "settles_accrual": true,
+        "pays_at_default_time": true,
+        "rebates_accrual": true,
+        "last_period_day_counter": "Actual360",
+        "cash_settlement_days": 3
       },
       "discounting_curve": "discount",
       "credit_curve_id": "eur_igs",

--- a/examples/data/curves/curves_eur_ois_estr_df_zero_tenor_grid.json
+++ b/examples/data/curves/curves_eur_ois_estr_df_zero_tenor_grid.json
@@ -14,7 +14,9 @@
           },
           "fixing_days": 0,
           "calendar": "TARGET",
-          "day_counter": "Actual360"
+          "day_counter": "Actual360",
+          "business_day_convention": "ModifiedFollowing",
+          "end_of_month": true
         }
       ],
       "curves": [
@@ -36,7 +38,11 @@
                 "tenor": {
                   "n": 1,
                   "unit": "Years"
-                }
+                },
+                "calendar": "TARGET",
+                "fixed_leg_convention": "ModifiedFollowing",
+                "fixed_leg_day_counter": "Actual360",
+                "fixed_leg_frequency": "Annual"
               }
             },
             {
@@ -50,7 +56,11 @@
                 "tenor": {
                   "n": 2,
                   "unit": "Years"
-                }
+                },
+                "calendar": "TARGET",
+                "fixed_leg_convention": "ModifiedFollowing",
+                "fixed_leg_day_counter": "Actual360",
+                "fixed_leg_frequency": "Annual"
               }
             },
             {
@@ -64,7 +74,11 @@
                 "tenor": {
                   "n": 5,
                   "unit": "Years"
-                }
+                },
+                "calendar": "TARGET",
+                "fixed_leg_convention": "ModifiedFollowing",
+                "fixed_leg_day_counter": "Actual360",
+                "fixed_leg_frequency": "Annual"
               }
             },
             {
@@ -78,7 +92,11 @@
                 "tenor": {
                   "n": 10,
                   "unit": "Years"
-                }
+                },
+                "calendar": "TARGET",
+                "fixed_leg_convention": "ModifiedFollowing",
+                "fixed_leg_day_counter": "Actual360",
+                "fixed_leg_frequency": "Annual"
               }
             }
           ]

--- a/examples/data/fixed_rate_bond_beyond_pillar_request.json
+++ b/examples/data/fixed_rate_bond_beyond_pillar_request.json
@@ -79,7 +79,8 @@
           "frequency": "Semiannual",
           "convention": "Unadjusted",
           "termination_date_convention": "Unadjusted",
-          "date_generation_rule": "Backward"
+          "date_generation_rule": "Backward",
+          "end_of_month": false
         }
       },
       "discounting_curve": "depos_curve",

--- a/examples/data/fixed_rate_bond_forwardflat_request.json
+++ b/examples/data/fixed_rate_bond_forwardflat_request.json
@@ -66,7 +66,8 @@
                   "frequency": "Semiannual",
                   "convention": "Unadjusted",
                   "termination_date_convention": "Unadjusted",
-                  "date_generation_rule": "Backward"
+                  "date_generation_rule": "Backward",
+                  "end_of_month": false
                 },
                 "coupon_rate": 0.02375,
                 "day_counter": "ActualActualBond",
@@ -88,7 +89,8 @@
                   "frequency": "Semiannual",
                   "convention": "Unadjusted",
                   "termination_date_convention": "Unadjusted",
-                  "date_generation_rule": "Backward"
+                  "date_generation_rule": "Backward",
+                  "end_of_month": false
                 },
                 "coupon_rate": 0.04625,
                 "day_counter": "ActualActualBond",
@@ -110,7 +112,8 @@
                   "frequency": "Semiannual",
                   "convention": "Unadjusted",
                   "termination_date_convention": "Unadjusted",
-                  "date_generation_rule": "Backward"
+                  "date_generation_rule": "Backward",
+                  "end_of_month": false
                 },
                 "coupon_rate": 0.03125,
                 "day_counter": "ActualActualBond",
@@ -132,7 +135,8 @@
                   "frequency": "Semiannual",
                   "convention": "Unadjusted",
                   "termination_date_convention": "Unadjusted",
-                  "date_generation_rule": "Backward"
+                  "date_generation_rule": "Backward",
+                  "end_of_month": false
                 },
                 "coupon_rate": 0.04,
                 "day_counter": "ActualActualBond",
@@ -154,7 +158,8 @@
                   "frequency": "Semiannual",
                   "convention": "Unadjusted",
                   "termination_date_convention": "Unadjusted",
-                  "date_generation_rule": "Backward"
+                  "date_generation_rule": "Backward",
+                  "end_of_month": false
                 },
                 "coupon_rate": 0.045,
                 "day_counter": "ActualActualBond",
@@ -189,7 +194,8 @@
           "frequency": "Semiannual",
           "convention": "Unadjusted",
           "termination_date_convention": "Unadjusted",
-          "date_generation_rule": "Backward"
+          "date_generation_rule": "Backward",
+          "end_of_month": false
         }
       },
       "discounting_curve": "depos_curve",

--- a/examples/data/fixed_rate_bond_request.json
+++ b/examples/data/fixed_rate_bond_request.json
@@ -66,7 +66,8 @@
                   "frequency": "Semiannual",
                   "convention": "Unadjusted",
                   "termination_date_convention": "Unadjusted",
-                  "date_generation_rule": "Backward"
+                  "date_generation_rule": "Backward",
+                  "end_of_month": false
                 },
                 "coupon_rate": 0.02375,
                 "day_counter": "ActualActualBond",
@@ -88,7 +89,8 @@
                   "frequency": "Semiannual",
                   "convention": "Unadjusted",
                   "termination_date_convention": "Unadjusted",
-                  "date_generation_rule": "Backward"
+                  "date_generation_rule": "Backward",
+                  "end_of_month": false
                 },
                 "coupon_rate": 0.04625,
                 "day_counter": "ActualActualBond",
@@ -110,7 +112,8 @@
                   "frequency": "Semiannual",
                   "convention": "Unadjusted",
                   "termination_date_convention": "Unadjusted",
-                  "date_generation_rule": "Backward"
+                  "date_generation_rule": "Backward",
+                  "end_of_month": false
                 },
                 "coupon_rate": 0.03125,
                 "day_counter": "ActualActualBond",
@@ -132,7 +135,8 @@
                   "frequency": "Semiannual",
                   "convention": "Unadjusted",
                   "termination_date_convention": "Unadjusted",
-                  "date_generation_rule": "Backward"
+                  "date_generation_rule": "Backward",
+                  "end_of_month": false
                 },
                 "coupon_rate": 0.04,
                 "day_counter": "ActualActualBond",
@@ -154,7 +158,8 @@
                   "frequency": "Semiannual",
                   "convention": "Unadjusted",
                   "termination_date_convention": "Unadjusted",
-                  "date_generation_rule": "Backward"
+                  "date_generation_rule": "Backward",
+                  "end_of_month": false
                 },
                 "coupon_rate": 0.045,
                 "day_counter": "ActualActualBond",
@@ -189,7 +194,8 @@
           "frequency": "Semiannual",
           "convention": "Unadjusted",
           "termination_date_convention": "Unadjusted",
-          "date_generation_rule": "Backward"
+          "date_generation_rule": "Backward",
+          "end_of_month": false
         }
       },
       "discounting_curve": "depos_curve",

--- a/examples/data/fixed_rate_bond_zerorate_request.json
+++ b/examples/data/fixed_rate_bond_zerorate_request.json
@@ -25,7 +25,7 @@
             {
               "point_type": "ZeroRatePoint",
               "point": {
-                "zero_rate": 0.0450,
+                "zero_rate": 0.045,
                 "calendar": "UnitedStatesGovernmentBond",
                 "business_day_convention": "Following",
                 "compounding": "Continuous",
@@ -174,7 +174,8 @@
           "frequency": "Semiannual",
           "convention": "Unadjusted",
           "termination_date_convention": "Unadjusted",
-          "date_generation_rule": "Backward"
+          "date_generation_rule": "Backward",
+          "end_of_month": false
         }
       },
       "discounting_curve": "usd_zero_curve",

--- a/examples/data/floating_rate_bond_request.json
+++ b/examples/data/floating_rate_bond_request.json
@@ -125,7 +125,8 @@
           "frequency": "Semiannual",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         },
         "index": {
           "id": "EUR_6M"

--- a/examples/data/inflation/yyiis_eur_3y_receiver_semiannual_30360.json
+++ b/examples/data/inflation/yyiis_eur_3y_receiver_semiannual_30360.json
@@ -15,7 +15,8 @@
           "calendar": "TARGET",
           "business_day_convention": "ModifiedFollowing",
           "day_counter": "Actual360",
-          "currency": "EUR"
+          "currency": "EUR",
+          "end_of_month": true
         }
       ],
       "curves": [
@@ -345,7 +346,8 @@
           "frequency": "Semiannual",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         },
         "fixed_rate": 0.021,
         "fixed_day_counter": "Thirty360",
@@ -356,7 +358,8 @@
           "frequency": "Semiannual",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         },
         "inflation_index_id": "EUHICP_YY",
         "observation_lag": {

--- a/examples/data/inflation/yyiis_eur_5y_payer_annual.json
+++ b/examples/data/inflation/yyiis_eur_5y_payer_annual.json
@@ -15,7 +15,8 @@
           "calendar": "TARGET",
           "business_day_convention": "ModifiedFollowing",
           "day_counter": "Actual360",
-          "currency": "EUR"
+          "currency": "EUR",
+          "end_of_month": true
         }
       ],
       "curves": [
@@ -345,7 +346,8 @@
           "frequency": "Annual",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         },
         "fixed_rate": 0.0215,
         "fixed_day_counter": "Actual365Fixed",
@@ -356,7 +358,8 @@
           "frequency": "Annual",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         },
         "inflation_index_id": "EUHICP_YY",
         "observation_lag": {

--- a/examples/data/inflation/yyiis_eur_5y_payer_spread25bp.json
+++ b/examples/data/inflation/yyiis_eur_5y_payer_spread25bp.json
@@ -15,7 +15,8 @@
           "calendar": "TARGET",
           "business_day_convention": "ModifiedFollowing",
           "day_counter": "Actual360",
-          "currency": "EUR"
+          "currency": "EUR",
+          "end_of_month": true
         }
       ],
       "curves": [
@@ -345,7 +346,8 @@
           "frequency": "Annual",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         },
         "fixed_rate": 0.022,
         "fixed_day_counter": "Actual365Fixed",
@@ -356,7 +358,8 @@
           "frequency": "Annual",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         },
         "inflation_index_id": "EUHICP_YY",
         "observation_lag": {

--- a/examples/data/inflation/yyiis_eur_5y_receiver_annual.json
+++ b/examples/data/inflation/yyiis_eur_5y_receiver_annual.json
@@ -15,7 +15,8 @@
           "calendar": "TARGET",
           "business_day_convention": "ModifiedFollowing",
           "day_counter": "Actual360",
-          "currency": "EUR"
+          "currency": "EUR",
+          "end_of_month": true
         }
       ],
       "curves": [
@@ -345,7 +346,8 @@
           "frequency": "Annual",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         },
         "fixed_rate": 0.0215,
         "fixed_day_counter": "Actual365Fixed",
@@ -356,7 +358,8 @@
           "frequency": "Annual",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         },
         "inflation_index_id": "EUHICP_YY",
         "observation_lag": {

--- a/examples/data/inflation/zciis_eur_10y_payer_linear_obs.json
+++ b/examples/data/inflation/zciis_eur_10y_payer_linear_obs.json
@@ -15,7 +15,8 @@
           "calendar": "TARGET",
           "business_day_convention": "ModifiedFollowing",
           "day_counter": "Actual360",
-          "currency": "EUR"
+          "currency": "EUR",
+          "end_of_month": true
         }
       ],
       "curves": [

--- a/examples/data/inflation/zciis_eur_3y_payer_asindex_obs.json
+++ b/examples/data/inflation/zciis_eur_3y_payer_asindex_obs.json
@@ -15,7 +15,8 @@
           "calendar": "TARGET",
           "business_day_convention": "ModifiedFollowing",
           "day_counter": "Actual360",
-          "currency": "EUR"
+          "currency": "EUR",
+          "end_of_month": true
         }
       ],
       "curves": [

--- a/examples/data/inflation/zciis_eur_5y_payer_6m_observation_lag.json
+++ b/examples/data/inflation/zciis_eur_5y_payer_6m_observation_lag.json
@@ -15,7 +15,8 @@
           "calendar": "TARGET",
           "business_day_convention": "ModifiedFollowing",
           "day_counter": "Actual360",
-          "currency": "EUR"
+          "currency": "EUR",
+          "end_of_month": true
         }
       ],
       "curves": [

--- a/examples/data/inflation/zciis_eur_5y_payer_dated_helpers.json
+++ b/examples/data/inflation/zciis_eur_5y_payer_dated_helpers.json
@@ -15,7 +15,8 @@
           "calendar": "TARGET",
           "business_day_convention": "ModifiedFollowing",
           "day_counter": "Actual360",
-          "currency": "EUR"
+          "currency": "EUR",
+          "end_of_month": true
         }
       ],
       "curves": [

--- a/examples/data/inflation/zciis_eur_5y_payer_linear_obs.json
+++ b/examples/data/inflation/zciis_eur_5y_payer_linear_obs.json
@@ -15,7 +15,8 @@
           "calendar": "TARGET",
           "business_day_convention": "ModifiedFollowing",
           "day_counter": "Actual360",
-          "currency": "EUR"
+          "currency": "EUR",
+          "end_of_month": true
         }
       ],
       "curves": [

--- a/examples/data/inflation/zciis_eur_5y_receiver_linear_obs.json
+++ b/examples/data/inflation/zciis_eur_5y_receiver_linear_obs.json
@@ -15,7 +15,8 @@
           "calendar": "TARGET",
           "business_day_convention": "ModifiedFollowing",
           "day_counter": "Actual360",
-          "currency": "EUR"
+          "currency": "EUR",
+          "end_of_month": true
         }
       ],
       "curves": [

--- a/examples/data/inflation_cap_floor/yoy_cf_eur_3y_cap_175bp_udblack.json
+++ b/examples/data/inflation_cap_floor/yoy_cf_eur_3y_cap_175bp_udblack.json
@@ -15,7 +15,8 @@
           "calendar": "TARGET",
           "business_day_convention": "ModifiedFollowing",
           "day_counter": "Actual360",
-          "currency": "EUR"
+          "currency": "EUR",
+          "end_of_month": true
         }
       ],
       "curves": [
@@ -364,7 +365,8 @@
           "frequency": "Annual",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         },
         "inflation_index_id": "EUHICP_YY",
         "observation_lag": {

--- a/examples/data/inflation_cap_floor/yoy_cf_eur_5y_cap_150bp_bachelier.json
+++ b/examples/data/inflation_cap_floor/yoy_cf_eur_5y_cap_150bp_bachelier.json
@@ -15,7 +15,8 @@
           "calendar": "TARGET",
           "business_day_convention": "ModifiedFollowing",
           "day_counter": "Actual360",
-          "currency": "EUR"
+          "currency": "EUR",
+          "end_of_month": true
         }
       ],
       "curves": [
@@ -364,7 +365,8 @@
           "frequency": "Annual",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         },
         "inflation_index_id": "EUHICP_YY",
         "observation_lag": {

--- a/examples/data/inflation_cap_floor/yoy_cf_eur_5y_cap_150bp_black_bites.json
+++ b/examples/data/inflation_cap_floor/yoy_cf_eur_5y_cap_150bp_black_bites.json
@@ -15,7 +15,8 @@
           "calendar": "TARGET",
           "business_day_convention": "ModifiedFollowing",
           "day_counter": "Actual360",
-          "currency": "EUR"
+          "currency": "EUR",
+          "end_of_month": true
         }
       ],
       "curves": [
@@ -364,7 +365,8 @@
           "frequency": "Annual",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         },
         "inflation_index_id": "EUHICP_YY",
         "observation_lag": {

--- a/examples/data/inflation_cap_floor/yoy_cf_eur_5y_cap_280bp_black_otm.json
+++ b/examples/data/inflation_cap_floor/yoy_cf_eur_5y_cap_280bp_black_otm.json
@@ -15,7 +15,8 @@
           "calendar": "TARGET",
           "business_day_convention": "ModifiedFollowing",
           "day_counter": "Actual360",
-          "currency": "EUR"
+          "currency": "EUR",
+          "end_of_month": true
         }
       ],
       "curves": [
@@ -364,7 +365,8 @@
           "frequency": "Annual",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         },
         "inflation_index_id": "EUHICP_YY",
         "observation_lag": {

--- a/examples/data/inflation_cap_floor/yoy_cf_eur_5y_collar_black.json
+++ b/examples/data/inflation_cap_floor/yoy_cf_eur_5y_collar_black.json
@@ -15,7 +15,8 @@
           "calendar": "TARGET",
           "business_day_convention": "ModifiedFollowing",
           "day_counter": "Actual360",
-          "currency": "EUR"
+          "currency": "EUR",
+          "end_of_month": true
         }
       ],
       "curves": [
@@ -364,7 +365,8 @@
           "frequency": "Annual",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         },
         "inflation_index_id": "EUHICP_YY",
         "observation_lag": {

--- a/examples/data/inflation_cap_floor/yoy_cf_eur_5y_floor_300bp_black_bites.json
+++ b/examples/data/inflation_cap_floor/yoy_cf_eur_5y_floor_300bp_black_bites.json
@@ -15,7 +15,8 @@
           "calendar": "TARGET",
           "business_day_convention": "ModifiedFollowing",
           "day_counter": "Actual360",
-          "currency": "EUR"
+          "currency": "EUR",
+          "end_of_month": true
         }
       ],
       "curves": [
@@ -364,7 +365,8 @@
           "frequency": "Annual",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         },
         "inflation_index_id": "EUHICP_YY",
         "observation_lag": {

--- a/examples/data/ir_swaps/basis_eur_5y_3m_vs_6m_ois_discounted_multicurve.json
+++ b/examples/data/ir_swaps/basis_eur_5y_3m_vs_6m_ois_discounted_multicurve.json
@@ -45,7 +45,9 @@
           },
           "fixing_days": 0,
           "calendar": "TARGET",
-          "day_counter": "Actual360"
+          "day_counter": "Actual360",
+          "business_day_convention": "ModifiedFollowing",
+          "end_of_month": true
         }
       ],
       "curves": [
@@ -67,7 +69,11 @@
                 "tenor": {
                   "n": 1,
                   "unit": "Years"
-                }
+                },
+                "calendar": "TARGET",
+                "fixed_leg_convention": "ModifiedFollowing",
+                "fixed_leg_day_counter": "Actual360",
+                "fixed_leg_frequency": "Annual"
               }
             },
             {
@@ -81,7 +87,11 @@
                 "tenor": {
                   "n": 2,
                   "unit": "Years"
-                }
+                },
+                "calendar": "TARGET",
+                "fixed_leg_convention": "ModifiedFollowing",
+                "fixed_leg_day_counter": "Actual360",
+                "fixed_leg_frequency": "Annual"
               }
             },
             {
@@ -95,7 +105,11 @@
                 "tenor": {
                   "n": 5,
                   "unit": "Years"
-                }
+                },
+                "calendar": "TARGET",
+                "fixed_leg_convention": "ModifiedFollowing",
+                "fixed_leg_day_counter": "Actual360",
+                "fixed_leg_frequency": "Annual"
               }
             },
             {
@@ -109,7 +123,11 @@
                 "tenor": {
                   "n": 10,
                   "unit": "Years"
-                }
+                },
+                "calendar": "TARGET",
+                "fixed_leg_convention": "ModifiedFollowing",
+                "fixed_leg_day_counter": "Actual360",
+                "fixed_leg_frequency": "Annual"
               }
             }
           ]
@@ -290,7 +308,8 @@
             "frequency": "Quarterly",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "index": {
             "id": "EUR_3M"
@@ -308,7 +327,8 @@
             "frequency": "Semiannual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "index": {
             "id": "EUR_6M"

--- a/examples/data/ir_swaps/basis_eur_5y_euribor3m_plus5bp_vs_euribor6m.json
+++ b/examples/data/ir_swaps/basis_eur_5y_euribor3m_plus5bp_vs_euribor6m.json
@@ -146,7 +146,8 @@
             "frequency": "Quarterly",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "index": {
             "id": "EUR_3M"
@@ -164,7 +165,8 @@
             "frequency": "Semiannual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "index": {
             "id": "EUR_6M"

--- a/examples/data/ir_swaps/cms_eur_5y_payer_cms10y_atm_matrix_lineartsr.json
+++ b/examples/data/ir_swaps/cms_eur_5y_payer_cms10y_atm_matrix_lineartsr.json
@@ -335,7 +335,8 @@
             "frequency": "Annual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "rate": 0.03,
           "day_counter": "Thirty360",
@@ -350,7 +351,8 @@
             "frequency": "Quarterly",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "swap_index_id": "EUR_SWAP_6M",
           "swap_tenor": {

--- a/examples/data/ir_swaps/cms_eur_5y_payer_cms10y_capped_hagan_analytic.json
+++ b/examples/data/ir_swaps/cms_eur_5y_payer_cms10y_capped_hagan_analytic.json
@@ -300,7 +300,8 @@
             "frequency": "Annual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "rate": 0.03,
           "day_counter": "Thirty360",
@@ -315,7 +316,8 @@
             "frequency": "Quarterly",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "swap_index_id": "EUR_SWAP_6M",
           "swap_tenor": {

--- a/examples/data/ir_swaps/cms_eur_5y_payer_cms10y_capped_lineartsr.json
+++ b/examples/data/ir_swaps/cms_eur_5y_payer_cms10y_capped_lineartsr.json
@@ -300,7 +300,8 @@
             "frequency": "Annual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "rate": 0.03,
           "day_counter": "Thirty360",
@@ -315,7 +316,8 @@
             "frequency": "Quarterly",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "swap_index_id": "EUR_SWAP_6M",
           "swap_tenor": {

--- a/examples/data/ir_swaps/cms_eur_5y_payer_cms10y_collared_lineartsr.json
+++ b/examples/data/ir_swaps/cms_eur_5y_payer_cms10y_collared_lineartsr.json
@@ -300,7 +300,8 @@
             "frequency": "Annual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "rate": 0.03,
           "day_counter": "Thirty360",
@@ -315,7 +316,8 @@
             "frequency": "Quarterly",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "swap_index_id": "EUR_SWAP_6M",
           "swap_tenor": {

--- a/examples/data/ir_swaps/cms_eur_5y_payer_cms10y_floored_lineartsr.json
+++ b/examples/data/ir_swaps/cms_eur_5y_payer_cms10y_floored_lineartsr.json
@@ -300,7 +300,8 @@
             "frequency": "Annual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "rate": 0.03,
           "day_counter": "Thirty360",
@@ -315,7 +316,8 @@
             "frequency": "Quarterly",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "swap_index_id": "EUR_SWAP_6M",
           "swap_tenor": {

--- a/examples/data/ir_swaps/cms_eur_5y_payer_cms10y_hagan_analytic.json
+++ b/examples/data/ir_swaps/cms_eur_5y_payer_cms10y_hagan_analytic.json
@@ -300,7 +300,8 @@
             "frequency": "Annual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "rate": 0.03,
           "day_counter": "Thirty360",
@@ -315,7 +316,8 @@
             "frequency": "Quarterly",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "swap_index_id": "EUR_SWAP_6M",
           "swap_tenor": {

--- a/examples/data/ir_swaps/cms_eur_5y_payer_cms10y_hagan_numeric.json
+++ b/examples/data/ir_swaps/cms_eur_5y_payer_cms10y_hagan_numeric.json
@@ -300,7 +300,8 @@
             "frequency": "Annual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "rate": 0.03,
           "day_counter": "Thirty360",
@@ -315,7 +316,8 @@
             "frequency": "Quarterly",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "swap_index_id": "EUR_SWAP_6M",
           "swap_tenor": {

--- a/examples/data/ir_swaps/cms_eur_5y_payer_cms10y_vs_fixed_lineartsr.json
+++ b/examples/data/ir_swaps/cms_eur_5y_payer_cms10y_vs_fixed_lineartsr.json
@@ -300,7 +300,8 @@
             "frequency": "Annual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "rate": 0.03,
           "day_counter": "Thirty360",
@@ -315,7 +316,8 @@
             "frequency": "Quarterly",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "swap_index_id": "EUR_SWAP_6M",
           "swap_tenor": {

--- a/examples/data/ir_swaps/cms_eur_5y_payer_cms2y_atm_matrix_lineartsr.json
+++ b/examples/data/ir_swaps/cms_eur_5y_payer_cms2y_atm_matrix_lineartsr.json
@@ -335,7 +335,8 @@
             "frequency": "Annual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "rate": 0.03,
           "day_counter": "Thirty360",
@@ -350,7 +351,8 @@
             "frequency": "Quarterly",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "swap_index_id": "EUR_SWAP_6M",
           "swap_tenor": {

--- a/examples/data/ir_swaps/cms_eur_5y_receiver_cms10y_gearing_spread_capped_lineartsr.json
+++ b/examples/data/ir_swaps/cms_eur_5y_receiver_cms10y_gearing_spread_capped_lineartsr.json
@@ -300,7 +300,8 @@
             "frequency": "Annual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "rate": 0.025,
           "day_counter": "Thirty360",
@@ -315,7 +316,8 @@
             "frequency": "Quarterly",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "swap_index_id": "EUR_SWAP_6M",
           "swap_tenor": {

--- a/examples/data/ir_swaps/cms_eur_5y_receiver_cms10y_gearing_spread_lineartsr.json
+++ b/examples/data/ir_swaps/cms_eur_5y_receiver_cms10y_gearing_spread_lineartsr.json
@@ -300,7 +300,8 @@
             "frequency": "Annual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "rate": 0.025,
           "day_counter": "Thirty360",
@@ -315,7 +316,8 @@
             "frequency": "Quarterly",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "swap_index_id": "EUR_SWAP_6M",
           "swap_tenor": {

--- a/examples/data/ir_swaps/cms_eur_5y_receiver_cms10y_neg_gearing_capped_lineartsr.json
+++ b/examples/data/ir_swaps/cms_eur_5y_receiver_cms10y_neg_gearing_capped_lineartsr.json
@@ -300,7 +300,8 @@
             "frequency": "Annual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "rate": 0.025,
           "day_counter": "Thirty360",
@@ -315,7 +316,8 @@
             "frequency": "Quarterly",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "swap_index_id": "EUR_SWAP_6M",
           "swap_tenor": {

--- a/examples/data/ir_swaps/irs_eur_1y_payer_vs_euribor6m.json
+++ b/examples/data/ir_swaps/irs_eur_1y_payer_vs_euribor6m.json
@@ -112,7 +112,8 @@
             "frequency": "Annual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "rate": 0.029,
           "day_counter": "Thirty360",
@@ -127,7 +128,8 @@
             "frequency": "Semiannual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "index": {
             "id": "EUR_6M"

--- a/examples/data/ir_swaps/irs_eur_2y_payer_imm_third_wednesday.json
+++ b/examples/data/ir_swaps/irs_eur_2y_payer_imm_third_wednesday.json
@@ -127,7 +127,8 @@
             "frequency": "Annual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "ThirdWednesday"
+            "date_generation_rule": "ThirdWednesday",
+            "end_of_month": false
           },
           "rate": 0.0302,
           "day_counter": "Thirty360",
@@ -142,7 +143,8 @@
             "frequency": "Quarterly",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "ThirdWednesday"
+            "date_generation_rule": "ThirdWednesday",
+            "end_of_month": false
           },
           "index": {
             "id": "EUR_3M"

--- a/examples/data/ir_swaps/irs_eur_30y_receiver_fixed_30360_vs_euribor6m.json
+++ b/examples/data/ir_swaps/irs_eur_30y_receiver_fixed_30360_vs_euribor6m.json
@@ -188,7 +188,8 @@
             "frequency": "Annual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "rate": 0.035,
           "day_counter": "Thirty360",
@@ -203,7 +204,8 @@
             "frequency": "Semiannual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "index": {
             "id": "EUR_6M"

--- a/examples/data/ir_swaps/irs_eur_3y_payer_vs_euribor1m_monthly.json
+++ b/examples/data/ir_swaps/irs_eur_3y_payer_vs_euribor1m_monthly.json
@@ -126,7 +126,8 @@
             "frequency": "Annual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "rate": 0.03,
           "day_counter": "Thirty360",
@@ -141,7 +142,8 @@
             "frequency": "Monthly",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "index": {
             "id": "EUR_1M"

--- a/examples/data/ir_swaps/irs_eur_4y_payer_vs_euribor3m_quarterly.json
+++ b/examples/data/ir_swaps/irs_eur_4y_payer_vs_euribor3m_quarterly.json
@@ -146,7 +146,8 @@
             "frequency": "Annual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "rate": 0.0305,
           "day_counter": "Thirty360",
@@ -161,7 +162,8 @@
             "frequency": "Quarterly",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "index": {
             "id": "EUR_3M"

--- a/examples/data/ir_swaps/irs_eur_5y_amortizing_payer.json
+++ b/examples/data/ir_swaps/irs_eur_5y_amortizing_payer.json
@@ -131,7 +131,8 @@
             "frequency": "Annual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "rate": 0.032,
           "day_counter": "Thirty360",
@@ -153,7 +154,8 @@
             "frequency": "Semiannual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "index": {
             "id": "EUR_6M"

--- a/examples/data/ir_swaps/irs_eur_5y_constant_via_notionals.json
+++ b/examples/data/ir_swaps/irs_eur_5y_constant_via_notionals.json
@@ -131,7 +131,8 @@
             "frequency": "Annual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "rate": 0.032,
           "day_counter": "Thirty360",
@@ -153,7 +154,8 @@
             "frequency": "Semiannual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "index": {
             "id": "EUR_6M"

--- a/examples/data/ir_swaps/irs_eur_5y_payer_1y_forward_start.json
+++ b/examples/data/ir_swaps/irs_eur_5y_payer_1y_forward_start.json
@@ -150,7 +150,8 @@
             "frequency": "Annual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "rate": 0.033,
           "day_counter": "Thirty360",
@@ -165,7 +166,8 @@
             "frequency": "Semiannual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "index": {
             "id": "EUR_6M"

--- a/examples/data/ir_swaps/irs_eur_5y_payer_fixed_30360_vs_euribor6m.json
+++ b/examples/data/ir_swaps/irs_eur_5y_payer_fixed_30360_vs_euribor6m.json
@@ -131,7 +131,8 @@
             "frequency": "Annual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "rate": 0.032,
           "day_counter": "Thirty360",
@@ -146,7 +147,8 @@
             "frequency": "Semiannual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "index": {
             "id": "EUR_6M"

--- a/examples/data/ir_swaps/irs_eur_5y_payer_ois_discounted_multicurve.json
+++ b/examples/data/ir_swaps/irs_eur_5y_payer_ois_discounted_multicurve.json
@@ -30,7 +30,9 @@
           },
           "fixing_days": 0,
           "calendar": "TARGET",
-          "day_counter": "Actual360"
+          "day_counter": "Actual360",
+          "business_day_convention": "ModifiedFollowing",
+          "end_of_month": true
         }
       ],
       "curves": [
@@ -52,7 +54,11 @@
                 "tenor": {
                   "n": 1,
                   "unit": "Years"
-                }
+                },
+                "calendar": "TARGET",
+                "fixed_leg_convention": "ModifiedFollowing",
+                "fixed_leg_day_counter": "Actual360",
+                "fixed_leg_frequency": "Annual"
               }
             },
             {
@@ -66,7 +72,11 @@
                 "tenor": {
                   "n": 2,
                   "unit": "Years"
-                }
+                },
+                "calendar": "TARGET",
+                "fixed_leg_convention": "ModifiedFollowing",
+                "fixed_leg_day_counter": "Actual360",
+                "fixed_leg_frequency": "Annual"
               }
             },
             {
@@ -80,7 +90,11 @@
                 "tenor": {
                   "n": 5,
                   "unit": "Years"
-                }
+                },
+                "calendar": "TARGET",
+                "fixed_leg_convention": "ModifiedFollowing",
+                "fixed_leg_day_counter": "Actual360",
+                "fixed_leg_frequency": "Annual"
               }
             },
             {
@@ -94,7 +108,11 @@
                 "tenor": {
                   "n": 10,
                   "unit": "Years"
-                }
+                },
+                "calendar": "TARGET",
+                "fixed_leg_convention": "ModifiedFollowing",
+                "fixed_leg_day_counter": "Actual360",
+                "fixed_leg_frequency": "Annual"
               }
             }
           ]
@@ -195,7 +213,8 @@
             "frequency": "Annual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "rate": 0.032,
           "day_counter": "Thirty360",
@@ -210,7 +229,8 @@
             "frequency": "Semiannual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "index": {
             "id": "EUR_6M"

--- a/examples/data/ir_swaps/irs_eur_5y_payer_spread25bp_following_backward.json
+++ b/examples/data/ir_swaps/irs_eur_5y_payer_spread25bp_following_backward.json
@@ -131,7 +131,8 @@
             "frequency": "Annual",
             "convention": "Following",
             "termination_date_convention": "Following",
-            "date_generation_rule": "Backward"
+            "date_generation_rule": "Backward",
+            "end_of_month": false
           },
           "rate": 0.033,
           "day_counter": "Thirty360",
@@ -146,7 +147,8 @@
             "frequency": "Semiannual",
             "convention": "Following",
             "termination_date_convention": "Following",
-            "date_generation_rule": "Backward"
+            "date_generation_rule": "Backward",
+            "end_of_month": false
           },
           "index": {
             "id": "EUR_6M"

--- a/examples/data/ir_swaps/irs_eur_5y_receiver_fixed_30360_vs_euribor6m.json
+++ b/examples/data/ir_swaps/irs_eur_5y_receiver_fixed_30360_vs_euribor6m.json
@@ -131,7 +131,8 @@
             "frequency": "Annual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "rate": 0.034,
           "day_counter": "Thirty360",
@@ -146,7 +147,8 @@
             "frequency": "Semiannual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "index": {
             "id": "EUR_6M"

--- a/examples/data/ir_swaps/irs_eur_5y_short_first_both_legs.json
+++ b/examples/data/ir_swaps/irs_eur_5y_short_first_both_legs.json
@@ -132,7 +132,8 @@
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
             "date_generation_rule": "Forward",
-            "first_date": "2025-03-17"
+            "first_date": "2025-03-17",
+            "end_of_month": false
           },
           "rate": 0.032,
           "day_counter": "Thirty360",
@@ -148,7 +149,8 @@
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
             "date_generation_rule": "Forward",
-            "first_date": "2025-03-17"
+            "first_date": "2025-03-17",
+            "end_of_month": false
           },
           "index": {
             "id": "EUR_6M"

--- a/examples/data/ir_swaps/irs_eur_5y_stepup_fixed_only.json
+++ b/examples/data/ir_swaps/irs_eur_5y_stepup_fixed_only.json
@@ -131,7 +131,8 @@
             "frequency": "Annual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "rate": 0.032,
           "day_counter": "Thirty360",
@@ -153,7 +154,8 @@
             "frequency": "Semiannual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "index": {
             "id": "EUR_6M"

--- a/examples/data/ir_swaps/irs_eur_7y_payer_fixed_act365_semiannual.json
+++ b/examples/data/ir_swaps/irs_eur_7y_payer_fixed_act365_semiannual.json
@@ -131,7 +131,8 @@
             "frequency": "Semiannual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "rate": 0.0325,
           "day_counter": "Actual365Fixed",
@@ -146,7 +147,8 @@
             "frequency": "Semiannual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "index": {
             "id": "EUR_6M"

--- a/examples/data/ir_swaps/irs_gbp_5y_payer_uk_calendar_act365_semiannual.json
+++ b/examples/data/ir_swaps/irs_gbp_5y_payer_uk_calendar_act365_semiannual.json
@@ -131,7 +131,8 @@
             "frequency": "Semiannual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "rate": 0.0435,
           "day_counter": "Actual365Fixed",
@@ -146,7 +147,8 @@
             "frequency": "Semiannual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "index": {
             "id": "GBP_6M"

--- a/examples/data/ir_swaps/ois_eur_2y_receiver_estr_spread10bp_quarterly.json
+++ b/examples/data/ir_swaps/ois_eur_2y_receiver_estr_spread10bp_quarterly.json
@@ -15,7 +15,9 @@
           },
           "fixing_days": 0,
           "calendar": "TARGET",
-          "day_counter": "Actual360"
+          "day_counter": "Actual360",
+          "business_day_convention": "ModifiedFollowing",
+          "end_of_month": true
         }
       ],
       "curves": [
@@ -37,7 +39,11 @@
                 "tenor": {
                   "n": 1,
                   "unit": "Years"
-                }
+                },
+                "calendar": "TARGET",
+                "fixed_leg_convention": "ModifiedFollowing",
+                "fixed_leg_day_counter": "Actual360",
+                "fixed_leg_frequency": "Annual"
               }
             },
             {
@@ -51,7 +57,11 @@
                 "tenor": {
                   "n": 2,
                   "unit": "Years"
-                }
+                },
+                "calendar": "TARGET",
+                "fixed_leg_convention": "ModifiedFollowing",
+                "fixed_leg_day_counter": "Actual360",
+                "fixed_leg_frequency": "Annual"
               }
             },
             {
@@ -65,7 +75,11 @@
                 "tenor": {
                   "n": 5,
                   "unit": "Years"
-                }
+                },
+                "calendar": "TARGET",
+                "fixed_leg_convention": "ModifiedFollowing",
+                "fixed_leg_day_counter": "Actual360",
+                "fixed_leg_frequency": "Annual"
               }
             },
             {
@@ -79,7 +93,11 @@
                 "tenor": {
                   "n": 10,
                   "unit": "Years"
-                }
+                },
+                "calendar": "TARGET",
+                "fixed_leg_convention": "ModifiedFollowing",
+                "fixed_leg_day_counter": "Actual360",
+                "fixed_leg_frequency": "Annual"
               }
             }
           ]
@@ -100,7 +118,8 @@
             "frequency": "Quarterly",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "rate": 0.028,
           "day_counter": "Actual360",
@@ -115,7 +134,8 @@
             "frequency": "Quarterly",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "index": {
             "id": "EUR_ESTR"

--- a/examples/data/ir_swaps/ois_eur_5y_payer_estr.json
+++ b/examples/data/ir_swaps/ois_eur_5y_payer_estr.json
@@ -15,7 +15,9 @@
           },
           "fixing_days": 0,
           "calendar": "TARGET",
-          "day_counter": "Actual360"
+          "day_counter": "Actual360",
+          "business_day_convention": "ModifiedFollowing",
+          "end_of_month": true
         }
       ],
       "curves": [
@@ -37,7 +39,11 @@
                 "tenor": {
                   "n": 1,
                   "unit": "Years"
-                }
+                },
+                "calendar": "TARGET",
+                "fixed_leg_convention": "ModifiedFollowing",
+                "fixed_leg_day_counter": "Actual360",
+                "fixed_leg_frequency": "Annual"
               }
             },
             {
@@ -51,7 +57,11 @@
                 "tenor": {
                   "n": 2,
                   "unit": "Years"
-                }
+                },
+                "calendar": "TARGET",
+                "fixed_leg_convention": "ModifiedFollowing",
+                "fixed_leg_day_counter": "Actual360",
+                "fixed_leg_frequency": "Annual"
               }
             },
             {
@@ -65,7 +75,11 @@
                 "tenor": {
                   "n": 5,
                   "unit": "Years"
-                }
+                },
+                "calendar": "TARGET",
+                "fixed_leg_convention": "ModifiedFollowing",
+                "fixed_leg_day_counter": "Actual360",
+                "fixed_leg_frequency": "Annual"
               }
             },
             {
@@ -79,7 +93,11 @@
                 "tenor": {
                   "n": 10,
                   "unit": "Years"
-                }
+                },
+                "calendar": "TARGET",
+                "fixed_leg_convention": "ModifiedFollowing",
+                "fixed_leg_day_counter": "Actual360",
+                "fixed_leg_frequency": "Annual"
               }
             }
           ]
@@ -100,7 +118,8 @@
             "frequency": "Annual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "rate": 0.027,
           "day_counter": "Actual360",
@@ -115,7 +134,8 @@
             "frequency": "Annual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "index": {
             "id": "EUR_ESTR"

--- a/examples/data/ir_swaps/ois_eur_5y_payer_estr_payment_lag2.json
+++ b/examples/data/ir_swaps/ois_eur_5y_payer_estr_payment_lag2.json
@@ -15,7 +15,9 @@
           },
           "fixing_days": 0,
           "calendar": "TARGET",
-          "day_counter": "Actual360"
+          "day_counter": "Actual360",
+          "business_day_convention": "ModifiedFollowing",
+          "end_of_month": true
         }
       ],
       "curves": [
@@ -37,7 +39,11 @@
                 "tenor": {
                   "n": 1,
                   "unit": "Years"
-                }
+                },
+                "calendar": "TARGET",
+                "fixed_leg_convention": "ModifiedFollowing",
+                "fixed_leg_day_counter": "Actual360",
+                "fixed_leg_frequency": "Annual"
               }
             },
             {
@@ -51,7 +57,11 @@
                 "tenor": {
                   "n": 2,
                   "unit": "Years"
-                }
+                },
+                "calendar": "TARGET",
+                "fixed_leg_convention": "ModifiedFollowing",
+                "fixed_leg_day_counter": "Actual360",
+                "fixed_leg_frequency": "Annual"
               }
             },
             {
@@ -65,7 +75,11 @@
                 "tenor": {
                   "n": 5,
                   "unit": "Years"
-                }
+                },
+                "calendar": "TARGET",
+                "fixed_leg_convention": "ModifiedFollowing",
+                "fixed_leg_day_counter": "Actual360",
+                "fixed_leg_frequency": "Annual"
               }
             },
             {
@@ -79,7 +93,11 @@
                 "tenor": {
                   "n": 10,
                   "unit": "Years"
-                }
+                },
+                "calendar": "TARGET",
+                "fixed_leg_convention": "ModifiedFollowing",
+                "fixed_leg_day_counter": "Actual360",
+                "fixed_leg_frequency": "Annual"
               }
             }
           ]
@@ -100,7 +118,8 @@
             "frequency": "Annual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "rate": 0.0268,
           "day_counter": "Actual360",
@@ -115,7 +134,8 @@
             "frequency": "Annual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "index": {
             "id": "EUR_ESTR"

--- a/examples/data/ir_swaps/ois_usd_3y_payer_sofr.json
+++ b/examples/data/ir_swaps/ois_usd_3y_payer_sofr.json
@@ -15,7 +15,9 @@
           },
           "fixing_days": 0,
           "calendar": "UnitedStatesGovernmentBond",
-          "day_counter": "Actual360"
+          "day_counter": "Actual360",
+          "business_day_convention": "ModifiedFollowing",
+          "end_of_month": true
         }
       ],
       "curves": [
@@ -37,7 +39,11 @@
                 "tenor": {
                   "n": 1,
                   "unit": "Years"
-                }
+                },
+                "calendar": "TARGET",
+                "fixed_leg_convention": "ModifiedFollowing",
+                "fixed_leg_day_counter": "Actual360",
+                "fixed_leg_frequency": "Annual"
               }
             },
             {
@@ -51,7 +57,11 @@
                 "tenor": {
                   "n": 3,
                   "unit": "Years"
-                }
+                },
+                "calendar": "TARGET",
+                "fixed_leg_convention": "ModifiedFollowing",
+                "fixed_leg_day_counter": "Actual360",
+                "fixed_leg_frequency": "Annual"
               }
             },
             {
@@ -65,7 +75,11 @@
                 "tenor": {
                   "n": 5,
                   "unit": "Years"
-                }
+                },
+                "calendar": "TARGET",
+                "fixed_leg_convention": "ModifiedFollowing",
+                "fixed_leg_day_counter": "Actual360",
+                "fixed_leg_frequency": "Annual"
               }
             }
           ]
@@ -86,7 +100,8 @@
             "frequency": "Annual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "rate": 0.0405,
           "day_counter": "Actual360",
@@ -101,7 +116,8 @@
             "frequency": "Annual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "index": {
             "id": "USD_SOFR"

--- a/examples/data/ois_swap_request.json
+++ b/examples/data/ois_swap_request.json
@@ -30,7 +30,9 @@
           },
           "fixing_days": 0,
           "calendar": "TARGET",
-          "day_counter": "Actual360"
+          "day_counter": "Actual360",
+          "business_day_convention": "ModifiedFollowing",
+          "end_of_month": true
         }
       ],
       "curves": [
@@ -106,7 +108,8 @@
             "frequency": "Annual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "rate": 0.03,
           "day_counter": "Actual360",
@@ -121,7 +124,8 @@
             "frequency": "Annual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "index": {
             "id": "ESTR"

--- a/examples/data/swaption/swpt_eur_1y5y_payer_atm_matrix_vol.json
+++ b/examples/data/swaption/swpt_eur_1y5y_payer_atm_matrix_vol.json
@@ -273,7 +273,8 @@
               "frequency": "Annual",
               "convention": "ModifiedFollowing",
               "termination_date_convention": "ModifiedFollowing",
-              "date_generation_rule": "Forward"
+              "date_generation_rule": "Forward",
+              "end_of_month": false
             },
             "rate": 0.031,
             "day_counter": "Thirty360",
@@ -288,7 +289,8 @@
               "frequency": "Semiannual",
               "convention": "ModifiedFollowing",
               "termination_date_convention": "ModifiedFollowing",
-              "date_generation_rule": "Forward"
+              "date_generation_rule": "Forward",
+              "end_of_month": false
             },
             "index": {
               "id": "EUR_6M"

--- a/examples/data/swaption/swpt_eur_1y5y_payer_bachelier_normal_80bp.json
+++ b/examples/data/swaption/swpt_eur_1y5y_payer_bachelier_normal_80bp.json
@@ -232,7 +232,8 @@
               "frequency": "Annual",
               "convention": "ModifiedFollowing",
               "termination_date_convention": "ModifiedFollowing",
-              "date_generation_rule": "Forward"
+              "date_generation_rule": "Forward",
+              "end_of_month": false
             },
             "rate": 0.031,
             "day_counter": "Thirty360",
@@ -247,7 +248,8 @@
               "frequency": "Semiannual",
               "convention": "ModifiedFollowing",
               "termination_date_convention": "ModifiedFollowing",
-              "date_generation_rule": "Forward"
+              "date_generation_rule": "Forward",
+              "end_of_month": false
             },
             "index": {
               "id": "EUR_6M"

--- a/examples/data/swaption/swpt_eur_1y5y_payer_cash_par_yield.json
+++ b/examples/data/swaption/swpt_eur_1y5y_payer_cash_par_yield.json
@@ -232,7 +232,8 @@
               "frequency": "Annual",
               "convention": "ModifiedFollowing",
               "termination_date_convention": "ModifiedFollowing",
-              "date_generation_rule": "Forward"
+              "date_generation_rule": "Forward",
+              "end_of_month": false
             },
             "rate": 0.031,
             "day_counter": "Thirty360",
@@ -247,7 +248,8 @@
               "frequency": "Semiannual",
               "convention": "ModifiedFollowing",
               "termination_date_convention": "ModifiedFollowing",
-              "date_generation_rule": "Forward"
+              "date_generation_rule": "Forward",
+              "end_of_month": false
             },
             "index": {
               "id": "EUR_6M"

--- a/examples/data/swaption/swpt_eur_1y5y_payer_itm_strike_2pct.json
+++ b/examples/data/swaption/swpt_eur_1y5y_payer_itm_strike_2pct.json
@@ -232,7 +232,8 @@
               "frequency": "Annual",
               "convention": "ModifiedFollowing",
               "termination_date_convention": "ModifiedFollowing",
-              "date_generation_rule": "Forward"
+              "date_generation_rule": "Forward",
+              "end_of_month": false
             },
             "rate": 0.02,
             "day_counter": "Thirty360",
@@ -247,7 +248,8 @@
               "frequency": "Semiannual",
               "convention": "ModifiedFollowing",
               "termination_date_convention": "ModifiedFollowing",
-              "date_generation_rule": "Forward"
+              "date_generation_rule": "Forward",
+              "end_of_month": false
             },
             "index": {
               "id": "EUR_6M"

--- a/examples/data/swaption/swpt_eur_1y5y_payer_near_atm_physical.json
+++ b/examples/data/swaption/swpt_eur_1y5y_payer_near_atm_physical.json
@@ -232,7 +232,8 @@
               "frequency": "Annual",
               "convention": "ModifiedFollowing",
               "termination_date_convention": "ModifiedFollowing",
-              "date_generation_rule": "Forward"
+              "date_generation_rule": "Forward",
+              "end_of_month": false
             },
             "rate": 0.031,
             "day_counter": "Thirty360",
@@ -247,7 +248,8 @@
               "frequency": "Semiannual",
               "convention": "ModifiedFollowing",
               "termination_date_convention": "ModifiedFollowing",
-              "date_generation_rule": "Forward"
+              "date_generation_rule": "Forward",
+              "end_of_month": false
             },
             "index": {
               "id": "EUR_6M"

--- a/examples/data/swaption/swpt_eur_1y5y_payer_otm_strike_4_5pct.json
+++ b/examples/data/swaption/swpt_eur_1y5y_payer_otm_strike_4_5pct.json
@@ -232,7 +232,8 @@
               "frequency": "Annual",
               "convention": "ModifiedFollowing",
               "termination_date_convention": "ModifiedFollowing",
-              "date_generation_rule": "Forward"
+              "date_generation_rule": "Forward",
+              "end_of_month": false
             },
             "rate": 0.045,
             "day_counter": "Thirty360",
@@ -247,7 +248,8 @@
               "frequency": "Semiannual",
               "convention": "ModifiedFollowing",
               "termination_date_convention": "ModifiedFollowing",
-              "date_generation_rule": "Forward"
+              "date_generation_rule": "Forward",
+              "end_of_month": false
             },
             "index": {
               "id": "EUR_6M"

--- a/examples/data/swaption/swpt_eur_1y5y_payer_shifted_black_2pct.json
+++ b/examples/data/swaption/swpt_eur_1y5y_payer_shifted_black_2pct.json
@@ -232,7 +232,8 @@
               "frequency": "Annual",
               "convention": "ModifiedFollowing",
               "termination_date_convention": "ModifiedFollowing",
-              "date_generation_rule": "Forward"
+              "date_generation_rule": "Forward",
+              "end_of_month": false
             },
             "rate": 0.031,
             "day_counter": "Thirty360",
@@ -247,7 +248,8 @@
               "frequency": "Semiannual",
               "convention": "ModifiedFollowing",
               "termination_date_convention": "ModifiedFollowing",
-              "date_generation_rule": "Forward"
+              "date_generation_rule": "Forward",
+              "end_of_month": false
             },
             "index": {
               "id": "EUR_6M"

--- a/examples/data/swaption/swpt_eur_1y5y_receiver_near_atm.json
+++ b/examples/data/swaption/swpt_eur_1y5y_receiver_near_atm.json
@@ -232,7 +232,8 @@
               "frequency": "Annual",
               "convention": "ModifiedFollowing",
               "termination_date_convention": "ModifiedFollowing",
-              "date_generation_rule": "Forward"
+              "date_generation_rule": "Forward",
+              "end_of_month": false
             },
             "rate": 0.031,
             "day_counter": "Thirty360",
@@ -247,7 +248,8 @@
               "frequency": "Semiannual",
               "convention": "ModifiedFollowing",
               "termination_date_convention": "ModifiedFollowing",
-              "date_generation_rule": "Forward"
+              "date_generation_rule": "Forward",
+              "end_of_month": false
             },
             "index": {
               "id": "EUR_6M"

--- a/examples/data/swaption/swpt_eur_2y10y_payer.json
+++ b/examples/data/swaption/swpt_eur_2y10y_payer.json
@@ -232,7 +232,8 @@
               "frequency": "Annual",
               "convention": "ModifiedFollowing",
               "termination_date_convention": "ModifiedFollowing",
-              "date_generation_rule": "Forward"
+              "date_generation_rule": "Forward",
+              "end_of_month": false
             },
             "rate": 0.033,
             "day_counter": "Thirty360",
@@ -247,7 +248,8 @@
               "frequency": "Semiannual",
               "convention": "ModifiedFollowing",
               "termination_date_convention": "ModifiedFollowing",
-              "date_generation_rule": "Forward"
+              "date_generation_rule": "Forward",
+              "end_of_month": false
             },
             "index": {
               "id": "EUR_6M"

--- a/examples/data/swaption/swpt_eur_5y5y_payer.json
+++ b/examples/data/swaption/swpt_eur_5y5y_payer.json
@@ -232,7 +232,8 @@
               "frequency": "Annual",
               "convention": "ModifiedFollowing",
               "termination_date_convention": "ModifiedFollowing",
-              "date_generation_rule": "Forward"
+              "date_generation_rule": "Forward",
+              "end_of_month": false
             },
             "rate": 0.033,
             "day_counter": "Thirty360",
@@ -247,7 +248,8 @@
               "frequency": "Semiannual",
               "convention": "ModifiedFollowing",
               "termination_date_convention": "ModifiedFollowing",
-              "date_generation_rule": "Forward"
+              "date_generation_rule": "Forward",
+              "end_of_month": false
             },
             "index": {
               "id": "EUR_6M"

--- a/examples/data/swaption/swpt_eur_american_2y_window_hw_explicit.json
+++ b/examples/data/swaption/swpt_eur_american_2y_window_hw_explicit.json
@@ -236,7 +236,8 @@
               "frequency": "Annual",
               "convention": "ModifiedFollowing",
               "termination_date_convention": "ModifiedFollowing",
-              "date_generation_rule": "Forward"
+              "date_generation_rule": "Forward",
+              "end_of_month": false
             },
             "rate": 0.031,
             "day_counter": "Thirty360",
@@ -251,7 +252,8 @@
               "frequency": "Semiannual",
               "convention": "ModifiedFollowing",
               "termination_date_convention": "ModifiedFollowing",
-              "date_generation_rule": "Forward"
+              "date_generation_rule": "Forward",
+              "end_of_month": false
             },
             "index": {
               "id": "EUR_6M"

--- a/examples/data/swaption/swpt_eur_bermudan_3ex_into_5y_hw_explicit.json
+++ b/examples/data/swaption/swpt_eur_bermudan_3ex_into_5y_hw_explicit.json
@@ -240,7 +240,8 @@
               "frequency": "Annual",
               "convention": "ModifiedFollowing",
               "termination_date_convention": "ModifiedFollowing",
-              "date_generation_rule": "Forward"
+              "date_generation_rule": "Forward",
+              "end_of_month": false
             },
             "rate": 0.031,
             "day_counter": "Thirty360",
@@ -255,7 +256,8 @@
               "frequency": "Semiannual",
               "convention": "ModifiedFollowing",
               "termination_date_convention": "ModifiedFollowing",
-              "date_generation_rule": "Forward"
+              "date_generation_rule": "Forward",
+              "end_of_month": false
             },
             "index": {
               "id": "EUR_6M"

--- a/examples/data/swaption/swpt_eur_ois_1y5y_payer_estr.json
+++ b/examples/data/swaption/swpt_eur_ois_1y5y_payer_estr.json
@@ -15,7 +15,9 @@
           },
           "fixing_days": 0,
           "calendar": "TARGET",
-          "day_counter": "Actual360"
+          "day_counter": "Actual360",
+          "business_day_convention": "ModifiedFollowing",
+          "end_of_month": true
         }
       ],
       "curves": [
@@ -37,7 +39,11 @@
                 "tenor": {
                   "n": 1,
                   "unit": "Years"
-                }
+                },
+                "calendar": "TARGET",
+                "fixed_leg_convention": "ModifiedFollowing",
+                "fixed_leg_day_counter": "Actual360",
+                "fixed_leg_frequency": "Annual"
               }
             },
             {
@@ -51,7 +57,11 @@
                 "tenor": {
                   "n": 2,
                   "unit": "Years"
-                }
+                },
+                "calendar": "TARGET",
+                "fixed_leg_convention": "ModifiedFollowing",
+                "fixed_leg_day_counter": "Actual360",
+                "fixed_leg_frequency": "Annual"
               }
             },
             {
@@ -65,7 +75,11 @@
                 "tenor": {
                   "n": 3,
                   "unit": "Years"
-                }
+                },
+                "calendar": "TARGET",
+                "fixed_leg_convention": "ModifiedFollowing",
+                "fixed_leg_day_counter": "Actual360",
+                "fixed_leg_frequency": "Annual"
               }
             },
             {
@@ -79,7 +93,11 @@
                 "tenor": {
                   "n": 5,
                   "unit": "Years"
-                }
+                },
+                "calendar": "TARGET",
+                "fixed_leg_convention": "ModifiedFollowing",
+                "fixed_leg_day_counter": "Actual360",
+                "fixed_leg_frequency": "Annual"
               }
             },
             {
@@ -93,7 +111,11 @@
                 "tenor": {
                   "n": 7,
                   "unit": "Years"
-                }
+                },
+                "calendar": "TARGET",
+                "fixed_leg_convention": "ModifiedFollowing",
+                "fixed_leg_day_counter": "Actual360",
+                "fixed_leg_frequency": "Annual"
               }
             },
             {
@@ -107,7 +129,11 @@
                 "tenor": {
                   "n": 10,
                   "unit": "Years"
-                }
+                },
+                "calendar": "TARGET",
+                "fixed_leg_convention": "ModifiedFollowing",
+                "fixed_leg_day_counter": "Actual360",
+                "fixed_leg_frequency": "Annual"
               }
             }
           ]
@@ -167,7 +193,8 @@
               "frequency": "Annual",
               "convention": "ModifiedFollowing",
               "termination_date_convention": "ModifiedFollowing",
-              "date_generation_rule": "Forward"
+              "date_generation_rule": "Forward",
+              "end_of_month": false
             },
             "rate": 0.0265,
             "day_counter": "Actual360",
@@ -182,7 +209,8 @@
               "frequency": "Annual",
               "convention": "ModifiedFollowing",
               "termination_date_convention": "ModifiedFollowing",
-              "date_generation_rule": "Forward"
+              "date_generation_rule": "Forward",
+              "end_of_month": false
             },
             "index": {
               "id": "EUR_ESTR"

--- a/examples/data/swaption_atm_matrix_request.json
+++ b/examples/data/swaption_atm_matrix_request.json
@@ -161,7 +161,8 @@
               "frequency": "Annual",
               "convention": "ModifiedFollowing",
               "termination_date_convention": "ModifiedFollowing",
-              "date_generation_rule": "Forward"
+              "date_generation_rule": "Forward",
+              "end_of_month": false
             },
             "rate": 0.03,
             "day_counter": "Thirty360",
@@ -176,7 +177,8 @@
               "frequency": "Semiannual",
               "convention": "ModifiedFollowing",
               "termination_date_convention": "ModifiedFollowing",
-              "date_generation_rule": "Forward"
+              "date_generation_rule": "Forward",
+              "end_of_month": false
             },
             "index": {
               "id": "EUR_6M"

--- a/examples/data/swaption_bermudan_hw_calibrated.json
+++ b/examples/data/swaption_bermudan_hw_calibrated.json
@@ -199,7 +199,8 @@
               "frequency": "Annual",
               "convention": "ModifiedFollowing",
               "termination_date_convention": "ModifiedFollowing",
-              "date_generation_rule": "Forward"
+              "date_generation_rule": "Forward",
+              "end_of_month": false
             },
             "rate": 0.035,
             "day_counter": "Thirty360",
@@ -214,7 +215,8 @@
               "frequency": "Semiannual",
               "convention": "ModifiedFollowing",
               "termination_date_convention": "ModifiedFollowing",
-              "date_generation_rule": "Forward"
+              "date_generation_rule": "Forward",
+              "end_of_month": false
             },
             "index": {
               "id": "EUR_6M"

--- a/examples/data/swaption_ois_bbg_zerorate_request.json
+++ b/examples/data/swaption_ois_bbg_zerorate_request.json
@@ -15,7 +15,8 @@
           "tenor": {
             "n": 0,
             "unit": "Days"
-          }
+          },
+          "end_of_month": true
         }
       ],
       "curves": [
@@ -49,7 +50,9 @@
                 "tenor": {
                   "n": 2,
                   "unit": "Weeks"
-                }
+                },
+                "compounding": "Continuous",
+                "frequency": "Annual"
               }
             },
             {
@@ -61,7 +64,9 @@
                 "tenor": {
                   "n": 3,
                   "unit": "Weeks"
-                }
+                },
+                "compounding": "Continuous",
+                "frequency": "Annual"
               }
             },
             {
@@ -73,7 +78,9 @@
                 "tenor": {
                   "n": 1,
                   "unit": "Months"
-                }
+                },
+                "compounding": "Continuous",
+                "frequency": "Annual"
               }
             },
             {
@@ -85,7 +92,9 @@
                 "tenor": {
                   "n": 2,
                   "unit": "Months"
-                }
+                },
+                "compounding": "Continuous",
+                "frequency": "Annual"
               }
             },
             {
@@ -97,7 +106,9 @@
                 "tenor": {
                   "n": 3,
                   "unit": "Months"
-                }
+                },
+                "compounding": "Continuous",
+                "frequency": "Annual"
               }
             },
             {
@@ -109,7 +120,9 @@
                 "tenor": {
                   "n": 4,
                   "unit": "Months"
-                }
+                },
+                "compounding": "Continuous",
+                "frequency": "Annual"
               }
             },
             {
@@ -121,7 +134,9 @@
                 "tenor": {
                   "n": 5,
                   "unit": "Months"
-                }
+                },
+                "compounding": "Continuous",
+                "frequency": "Annual"
               }
             },
             {
@@ -133,7 +148,9 @@
                 "tenor": {
                   "n": 6,
                   "unit": "Months"
-                }
+                },
+                "compounding": "Continuous",
+                "frequency": "Annual"
               }
             },
             {
@@ -145,7 +162,9 @@
                 "tenor": {
                   "n": 7,
                   "unit": "Months"
-                }
+                },
+                "compounding": "Continuous",
+                "frequency": "Annual"
               }
             },
             {
@@ -157,7 +176,9 @@
                 "tenor": {
                   "n": 8,
                   "unit": "Months"
-                }
+                },
+                "compounding": "Continuous",
+                "frequency": "Annual"
               }
             },
             {
@@ -169,7 +190,9 @@
                 "tenor": {
                   "n": 9,
                   "unit": "Months"
-                }
+                },
+                "compounding": "Continuous",
+                "frequency": "Annual"
               }
             },
             {
@@ -181,7 +204,9 @@
                 "tenor": {
                   "n": 10,
                   "unit": "Months"
-                }
+                },
+                "compounding": "Continuous",
+                "frequency": "Annual"
               }
             },
             {
@@ -193,7 +218,9 @@
                 "tenor": {
                   "n": 11,
                   "unit": "Months"
-                }
+                },
+                "compounding": "Continuous",
+                "frequency": "Annual"
               }
             },
             {
@@ -205,7 +232,9 @@
                 "tenor": {
                   "n": 12,
                   "unit": "Months"
-                }
+                },
+                "compounding": "Continuous",
+                "frequency": "Annual"
               }
             },
             {
@@ -217,7 +246,9 @@
                 "tenor": {
                   "n": 18,
                   "unit": "Months"
-                }
+                },
+                "compounding": "Continuous",
+                "frequency": "Annual"
               }
             },
             {
@@ -229,7 +260,9 @@
                 "tenor": {
                   "n": 2,
                   "unit": "Years"
-                }
+                },
+                "compounding": "Continuous",
+                "frequency": "Annual"
               }
             },
             {
@@ -241,7 +274,9 @@
                 "tenor": {
                   "n": 3,
                   "unit": "Years"
-                }
+                },
+                "compounding": "Continuous",
+                "frequency": "Annual"
               }
             },
             {
@@ -253,7 +288,9 @@
                 "tenor": {
                   "n": 4,
                   "unit": "Years"
-                }
+                },
+                "compounding": "Continuous",
+                "frequency": "Annual"
               }
             },
             {
@@ -265,7 +302,9 @@
                 "tenor": {
                   "n": 5,
                   "unit": "Years"
-                }
+                },
+                "compounding": "Continuous",
+                "frequency": "Annual"
               }
             },
             {
@@ -277,7 +316,9 @@
                 "tenor": {
                   "n": 6,
                   "unit": "Years"
-                }
+                },
+                "compounding": "Continuous",
+                "frequency": "Annual"
               }
             },
             {
@@ -289,7 +330,9 @@
                 "tenor": {
                   "n": 7,
                   "unit": "Years"
-                }
+                },
+                "compounding": "Continuous",
+                "frequency": "Annual"
               }
             },
             {
@@ -301,7 +344,9 @@
                 "tenor": {
                   "n": 8,
                   "unit": "Years"
-                }
+                },
+                "compounding": "Continuous",
+                "frequency": "Annual"
               }
             },
             {
@@ -313,7 +358,9 @@
                 "tenor": {
                   "n": 9,
                   "unit": "Years"
-                }
+                },
+                "compounding": "Continuous",
+                "frequency": "Annual"
               }
             },
             {
@@ -325,7 +372,9 @@
                 "tenor": {
                   "n": 10,
                   "unit": "Years"
-                }
+                },
+                "compounding": "Continuous",
+                "frequency": "Annual"
               }
             },
             {
@@ -337,7 +386,9 @@
                 "tenor": {
                   "n": 12,
                   "unit": "Years"
-                }
+                },
+                "compounding": "Continuous",
+                "frequency": "Annual"
               }
             },
             {
@@ -349,7 +400,9 @@
                 "tenor": {
                   "n": 15,
                   "unit": "Years"
-                }
+                },
+                "compounding": "Continuous",
+                "frequency": "Annual"
               }
             },
             {
@@ -361,7 +414,9 @@
                 "tenor": {
                   "n": 20,
                   "unit": "Years"
-                }
+                },
+                "compounding": "Continuous",
+                "frequency": "Annual"
               }
             },
             {
@@ -373,7 +428,9 @@
                 "tenor": {
                   "n": 25,
                   "unit": "Years"
-                }
+                },
+                "compounding": "Continuous",
+                "frequency": "Annual"
               }
             },
             {
@@ -385,7 +442,9 @@
                 "tenor": {
                   "n": 30,
                   "unit": "Years"
-                }
+                },
+                "compounding": "Continuous",
+                "frequency": "Annual"
               }
             },
             {
@@ -397,7 +456,9 @@
                 "tenor": {
                   "n": 40,
                   "unit": "Years"
-                }
+                },
+                "compounding": "Continuous",
+                "frequency": "Annual"
               }
             },
             {
@@ -409,7 +470,9 @@
                 "tenor": {
                   "n": 50,
                   "unit": "Years"
-                }
+                },
+                "compounding": "Continuous",
+                "frequency": "Annual"
               }
             }
           ]
@@ -469,7 +532,8 @@
               "frequency": "Annual",
               "convention": "ModifiedFollowing",
               "termination_date_convention": "ModifiedFollowing",
-              "date_generation_rule": "Forward"
+              "date_generation_rule": "Forward",
+              "end_of_month": false
             },
             "rate": 0.03367463,
             "day_counter": "Actual360",
@@ -484,7 +548,8 @@
               "frequency": "Annual",
               "convention": "ModifiedFollowing",
               "termination_date_convention": "ModifiedFollowing",
-              "date_generation_rule": "Forward"
+              "date_generation_rule": "Forward",
+              "end_of_month": false
             },
             "index": {
               "id": "USD_SOFR"

--- a/examples/data/swaption_ois_request.json
+++ b/examples/data/swaption_ois_request.json
@@ -15,7 +15,8 @@
           "tenor": {
             "n": 0,
             "unit": "Days"
-          }
+          },
+          "end_of_month": true
         }
       ],
       "curves": [
@@ -659,7 +660,8 @@
               "frequency": "Annual",
               "convention": "ModifiedFollowing",
               "termination_date_convention": "ModifiedFollowing",
-              "date_generation_rule": "Forward"
+              "date_generation_rule": "Forward",
+              "end_of_month": false
             },
             "rate": 0.03367463,
             "day_counter": "Actual360",
@@ -674,7 +676,8 @@
               "frequency": "Annual",
               "convention": "ModifiedFollowing",
               "termination_date_convention": "ModifiedFollowing",
-              "date_generation_rule": "Forward"
+              "date_generation_rule": "Forward",
+              "end_of_month": false
             },
             "index": {
               "id": "USD_SOFR"

--- a/examples/data/swaption_request.json
+++ b/examples/data/swaption_request.json
@@ -146,7 +146,8 @@
               "frequency": "Annual",
               "convention": "ModifiedFollowing",
               "termination_date_convention": "ModifiedFollowing",
-              "date_generation_rule": "Forward"
+              "date_generation_rule": "Forward",
+              "end_of_month": false
             },
             "rate": 0.035,
             "day_counter": "Thirty360",
@@ -161,7 +162,8 @@
               "frequency": "Semiannual",
               "convention": "ModifiedFollowing",
               "termination_date_convention": "ModifiedFollowing",
-              "date_generation_rule": "Forward"
+              "date_generation_rule": "Forward",
+              "end_of_month": false
             },
             "index": {
               "id": "EUR_6M"

--- a/examples/data/swaption_sabr_calibrate_request.json
+++ b/examples/data/swaption_sabr_calibrate_request.json
@@ -228,7 +228,8 @@
               "frequency": "Annual",
               "convention": "ModifiedFollowing",
               "termination_date_convention": "ModifiedFollowing",
-              "date_generation_rule": "Forward"
+              "date_generation_rule": "Forward",
+              "end_of_month": false
             },
             "rate": 0.02,
             "day_counter": "Thirty360",
@@ -243,7 +244,8 @@
               "frequency": "Semiannual",
               "convention": "ModifiedFollowing",
               "termination_date_convention": "ModifiedFollowing",
-              "date_generation_rule": "Forward"
+              "date_generation_rule": "Forward",
+              "end_of_month": false
             },
             "index": {
               "id": "EUR_6M"

--- a/examples/data/swaption_smile_cube_request.json
+++ b/examples/data/swaption_smile_cube_request.json
@@ -226,7 +226,8 @@
               "frequency": "Annual",
               "convention": "ModifiedFollowing",
               "termination_date_convention": "ModifiedFollowing",
-              "date_generation_rule": "Forward"
+              "date_generation_rule": "Forward",
+              "end_of_month": false
             },
             "rate": 0.02,
             "day_counter": "Thirty360",
@@ -241,7 +242,8 @@
               "frequency": "Semiannual",
               "convention": "ModifiedFollowing",
               "termination_date_convention": "ModifiedFollowing",
-              "date_generation_rule": "Forward"
+              "date_generation_rule": "Forward",
+              "end_of_month": false
             },
             "index": {
               "id": "EUR_6M"

--- a/examples/data/vanilla_swap_multicurve_request.json
+++ b/examples/data/vanilla_swap_multicurve_request.json
@@ -30,7 +30,8 @@
           "tenor": {
             "n": 0,
             "unit": "Days"
-          }
+          },
+          "end_of_month": true
         }
       ],
       "curves": [
@@ -64,7 +65,12 @@
                 "tenor": {
                   "n": 1,
                   "unit": "Years"
-                }
+                },
+                "settlement_days": 2,
+                "calendar": "TARGET",
+                "fixed_leg_convention": "ModifiedFollowing",
+                "fixed_leg_day_counter": "Actual360",
+                "fixed_leg_frequency": "Annual"
               }
             },
             {
@@ -77,7 +83,12 @@
                 "tenor": {
                   "n": 5,
                   "unit": "Years"
-                }
+                },
+                "settlement_days": 2,
+                "calendar": "TARGET",
+                "fixed_leg_convention": "ModifiedFollowing",
+                "fixed_leg_day_counter": "Actual360",
+                "fixed_leg_frequency": "Annual"
               }
             },
             {
@@ -90,7 +101,12 @@
                 "tenor": {
                   "n": 10,
                   "unit": "Years"
-                }
+                },
+                "settlement_days": 2,
+                "calendar": "TARGET",
+                "fixed_leg_convention": "ModifiedFollowing",
+                "fixed_leg_day_counter": "Actual360",
+                "fixed_leg_frequency": "Annual"
               }
             }
           ]

--- a/examples/data/vanilla_swap_request.json
+++ b/examples/data/vanilla_swap_request.json
@@ -112,7 +112,8 @@
             "frequency": "Annual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "rate": 0.035,
           "day_counter": "Thirty360",
@@ -127,7 +128,8 @@
             "frequency": "Semiannual",
             "convention": "ModifiedFollowing",
             "termination_date_convention": "ModifiedFollowing",
-            "date_generation_rule": "Forward"
+            "date_generation_rule": "Forward",
+            "end_of_month": false
           },
           "index": {
             "id": "EUR_6M"

--- a/examples/data/year_on_year_inflation_cap_floor_request.json
+++ b/examples/data/year_on_year_inflation_cap_floor_request.json
@@ -15,7 +15,8 @@
           "calendar": "TARGET",
           "business_day_convention": "ModifiedFollowing",
           "day_counter": "Actual360",
-          "currency": "EUR"
+          "currency": "EUR",
+          "end_of_month": true
         }
       ],
       "curves": [
@@ -364,7 +365,8 @@
           "frequency": "Annual",
           "convention": "ModifiedFollowing",
           "termination_date_convention": "ModifiedFollowing",
-          "date_generation_rule": "Forward"
+          "date_generation_rule": "Forward",
+          "end_of_month": false
         },
         "inflation_index_id": "EUHICP_YY",
         "observation_lag": {

--- a/flatbuffers/cpp/cds_generated.h
+++ b/flatbuffers/cpp/cds_generated.h
@@ -31,14 +31,14 @@ struct CDST : public ::flatbuffers::NativeTable {
   ::flatbuffers::Optional<double> upfront = ::flatbuffers::nullopt;
   ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt;
   ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt;
-  bool settles_accrual = true;
-  bool pays_at_default_time = true;
-  bool rebates_accrual = true;
+  ::flatbuffers::Optional<bool> settles_accrual = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<bool> pays_at_default_time = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<bool> rebates_accrual = ::flatbuffers::nullopt;
   std::string protection_start{};
   std::string upfront_date{};
-  quantra::enums::DayCounter last_period_day_counter = quantra::enums::DayCounter_Actual360;
+  ::flatbuffers::Optional<quantra::enums::DayCounter> last_period_day_counter = ::flatbuffers::nullopt;
   std::string trade_date{};
-  int32_t cash_settlement_days = 3;
+  ::flatbuffers::Optional<int32_t> cash_settlement_days = ::flatbuffers::nullopt;
   CDST() = default;
   CDST(const CDST &o);
   CDST(CDST&&) FLATBUFFERS_NOEXCEPT = default;
@@ -93,14 +93,16 @@ struct CDS FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention() const {
     return GetOptional<int8_t, quantra::enums::BusinessDayConvention>(VT_BUSINESS_DAY_CONVENTION);
   }
-  bool settles_accrual() const {
-    return GetField<uint8_t>(VT_SETTLES_ACCRUAL, 1) != 0;
+  /// ISDA settlement conventions. Presence-required: each is a deliberate
+  /// choice (false round-trips) so an omission is a 400, never a silent true.
+  ::flatbuffers::Optional<bool> settles_accrual() const {
+    return GetOptional<uint8_t, bool>(VT_SETTLES_ACCRUAL);
   }
-  bool pays_at_default_time() const {
-    return GetField<uint8_t>(VT_PAYS_AT_DEFAULT_TIME, 1) != 0;
+  ::flatbuffers::Optional<bool> pays_at_default_time() const {
+    return GetOptional<uint8_t, bool>(VT_PAYS_AT_DEFAULT_TIME);
   }
-  bool rebates_accrual() const {
-    return GetField<uint8_t>(VT_REBATES_ACCRUAL, 1) != 0;
+  ::flatbuffers::Optional<bool> rebates_accrual() const {
+    return GetOptional<uint8_t, bool>(VT_REBATES_ACCRUAL);
   }
   const ::flatbuffers::String *protection_start() const {
     return GetPointer<const ::flatbuffers::String *>(VT_PROTECTION_START);
@@ -108,14 +110,14 @@ struct CDS FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   const ::flatbuffers::String *upfront_date() const {
     return GetPointer<const ::flatbuffers::String *>(VT_UPFRONT_DATE);
   }
-  quantra::enums::DayCounter last_period_day_counter() const {
-    return static_cast<quantra::enums::DayCounter>(GetField<int8_t>(VT_LAST_PERIOD_DAY_COUNTER, 0));
+  ::flatbuffers::Optional<quantra::enums::DayCounter> last_period_day_counter() const {
+    return GetOptional<int8_t, quantra::enums::DayCounter>(VT_LAST_PERIOD_DAY_COUNTER);
   }
   const ::flatbuffers::String *trade_date() const {
     return GetPointer<const ::flatbuffers::String *>(VT_TRADE_DATE);
   }
-  int32_t cash_settlement_days() const {
-    return GetField<int32_t>(VT_CASH_SETTLEMENT_DAYS, 3);
+  ::flatbuffers::Optional<int32_t> cash_settlement_days() const {
+    return GetOptional<int32_t, int32_t>(VT_CASH_SETTLEMENT_DAYS);
   }
   bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -171,13 +173,13 @@ struct CDSBuilder {
     fbb_.AddElement<int8_t>(CDS::VT_BUSINESS_DAY_CONVENTION, static_cast<int8_t>(business_day_convention));
   }
   void add_settles_accrual(bool settles_accrual) {
-    fbb_.AddElement<uint8_t>(CDS::VT_SETTLES_ACCRUAL, static_cast<uint8_t>(settles_accrual), 1);
+    fbb_.AddElement<uint8_t>(CDS::VT_SETTLES_ACCRUAL, static_cast<uint8_t>(settles_accrual));
   }
   void add_pays_at_default_time(bool pays_at_default_time) {
-    fbb_.AddElement<uint8_t>(CDS::VT_PAYS_AT_DEFAULT_TIME, static_cast<uint8_t>(pays_at_default_time), 1);
+    fbb_.AddElement<uint8_t>(CDS::VT_PAYS_AT_DEFAULT_TIME, static_cast<uint8_t>(pays_at_default_time));
   }
   void add_rebates_accrual(bool rebates_accrual) {
-    fbb_.AddElement<uint8_t>(CDS::VT_REBATES_ACCRUAL, static_cast<uint8_t>(rebates_accrual), 1);
+    fbb_.AddElement<uint8_t>(CDS::VT_REBATES_ACCRUAL, static_cast<uint8_t>(rebates_accrual));
   }
   void add_protection_start(::flatbuffers::Offset<::flatbuffers::String> protection_start) {
     fbb_.AddOffset(CDS::VT_PROTECTION_START, protection_start);
@@ -186,13 +188,13 @@ struct CDSBuilder {
     fbb_.AddOffset(CDS::VT_UPFRONT_DATE, upfront_date);
   }
   void add_last_period_day_counter(quantra::enums::DayCounter last_period_day_counter) {
-    fbb_.AddElement<int8_t>(CDS::VT_LAST_PERIOD_DAY_COUNTER, static_cast<int8_t>(last_period_day_counter), 0);
+    fbb_.AddElement<int8_t>(CDS::VT_LAST_PERIOD_DAY_COUNTER, static_cast<int8_t>(last_period_day_counter));
   }
   void add_trade_date(::flatbuffers::Offset<::flatbuffers::String> trade_date) {
     fbb_.AddOffset(CDS::VT_TRADE_DATE, trade_date);
   }
   void add_cash_settlement_days(int32_t cash_settlement_days) {
-    fbb_.AddElement<int32_t>(CDS::VT_CASH_SETTLEMENT_DAYS, cash_settlement_days, 3);
+    fbb_.AddElement<int32_t>(CDS::VT_CASH_SETTLEMENT_DAYS, cash_settlement_days);
   }
   explicit CDSBuilder(::flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
@@ -214,27 +216,27 @@ inline ::flatbuffers::Offset<CDS> CreateCDS(
     ::flatbuffers::Optional<double> upfront = ::flatbuffers::nullopt,
     ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
     ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt,
-    bool settles_accrual = true,
-    bool pays_at_default_time = true,
-    bool rebates_accrual = true,
+    ::flatbuffers::Optional<bool> settles_accrual = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<bool> pays_at_default_time = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<bool> rebates_accrual = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<::flatbuffers::String> protection_start = 0,
     ::flatbuffers::Offset<::flatbuffers::String> upfront_date = 0,
-    quantra::enums::DayCounter last_period_day_counter = quantra::enums::DayCounter_Actual360,
+    ::flatbuffers::Optional<quantra::enums::DayCounter> last_period_day_counter = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<::flatbuffers::String> trade_date = 0,
-    int32_t cash_settlement_days = 3) {
+    ::flatbuffers::Optional<int32_t> cash_settlement_days = ::flatbuffers::nullopt) {
   CDSBuilder builder_(_fbb);
   if(upfront) { builder_.add_upfront(*upfront); }
   if(running_coupon) { builder_.add_running_coupon(*running_coupon); }
   if(notional) { builder_.add_notional(*notional); }
-  builder_.add_cash_settlement_days(cash_settlement_days);
+  if(cash_settlement_days) { builder_.add_cash_settlement_days(*cash_settlement_days); }
   builder_.add_trade_date(trade_date);
   builder_.add_upfront_date(upfront_date);
   builder_.add_protection_start(protection_start);
   builder_.add_schedule(schedule);
-  builder_.add_last_period_day_counter(last_period_day_counter);
-  builder_.add_rebates_accrual(rebates_accrual);
-  builder_.add_pays_at_default_time(pays_at_default_time);
-  builder_.add_settles_accrual(settles_accrual);
+  if(last_period_day_counter) { builder_.add_last_period_day_counter(*last_period_day_counter); }
+  if(rebates_accrual) { builder_.add_rebates_accrual(*rebates_accrual); }
+  if(pays_at_default_time) { builder_.add_pays_at_default_time(*pays_at_default_time); }
+  if(settles_accrual) { builder_.add_settles_accrual(*settles_accrual); }
   if(business_day_convention) { builder_.add_business_day_convention(*business_day_convention); }
   if(day_counter) { builder_.add_day_counter(*day_counter); }
   if(side) { builder_.add_side(*side); }
@@ -250,14 +252,14 @@ inline ::flatbuffers::Offset<CDS> CreateCDSDirect(
     ::flatbuffers::Optional<double> upfront = ::flatbuffers::nullopt,
     ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
     ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt,
-    bool settles_accrual = true,
-    bool pays_at_default_time = true,
-    bool rebates_accrual = true,
+    ::flatbuffers::Optional<bool> settles_accrual = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<bool> pays_at_default_time = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<bool> rebates_accrual = ::flatbuffers::nullopt,
     const char *protection_start = nullptr,
     const char *upfront_date = nullptr,
-    quantra::enums::DayCounter last_period_day_counter = quantra::enums::DayCounter_Actual360,
+    ::flatbuffers::Optional<quantra::enums::DayCounter> last_period_day_counter = ::flatbuffers::nullopt,
     const char *trade_date = nullptr,
-    int32_t cash_settlement_days = 3) {
+    ::flatbuffers::Optional<int32_t> cash_settlement_days = ::flatbuffers::nullopt) {
   auto protection_start__ = protection_start ? _fbb.CreateString(protection_start) : 0;
   auto upfront_date__ = upfront_date ? _fbb.CreateString(upfront_date) : 0;
   auto trade_date__ = trade_date ? _fbb.CreateString(trade_date) : 0;

--- a/flatbuffers/cpp/common_generated.h
+++ b/flatbuffers/cpp/common_generated.h
@@ -175,11 +175,14 @@ bool VerifyFlowVector(::flatbuffers::Verifier &verifier, const ::flatbuffers::Ve
 
 struct PeriodT : public ::flatbuffers::NativeTable {
   typedef Period TableType;
-  int32_t n = 0;
-  quantra::enums::TimeUnit unit = quantra::enums::TimeUnit_Months;
+  ::flatbuffers::Optional<int32_t> n = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::TimeUnit> unit = ::flatbuffers::nullopt;
 };
 
-/// Canonical period type used across APIs.
+/// Canonical period type used across APIs. Both fields are presence-required:
+/// a bare `n` would silently default to 0 and an omitted `unit` would silently
+/// mean Months, so a forgotten value is a 400 naming the field rather than a
+/// silent (0 Months) tenor.
 struct Period FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   typedef PeriodT NativeTableType;
   typedef PeriodBuilder Builder;
@@ -187,11 +190,11 @@ struct Period FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
     VT_N = 4,
     VT_UNIT = 6
   };
-  int32_t n() const {
-    return GetField<int32_t>(VT_N, 0);
+  ::flatbuffers::Optional<int32_t> n() const {
+    return GetOptional<int32_t, int32_t>(VT_N);
   }
-  quantra::enums::TimeUnit unit() const {
-    return static_cast<quantra::enums::TimeUnit>(GetField<int8_t>(VT_UNIT, 5));
+  ::flatbuffers::Optional<quantra::enums::TimeUnit> unit() const {
+    return GetOptional<int8_t, quantra::enums::TimeUnit>(VT_UNIT);
   }
   bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -209,10 +212,10 @@ struct PeriodBuilder {
   ::flatbuffers::FlatBufferBuilder &fbb_;
   ::flatbuffers::uoffset_t start_;
   void add_n(int32_t n) {
-    fbb_.AddElement<int32_t>(Period::VT_N, n, 0);
+    fbb_.AddElement<int32_t>(Period::VT_N, n);
   }
   void add_unit(quantra::enums::TimeUnit unit) {
-    fbb_.AddElement<int8_t>(Period::VT_UNIT, static_cast<int8_t>(unit), 5);
+    fbb_.AddElement<int8_t>(Period::VT_UNIT, static_cast<int8_t>(unit));
   }
   explicit PeriodBuilder(::flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
@@ -227,11 +230,11 @@ struct PeriodBuilder {
 
 inline ::flatbuffers::Offset<Period> CreatePeriod(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    int32_t n = 0,
-    quantra::enums::TimeUnit unit = quantra::enums::TimeUnit_Months) {
+    ::flatbuffers::Optional<int32_t> n = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::TimeUnit> unit = ::flatbuffers::nullopt) {
   PeriodBuilder builder_(_fbb);
-  builder_.add_n(n);
-  builder_.add_unit(unit);
+  if(n) { builder_.add_n(*n); }
+  if(unit) { builder_.add_unit(*unit); }
   return builder_.Finish();
 }
 

--- a/flatbuffers/cpp/credit_curve_generated.h
+++ b/flatbuffers/cpp/credit_curve_generated.h
@@ -173,18 +173,20 @@ inline ::flatbuffers::Offset<CdsQuote> CreateCdsQuoteDirect(
 
 struct CdsHelperConventionsT : public ::flatbuffers::NativeTable {
   typedef CdsHelperConventions TableType;
-  int32_t settlement_days = 0;
-  quantra::enums::Frequency frequency = quantra::enums::Frequency_Quarterly;
-  quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_Following;
-  quantra::enums::DateGenerationRule date_generation_rule = quantra::enums::DateGenerationRule_TwentiethIMM;
-  quantra::enums::DayCounter last_period_day_counter = quantra::enums::DayCounter_Actual365Fixed;
-  bool settles_accrual = true;
-  bool pays_at_default_time = true;
-  bool rebates_accrual = true;
-  quantra::enums::CdsHelperModel helper_model = quantra::enums::CdsHelperModel_MidPoint;
+  ::flatbuffers::Optional<int32_t> settlement_days = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::Frequency> frequency = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::DateGenerationRule> date_generation_rule = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::DayCounter> last_period_day_counter = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<bool> settles_accrual = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<bool> pays_at_default_time = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<bool> rebates_accrual = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::CdsHelperModel> helper_model = ::flatbuffers::nullopt;
 };
 
-/// CDS helper conventions for curve building.
+/// CDS helper conventions for curve building. Every convention is
+/// presence-required: an omitted value is a 400 naming the field, never a
+/// silent market-default assumption.
 struct CdsHelperConventions FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   typedef CdsHelperConventionsT NativeTableType;
   typedef CdsHelperConventionsBuilder Builder;
@@ -199,32 +201,32 @@ struct CdsHelperConventions FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Tab
     VT_REBATES_ACCRUAL = 18,
     VT_HELPER_MODEL = 20
   };
-  int32_t settlement_days() const {
-    return GetField<int32_t>(VT_SETTLEMENT_DAYS, 0);
+  ::flatbuffers::Optional<int32_t> settlement_days() const {
+    return GetOptional<int32_t, int32_t>(VT_SETTLEMENT_DAYS);
   }
-  quantra::enums::Frequency frequency() const {
-    return static_cast<quantra::enums::Frequency>(GetField<int8_t>(VT_FREQUENCY, 10));
+  ::flatbuffers::Optional<quantra::enums::Frequency> frequency() const {
+    return GetOptional<int8_t, quantra::enums::Frequency>(VT_FREQUENCY);
   }
-  quantra::enums::BusinessDayConvention business_day_convention() const {
-    return static_cast<quantra::enums::BusinessDayConvention>(GetField<int8_t>(VT_BUSINESS_DAY_CONVENTION, 0));
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention() const {
+    return GetOptional<int8_t, quantra::enums::BusinessDayConvention>(VT_BUSINESS_DAY_CONVENTION);
   }
-  quantra::enums::DateGenerationRule date_generation_rule() const {
-    return static_cast<quantra::enums::DateGenerationRule>(GetField<int8_t>(VT_DATE_GENERATION_RULE, 6));
+  ::flatbuffers::Optional<quantra::enums::DateGenerationRule> date_generation_rule() const {
+    return GetOptional<int8_t, quantra::enums::DateGenerationRule>(VT_DATE_GENERATION_RULE);
   }
-  quantra::enums::DayCounter last_period_day_counter() const {
-    return static_cast<quantra::enums::DayCounter>(GetField<int8_t>(VT_LAST_PERIOD_DAY_COUNTER, 1));
+  ::flatbuffers::Optional<quantra::enums::DayCounter> last_period_day_counter() const {
+    return GetOptional<int8_t, quantra::enums::DayCounter>(VT_LAST_PERIOD_DAY_COUNTER);
   }
-  bool settles_accrual() const {
-    return GetField<uint8_t>(VT_SETTLES_ACCRUAL, 1) != 0;
+  ::flatbuffers::Optional<bool> settles_accrual() const {
+    return GetOptional<uint8_t, bool>(VT_SETTLES_ACCRUAL);
   }
-  bool pays_at_default_time() const {
-    return GetField<uint8_t>(VT_PAYS_AT_DEFAULT_TIME, 1) != 0;
+  ::flatbuffers::Optional<bool> pays_at_default_time() const {
+    return GetOptional<uint8_t, bool>(VT_PAYS_AT_DEFAULT_TIME);
   }
-  bool rebates_accrual() const {
-    return GetField<uint8_t>(VT_REBATES_ACCRUAL, 1) != 0;
+  ::flatbuffers::Optional<bool> rebates_accrual() const {
+    return GetOptional<uint8_t, bool>(VT_REBATES_ACCRUAL);
   }
-  quantra::enums::CdsHelperModel helper_model() const {
-    return static_cast<quantra::enums::CdsHelperModel>(GetField<int8_t>(VT_HELPER_MODEL, 0));
+  ::flatbuffers::Optional<quantra::enums::CdsHelperModel> helper_model() const {
+    return GetOptional<int8_t, quantra::enums::CdsHelperModel>(VT_HELPER_MODEL);
   }
   bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -249,31 +251,31 @@ struct CdsHelperConventionsBuilder {
   ::flatbuffers::FlatBufferBuilder &fbb_;
   ::flatbuffers::uoffset_t start_;
   void add_settlement_days(int32_t settlement_days) {
-    fbb_.AddElement<int32_t>(CdsHelperConventions::VT_SETTLEMENT_DAYS, settlement_days, 0);
+    fbb_.AddElement<int32_t>(CdsHelperConventions::VT_SETTLEMENT_DAYS, settlement_days);
   }
   void add_frequency(quantra::enums::Frequency frequency) {
-    fbb_.AddElement<int8_t>(CdsHelperConventions::VT_FREQUENCY, static_cast<int8_t>(frequency), 10);
+    fbb_.AddElement<int8_t>(CdsHelperConventions::VT_FREQUENCY, static_cast<int8_t>(frequency));
   }
   void add_business_day_convention(quantra::enums::BusinessDayConvention business_day_convention) {
-    fbb_.AddElement<int8_t>(CdsHelperConventions::VT_BUSINESS_DAY_CONVENTION, static_cast<int8_t>(business_day_convention), 0);
+    fbb_.AddElement<int8_t>(CdsHelperConventions::VT_BUSINESS_DAY_CONVENTION, static_cast<int8_t>(business_day_convention));
   }
   void add_date_generation_rule(quantra::enums::DateGenerationRule date_generation_rule) {
-    fbb_.AddElement<int8_t>(CdsHelperConventions::VT_DATE_GENERATION_RULE, static_cast<int8_t>(date_generation_rule), 6);
+    fbb_.AddElement<int8_t>(CdsHelperConventions::VT_DATE_GENERATION_RULE, static_cast<int8_t>(date_generation_rule));
   }
   void add_last_period_day_counter(quantra::enums::DayCounter last_period_day_counter) {
-    fbb_.AddElement<int8_t>(CdsHelperConventions::VT_LAST_PERIOD_DAY_COUNTER, static_cast<int8_t>(last_period_day_counter), 1);
+    fbb_.AddElement<int8_t>(CdsHelperConventions::VT_LAST_PERIOD_DAY_COUNTER, static_cast<int8_t>(last_period_day_counter));
   }
   void add_settles_accrual(bool settles_accrual) {
-    fbb_.AddElement<uint8_t>(CdsHelperConventions::VT_SETTLES_ACCRUAL, static_cast<uint8_t>(settles_accrual), 1);
+    fbb_.AddElement<uint8_t>(CdsHelperConventions::VT_SETTLES_ACCRUAL, static_cast<uint8_t>(settles_accrual));
   }
   void add_pays_at_default_time(bool pays_at_default_time) {
-    fbb_.AddElement<uint8_t>(CdsHelperConventions::VT_PAYS_AT_DEFAULT_TIME, static_cast<uint8_t>(pays_at_default_time), 1);
+    fbb_.AddElement<uint8_t>(CdsHelperConventions::VT_PAYS_AT_DEFAULT_TIME, static_cast<uint8_t>(pays_at_default_time));
   }
   void add_rebates_accrual(bool rebates_accrual) {
-    fbb_.AddElement<uint8_t>(CdsHelperConventions::VT_REBATES_ACCRUAL, static_cast<uint8_t>(rebates_accrual), 1);
+    fbb_.AddElement<uint8_t>(CdsHelperConventions::VT_REBATES_ACCRUAL, static_cast<uint8_t>(rebates_accrual));
   }
   void add_helper_model(quantra::enums::CdsHelperModel helper_model) {
-    fbb_.AddElement<int8_t>(CdsHelperConventions::VT_HELPER_MODEL, static_cast<int8_t>(helper_model), 0);
+    fbb_.AddElement<int8_t>(CdsHelperConventions::VT_HELPER_MODEL, static_cast<int8_t>(helper_model));
   }
   explicit CdsHelperConventionsBuilder(::flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
@@ -288,25 +290,25 @@ struct CdsHelperConventionsBuilder {
 
 inline ::flatbuffers::Offset<CdsHelperConventions> CreateCdsHelperConventions(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    int32_t settlement_days = 0,
-    quantra::enums::Frequency frequency = quantra::enums::Frequency_Quarterly,
-    quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_Following,
-    quantra::enums::DateGenerationRule date_generation_rule = quantra::enums::DateGenerationRule_TwentiethIMM,
-    quantra::enums::DayCounter last_period_day_counter = quantra::enums::DayCounter_Actual365Fixed,
-    bool settles_accrual = true,
-    bool pays_at_default_time = true,
-    bool rebates_accrual = true,
-    quantra::enums::CdsHelperModel helper_model = quantra::enums::CdsHelperModel_MidPoint) {
+    ::flatbuffers::Optional<int32_t> settlement_days = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::Frequency> frequency = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::DateGenerationRule> date_generation_rule = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::DayCounter> last_period_day_counter = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<bool> settles_accrual = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<bool> pays_at_default_time = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<bool> rebates_accrual = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::CdsHelperModel> helper_model = ::flatbuffers::nullopt) {
   CdsHelperConventionsBuilder builder_(_fbb);
-  builder_.add_settlement_days(settlement_days);
-  builder_.add_helper_model(helper_model);
-  builder_.add_rebates_accrual(rebates_accrual);
-  builder_.add_pays_at_default_time(pays_at_default_time);
-  builder_.add_settles_accrual(settles_accrual);
-  builder_.add_last_period_day_counter(last_period_day_counter);
-  builder_.add_date_generation_rule(date_generation_rule);
-  builder_.add_business_day_convention(business_day_convention);
-  builder_.add_frequency(frequency);
+  if(settlement_days) { builder_.add_settlement_days(*settlement_days); }
+  if(helper_model) { builder_.add_helper_model(*helper_model); }
+  if(rebates_accrual) { builder_.add_rebates_accrual(*rebates_accrual); }
+  if(pays_at_default_time) { builder_.add_pays_at_default_time(*pays_at_default_time); }
+  if(settles_accrual) { builder_.add_settles_accrual(*settles_accrual); }
+  if(last_period_day_counter) { builder_.add_last_period_day_counter(*last_period_day_counter); }
+  if(date_generation_rule) { builder_.add_date_generation_rule(*date_generation_rule); }
+  if(business_day_convention) { builder_.add_business_day_convention(*business_day_convention); }
+  if(frequency) { builder_.add_frequency(*frequency); }
   return builder_.Finish();
 }
 
@@ -316,10 +318,10 @@ struct CreditCurveSpecT : public ::flatbuffers::NativeTable {
   typedef CreditCurveSpec TableType;
   std::string id{};
   std::string reference_date{};
-  quantra::enums::Calendar calendar = quantra::enums::Calendar_NullCalendar;
-  quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual365Fixed;
-  double recovery_rate = 0.4;
-  quantra::enums::Interpolator curve_interpolator = quantra::enums::Interpolator_LogLinear;
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<double> recovery_rate = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::Interpolator> curve_interpolator = ::flatbuffers::nullopt;
   std::unique_ptr<quantra::CdsHelperConventionsT> helper_conventions{};
   std::vector<std::unique_ptr<quantra::CdsQuoteT>> quotes{};
   ::flatbuffers::Optional<double> flat_hazard_rate = ::flatbuffers::nullopt;
@@ -350,17 +352,17 @@ struct CreditCurveSpec FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   const ::flatbuffers::String *reference_date() const {
     return GetPointer<const ::flatbuffers::String *>(VT_REFERENCE_DATE);
   }
-  quantra::enums::Calendar calendar() const {
-    return static_cast<quantra::enums::Calendar>(GetField<int8_t>(VT_CALENDAR, 21));
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar() const {
+    return GetOptional<int8_t, quantra::enums::Calendar>(VT_CALENDAR);
   }
-  quantra::enums::DayCounter day_counter() const {
-    return static_cast<quantra::enums::DayCounter>(GetField<int8_t>(VT_DAY_COUNTER, 1));
+  ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter() const {
+    return GetOptional<int8_t, quantra::enums::DayCounter>(VT_DAY_COUNTER);
   }
-  double recovery_rate() const {
-    return GetField<double>(VT_RECOVERY_RATE, 0.4);
+  ::flatbuffers::Optional<double> recovery_rate() const {
+    return GetOptional<double, double>(VT_RECOVERY_RATE);
   }
-  quantra::enums::Interpolator curve_interpolator() const {
-    return static_cast<quantra::enums::Interpolator>(GetField<int8_t>(VT_CURVE_INTERPOLATOR, 4));
+  ::flatbuffers::Optional<quantra::enums::Interpolator> curve_interpolator() const {
+    return GetOptional<int8_t, quantra::enums::Interpolator>(VT_CURVE_INTERPOLATOR);
   }
   const quantra::CdsHelperConventions *helper_conventions() const {
     return GetPointer<const quantra::CdsHelperConventions *>(VT_HELPER_CONVENTIONS);
@@ -409,16 +411,16 @@ struct CreditCurveSpecBuilder {
     fbb_.AddOffset(CreditCurveSpec::VT_REFERENCE_DATE, reference_date);
   }
   void add_calendar(quantra::enums::Calendar calendar) {
-    fbb_.AddElement<int8_t>(CreditCurveSpec::VT_CALENDAR, static_cast<int8_t>(calendar), 21);
+    fbb_.AddElement<int8_t>(CreditCurveSpec::VT_CALENDAR, static_cast<int8_t>(calendar));
   }
   void add_day_counter(quantra::enums::DayCounter day_counter) {
-    fbb_.AddElement<int8_t>(CreditCurveSpec::VT_DAY_COUNTER, static_cast<int8_t>(day_counter), 1);
+    fbb_.AddElement<int8_t>(CreditCurveSpec::VT_DAY_COUNTER, static_cast<int8_t>(day_counter));
   }
   void add_recovery_rate(double recovery_rate) {
-    fbb_.AddElement<double>(CreditCurveSpec::VT_RECOVERY_RATE, recovery_rate, 0.4);
+    fbb_.AddElement<double>(CreditCurveSpec::VT_RECOVERY_RATE, recovery_rate);
   }
   void add_curve_interpolator(quantra::enums::Interpolator curve_interpolator) {
-    fbb_.AddElement<int8_t>(CreditCurveSpec::VT_CURVE_INTERPOLATOR, static_cast<int8_t>(curve_interpolator), 4);
+    fbb_.AddElement<int8_t>(CreditCurveSpec::VT_CURVE_INTERPOLATOR, static_cast<int8_t>(curve_interpolator));
   }
   void add_helper_conventions(::flatbuffers::Offset<quantra::CdsHelperConventions> helper_conventions) {
     fbb_.AddOffset(CreditCurveSpec::VT_HELPER_CONVENTIONS, helper_conventions);
@@ -446,23 +448,23 @@ inline ::flatbuffers::Offset<CreditCurveSpec> CreateCreditCurveSpec(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     ::flatbuffers::Offset<::flatbuffers::String> id = 0,
     ::flatbuffers::Offset<::flatbuffers::String> reference_date = 0,
-    quantra::enums::Calendar calendar = quantra::enums::Calendar_NullCalendar,
-    quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual365Fixed,
-    double recovery_rate = 0.4,
-    quantra::enums::Interpolator curve_interpolator = quantra::enums::Interpolator_LogLinear,
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<double> recovery_rate = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::Interpolator> curve_interpolator = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::CdsHelperConventions> helper_conventions = 0,
     ::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<quantra::CdsQuote>>> quotes = 0,
     ::flatbuffers::Optional<double> flat_hazard_rate = ::flatbuffers::nullopt) {
   CreditCurveSpecBuilder builder_(_fbb);
   if(flat_hazard_rate) { builder_.add_flat_hazard_rate(*flat_hazard_rate); }
-  builder_.add_recovery_rate(recovery_rate);
+  if(recovery_rate) { builder_.add_recovery_rate(*recovery_rate); }
   builder_.add_quotes(quotes);
   builder_.add_helper_conventions(helper_conventions);
   builder_.add_reference_date(reference_date);
   builder_.add_id(id);
-  builder_.add_curve_interpolator(curve_interpolator);
-  builder_.add_day_counter(day_counter);
-  builder_.add_calendar(calendar);
+  if(curve_interpolator) { builder_.add_curve_interpolator(*curve_interpolator); }
+  if(day_counter) { builder_.add_day_counter(*day_counter); }
+  if(calendar) { builder_.add_calendar(*calendar); }
   return builder_.Finish();
 }
 
@@ -470,10 +472,10 @@ inline ::flatbuffers::Offset<CreditCurveSpec> CreateCreditCurveSpecDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     const char *id = nullptr,
     const char *reference_date = nullptr,
-    quantra::enums::Calendar calendar = quantra::enums::Calendar_NullCalendar,
-    quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual365Fixed,
-    double recovery_rate = 0.4,
-    quantra::enums::Interpolator curve_interpolator = quantra::enums::Interpolator_LogLinear,
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<double> recovery_rate = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::Interpolator> curve_interpolator = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::CdsHelperConventions> helper_conventions = 0,
     const std::vector<::flatbuffers::Offset<quantra::CdsQuote>> *quotes = nullptr,
     ::flatbuffers::Optional<double> flat_hazard_rate = ::flatbuffers::nullopt) {

--- a/flatbuffers/cpp/index_generated.h
+++ b/flatbuffers/cpp/index_generated.h
@@ -142,13 +142,13 @@ struct IndexDefT : public ::flatbuffers::NativeTable {
   typedef IndexDef TableType;
   std::string id{};
   std::string name{};
-  quantra::IndexType index_type = quantra::IndexType_Ibor;
+  ::flatbuffers::Optional<quantra::IndexType> index_type = ::flatbuffers::nullopt;
   std::unique_ptr<quantra::PeriodT> tenor{};
-  int32_t fixing_days = 2;
-  quantra::enums::Calendar calendar = quantra::enums::Calendar_TARGET;
-  quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_ModifiedFollowing;
-  quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360;
-  bool end_of_month = true;
+  ::flatbuffers::Optional<int32_t> fixing_days = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<bool> end_of_month = ::flatbuffers::nullopt;
   std::string currency{};
   std::vector<std::unique_ptr<quantra::FixingT>> fixings{};
   IndexDefT() = default;
@@ -182,33 +182,35 @@ struct IndexDef FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   const ::flatbuffers::String *name() const {
     return GetPointer<const ::flatbuffers::String *>(VT_NAME);
   }
-  /// IBOR or Overnight. Determines QuantLib class used.
-  quantra::IndexType index_type() const {
-    return static_cast<quantra::IndexType>(GetField<int8_t>(VT_INDEX_TYPE, 0));
+  /// IBOR or Overnight. Determines QuantLib class used. Presence-required: an
+  /// omitted value is a 400, never the silent Ibor default.
+  ::flatbuffers::Optional<quantra::IndexType> index_type() const {
+    return GetOptional<int8_t, quantra::IndexType>(VT_INDEX_TYPE);
   }
   /// Tenor period (e.g., 6 Months for Euribor 6M, 0 Days for overnight).
   const quantra::Period *tenor() const {
     return GetPointer<const quantra::Period *>(VT_TENOR);
   }
-  /// Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR).
-  int32_t fixing_days() const {
-    return GetField<int32_t>(VT_FIXING_DAYS, 2);
+  /// Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR). Presence-required.
+  ::flatbuffers::Optional<int32_t> fixing_days() const {
+    return GetOptional<int32_t, int32_t>(VT_FIXING_DAYS);
   }
-  /// Calendar for fixing/payment dates.
-  quantra::enums::Calendar calendar() const {
-    return static_cast<quantra::enums::Calendar>(GetField<int8_t>(VT_CALENDAR, 32));
+  /// Calendar for fixing/payment dates. Presence-required.
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar() const {
+    return GetOptional<int8_t, quantra::enums::Calendar>(VT_CALENDAR);
   }
-  /// Business day convention.
-  quantra::enums::BusinessDayConvention business_day_convention() const {
-    return static_cast<quantra::enums::BusinessDayConvention>(GetField<int8_t>(VT_BUSINESS_DAY_CONVENTION, 2));
+  /// Business day convention. Presence-required.
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention() const {
+    return GetOptional<int8_t, quantra::enums::BusinessDayConvention>(VT_BUSINESS_DAY_CONVENTION);
   }
-  /// Day count convention.
-  quantra::enums::DayCounter day_counter() const {
-    return static_cast<quantra::enums::DayCounter>(GetField<int8_t>(VT_DAY_COUNTER, 0));
+  /// Day count convention. Presence-required.
+  ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter() const {
+    return GetOptional<int8_t, quantra::enums::DayCounter>(VT_DAY_COUNTER);
   }
-  /// End of month rule (IBOR only, ignored for overnight).
-  bool end_of_month() const {
-    return GetField<uint8_t>(VT_END_OF_MONTH, 1) != 0;
+  /// End of month rule (IBOR only, ignored for overnight). Presence-required:
+  /// absent-vs-false silently changes money-market schedule dates.
+  ::flatbuffers::Optional<bool> end_of_month() const {
+    return GetOptional<uint8_t, bool>(VT_END_OF_MONTH);
   }
   /// ISO currency code (e.g., "EUR", "USD", "GBP", "JPY").
   const ::flatbuffers::String *currency() const {
@@ -255,25 +257,25 @@ struct IndexDefBuilder {
     fbb_.AddOffset(IndexDef::VT_NAME, name);
   }
   void add_index_type(quantra::IndexType index_type) {
-    fbb_.AddElement<int8_t>(IndexDef::VT_INDEX_TYPE, static_cast<int8_t>(index_type), 0);
+    fbb_.AddElement<int8_t>(IndexDef::VT_INDEX_TYPE, static_cast<int8_t>(index_type));
   }
   void add_tenor(::flatbuffers::Offset<quantra::Period> tenor) {
     fbb_.AddOffset(IndexDef::VT_TENOR, tenor);
   }
   void add_fixing_days(int32_t fixing_days) {
-    fbb_.AddElement<int32_t>(IndexDef::VT_FIXING_DAYS, fixing_days, 2);
+    fbb_.AddElement<int32_t>(IndexDef::VT_FIXING_DAYS, fixing_days);
   }
   void add_calendar(quantra::enums::Calendar calendar) {
-    fbb_.AddElement<int8_t>(IndexDef::VT_CALENDAR, static_cast<int8_t>(calendar), 32);
+    fbb_.AddElement<int8_t>(IndexDef::VT_CALENDAR, static_cast<int8_t>(calendar));
   }
   void add_business_day_convention(quantra::enums::BusinessDayConvention business_day_convention) {
-    fbb_.AddElement<int8_t>(IndexDef::VT_BUSINESS_DAY_CONVENTION, static_cast<int8_t>(business_day_convention), 2);
+    fbb_.AddElement<int8_t>(IndexDef::VT_BUSINESS_DAY_CONVENTION, static_cast<int8_t>(business_day_convention));
   }
   void add_day_counter(quantra::enums::DayCounter day_counter) {
-    fbb_.AddElement<int8_t>(IndexDef::VT_DAY_COUNTER, static_cast<int8_t>(day_counter), 0);
+    fbb_.AddElement<int8_t>(IndexDef::VT_DAY_COUNTER, static_cast<int8_t>(day_counter));
   }
   void add_end_of_month(bool end_of_month) {
-    fbb_.AddElement<uint8_t>(IndexDef::VT_END_OF_MONTH, static_cast<uint8_t>(end_of_month), 1);
+    fbb_.AddElement<uint8_t>(IndexDef::VT_END_OF_MONTH, static_cast<uint8_t>(end_of_month));
   }
   void add_currency(::flatbuffers::Offset<::flatbuffers::String> currency) {
     fbb_.AddOffset(IndexDef::VT_CURRENCY, currency);
@@ -298,27 +300,27 @@ inline ::flatbuffers::Offset<IndexDef> CreateIndexDef(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     ::flatbuffers::Offset<::flatbuffers::String> id = 0,
     ::flatbuffers::Offset<::flatbuffers::String> name = 0,
-    quantra::IndexType index_type = quantra::IndexType_Ibor,
+    ::flatbuffers::Optional<quantra::IndexType> index_type = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::Period> tenor = 0,
-    int32_t fixing_days = 2,
-    quantra::enums::Calendar calendar = quantra::enums::Calendar_TARGET,
-    quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_ModifiedFollowing,
-    quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360,
-    bool end_of_month = true,
+    ::flatbuffers::Optional<int32_t> fixing_days = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<bool> end_of_month = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<::flatbuffers::String> currency = 0,
     ::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<quantra::Fixing>>> fixings = 0) {
   IndexDefBuilder builder_(_fbb);
   builder_.add_fixings(fixings);
   builder_.add_currency(currency);
-  builder_.add_fixing_days(fixing_days);
+  if(fixing_days) { builder_.add_fixing_days(*fixing_days); }
   builder_.add_tenor(tenor);
   builder_.add_name(name);
   builder_.add_id(id);
-  builder_.add_end_of_month(end_of_month);
-  builder_.add_day_counter(day_counter);
-  builder_.add_business_day_convention(business_day_convention);
-  builder_.add_calendar(calendar);
-  builder_.add_index_type(index_type);
+  if(end_of_month) { builder_.add_end_of_month(*end_of_month); }
+  if(day_counter) { builder_.add_day_counter(*day_counter); }
+  if(business_day_convention) { builder_.add_business_day_convention(*business_day_convention); }
+  if(calendar) { builder_.add_calendar(*calendar); }
+  if(index_type) { builder_.add_index_type(*index_type); }
   return builder_.Finish();
 }
 
@@ -326,13 +328,13 @@ inline ::flatbuffers::Offset<IndexDef> CreateIndexDefDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     const char *id = nullptr,
     const char *name = nullptr,
-    quantra::IndexType index_type = quantra::IndexType_Ibor,
+    ::flatbuffers::Optional<quantra::IndexType> index_type = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::Period> tenor = 0,
-    int32_t fixing_days = 2,
-    quantra::enums::Calendar calendar = quantra::enums::Calendar_TARGET,
-    quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_ModifiedFollowing,
-    quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual360,
-    bool end_of_month = true,
+    ::flatbuffers::Optional<int32_t> fixing_days = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<bool> end_of_month = ::flatbuffers::nullopt,
     const char *currency = nullptr,
     const std::vector<::flatbuffers::Offset<quantra::Fixing>> *fixings = nullptr) {
   auto id__ = id ? _fbb.CreateString(id) : 0;

--- a/flatbuffers/cpp/inflation_generated.h
+++ b/flatbuffers/cpp/inflation_generated.h
@@ -154,14 +154,14 @@ struct InflationIndexSpecT : public ::flatbuffers::NativeTable {
   std::string id{};
   std::string family_name{};
   std::string currency{};
-  quantra::enums::Calendar calendar = quantra::enums::Calendar_TARGET;
-  quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual365Fixed;
-  quantra::enums::Frequency frequency = quantra::enums::Frequency_Monthly;
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::Frequency> frequency = ::flatbuffers::nullopt;
   std::unique_ptr<quantra::PeriodT> availability_lag{};
   std::unique_ptr<quantra::PeriodT> observation_lag{};
-  bool interpolated = true;
-  bool revised = false;
-  quantra::enums::InflationCurveKind kind = quantra::enums::InflationCurveKind_ZeroInflation;
+  ::flatbuffers::Optional<bool> interpolated = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<bool> revised = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::InflationCurveKind> kind = ::flatbuffers::nullopt;
   std::string underlying_zero_index_id{};
   std::vector<std::unique_ptr<quantra::FixingT>> fixings{};
   InflationIndexSpecT() = default;
@@ -201,14 +201,14 @@ struct InflationIndexSpec FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table
   const ::flatbuffers::String *currency() const {
     return GetPointer<const ::flatbuffers::String *>(VT_CURRENCY);
   }
-  quantra::enums::Calendar calendar() const {
-    return static_cast<quantra::enums::Calendar>(GetField<int8_t>(VT_CALENDAR, 32));
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar() const {
+    return GetOptional<int8_t, quantra::enums::Calendar>(VT_CALENDAR);
   }
-  quantra::enums::DayCounter day_counter() const {
-    return static_cast<quantra::enums::DayCounter>(GetField<int8_t>(VT_DAY_COUNTER, 1));
+  ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter() const {
+    return GetOptional<int8_t, quantra::enums::DayCounter>(VT_DAY_COUNTER);
   }
-  quantra::enums::Frequency frequency() const {
-    return static_cast<quantra::enums::Frequency>(GetField<int8_t>(VT_FREQUENCY, 6));
+  ::flatbuffers::Optional<quantra::enums::Frequency> frequency() const {
+    return GetOptional<int8_t, quantra::enums::Frequency>(VT_FREQUENCY);
   }
   /// Publication availability lag (e.g., 2 Months).
   const quantra::Period *availability_lag() const {
@@ -218,16 +218,17 @@ struct InflationIndexSpec FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table
   const quantra::Period *observation_lag() const {
     return GetPointer<const quantra::Period *>(VT_OBSERVATION_LAG);
   }
-  /// Whether the index is interpolated between fixings.
-  bool interpolated() const {
-    return GetField<uint8_t>(VT_INTERPOLATED, 1) != 0;
+  /// Whether the index is interpolated between fixings. Presence-required:
+  /// absent-vs-false silently changes the observed CPI.
+  ::flatbuffers::Optional<bool> interpolated() const {
+    return GetOptional<uint8_t, bool>(VT_INTERPOLATED);
   }
-  /// Whether index values can be revised (rare; defaults to false).
-  bool revised() const {
-    return GetField<uint8_t>(VT_REVISED, 0) != 0;
+  /// Whether index values can be revised (rare). Presence-required.
+  ::flatbuffers::Optional<bool> revised() const {
+    return GetOptional<uint8_t, bool>(VT_REVISED);
   }
-  quantra::enums::InflationCurveKind kind() const {
-    return static_cast<quantra::enums::InflationCurveKind>(GetField<int8_t>(VT_KIND, 0));
+  ::flatbuffers::Optional<quantra::enums::InflationCurveKind> kind() const {
+    return GetOptional<int8_t, quantra::enums::InflationCurveKind>(VT_KIND);
   }
   /// For ratio-based YoY indices, link to the underlying zero inflation index id.
   const ::flatbuffers::String *underlying_zero_index_id() const {
@@ -281,13 +282,13 @@ struct InflationIndexSpecBuilder {
     fbb_.AddOffset(InflationIndexSpec::VT_CURRENCY, currency);
   }
   void add_calendar(quantra::enums::Calendar calendar) {
-    fbb_.AddElement<int8_t>(InflationIndexSpec::VT_CALENDAR, static_cast<int8_t>(calendar), 32);
+    fbb_.AddElement<int8_t>(InflationIndexSpec::VT_CALENDAR, static_cast<int8_t>(calendar));
   }
   void add_day_counter(quantra::enums::DayCounter day_counter) {
-    fbb_.AddElement<int8_t>(InflationIndexSpec::VT_DAY_COUNTER, static_cast<int8_t>(day_counter), 1);
+    fbb_.AddElement<int8_t>(InflationIndexSpec::VT_DAY_COUNTER, static_cast<int8_t>(day_counter));
   }
   void add_frequency(quantra::enums::Frequency frequency) {
-    fbb_.AddElement<int8_t>(InflationIndexSpec::VT_FREQUENCY, static_cast<int8_t>(frequency), 6);
+    fbb_.AddElement<int8_t>(InflationIndexSpec::VT_FREQUENCY, static_cast<int8_t>(frequency));
   }
   void add_availability_lag(::flatbuffers::Offset<quantra::Period> availability_lag) {
     fbb_.AddOffset(InflationIndexSpec::VT_AVAILABILITY_LAG, availability_lag);
@@ -296,13 +297,13 @@ struct InflationIndexSpecBuilder {
     fbb_.AddOffset(InflationIndexSpec::VT_OBSERVATION_LAG, observation_lag);
   }
   void add_interpolated(bool interpolated) {
-    fbb_.AddElement<uint8_t>(InflationIndexSpec::VT_INTERPOLATED, static_cast<uint8_t>(interpolated), 1);
+    fbb_.AddElement<uint8_t>(InflationIndexSpec::VT_INTERPOLATED, static_cast<uint8_t>(interpolated));
   }
   void add_revised(bool revised) {
-    fbb_.AddElement<uint8_t>(InflationIndexSpec::VT_REVISED, static_cast<uint8_t>(revised), 0);
+    fbb_.AddElement<uint8_t>(InflationIndexSpec::VT_REVISED, static_cast<uint8_t>(revised));
   }
   void add_kind(quantra::enums::InflationCurveKind kind) {
-    fbb_.AddElement<int8_t>(InflationIndexSpec::VT_KIND, static_cast<int8_t>(kind), 0);
+    fbb_.AddElement<int8_t>(InflationIndexSpec::VT_KIND, static_cast<int8_t>(kind));
   }
   void add_underlying_zero_index_id(::flatbuffers::Offset<::flatbuffers::String> underlying_zero_index_id) {
     fbb_.AddOffset(InflationIndexSpec::VT_UNDERLYING_ZERO_INDEX_ID, underlying_zero_index_id);
@@ -327,14 +328,14 @@ inline ::flatbuffers::Offset<InflationIndexSpec> CreateInflationIndexSpec(
     ::flatbuffers::Offset<::flatbuffers::String> id = 0,
     ::flatbuffers::Offset<::flatbuffers::String> family_name = 0,
     ::flatbuffers::Offset<::flatbuffers::String> currency = 0,
-    quantra::enums::Calendar calendar = quantra::enums::Calendar_TARGET,
-    quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual365Fixed,
-    quantra::enums::Frequency frequency = quantra::enums::Frequency_Monthly,
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::Frequency> frequency = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::Period> availability_lag = 0,
     ::flatbuffers::Offset<quantra::Period> observation_lag = 0,
-    bool interpolated = true,
-    bool revised = false,
-    quantra::enums::InflationCurveKind kind = quantra::enums::InflationCurveKind_ZeroInflation,
+    ::flatbuffers::Optional<bool> interpolated = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<bool> revised = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::InflationCurveKind> kind = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<::flatbuffers::String> underlying_zero_index_id = 0,
     ::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<quantra::Fixing>>> fixings = 0) {
   InflationIndexSpecBuilder builder_(_fbb);
@@ -345,12 +346,12 @@ inline ::flatbuffers::Offset<InflationIndexSpec> CreateInflationIndexSpec(
   builder_.add_currency(currency);
   builder_.add_family_name(family_name);
   builder_.add_id(id);
-  builder_.add_kind(kind);
-  builder_.add_revised(revised);
-  builder_.add_interpolated(interpolated);
-  builder_.add_frequency(frequency);
-  builder_.add_day_counter(day_counter);
-  builder_.add_calendar(calendar);
+  if(kind) { builder_.add_kind(*kind); }
+  if(revised) { builder_.add_revised(*revised); }
+  if(interpolated) { builder_.add_interpolated(*interpolated); }
+  if(frequency) { builder_.add_frequency(*frequency); }
+  if(day_counter) { builder_.add_day_counter(*day_counter); }
+  if(calendar) { builder_.add_calendar(*calendar); }
   return builder_.Finish();
 }
 
@@ -359,14 +360,14 @@ inline ::flatbuffers::Offset<InflationIndexSpec> CreateInflationIndexSpecDirect(
     const char *id = nullptr,
     const char *family_name = nullptr,
     const char *currency = nullptr,
-    quantra::enums::Calendar calendar = quantra::enums::Calendar_TARGET,
-    quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual365Fixed,
-    quantra::enums::Frequency frequency = quantra::enums::Frequency_Monthly,
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::Frequency> frequency = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::Period> availability_lag = 0,
     ::flatbuffers::Offset<quantra::Period> observation_lag = 0,
-    bool interpolated = true,
-    bool revised = false,
-    quantra::enums::InflationCurveKind kind = quantra::enums::InflationCurveKind_ZeroInflation,
+    ::flatbuffers::Optional<bool> interpolated = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<bool> revised = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::InflationCurveKind> kind = ::flatbuffers::nullopt,
     const char *underlying_zero_index_id = nullptr,
     const std::vector<::flatbuffers::Offset<quantra::Fixing>> *fixings = nullptr) {
   auto id__ = id ? _fbb.CreateString(id) : 0;
@@ -401,10 +402,10 @@ struct ZeroCouponInflationSwapHelperT : public ::flatbuffers::NativeTable {
   std::unique_ptr<quantra::PeriodT> tenor{};
   std::string start_date{};
   std::string end_date{};
-  quantra::enums::Calendar calendar = quantra::enums::Calendar_TARGET;
-  quantra::enums::BusinessDayConvention payment_convention = quantra::enums::BusinessDayConvention_ModifiedFollowing;
-  quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual365Fixed;
-  quantra::enums::CPIInterpolationType observation_interpolation = quantra::enums::CPIInterpolationType_AsIndex;
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> payment_convention = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::CPIInterpolationType> observation_interpolation = ::flatbuffers::nullopt;
   ZeroCouponInflationSwapHelperT() = default;
   ZeroCouponInflationSwapHelperT(const ZeroCouponInflationSwapHelperT &o);
   ZeroCouponInflationSwapHelperT(ZeroCouponInflationSwapHelperT&&) FLATBUFFERS_NOEXCEPT = default;
@@ -453,17 +454,17 @@ struct ZeroCouponInflationSwapHelper FLATBUFFERS_FINAL_CLASS : private ::flatbuf
   const ::flatbuffers::String *end_date() const {
     return GetPointer<const ::flatbuffers::String *>(VT_END_DATE);
   }
-  quantra::enums::Calendar calendar() const {
-    return static_cast<quantra::enums::Calendar>(GetField<int8_t>(VT_CALENDAR, 32));
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar() const {
+    return GetOptional<int8_t, quantra::enums::Calendar>(VT_CALENDAR);
   }
-  quantra::enums::BusinessDayConvention payment_convention() const {
-    return static_cast<quantra::enums::BusinessDayConvention>(GetField<int8_t>(VT_PAYMENT_CONVENTION, 2));
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> payment_convention() const {
+    return GetOptional<int8_t, quantra::enums::BusinessDayConvention>(VT_PAYMENT_CONVENTION);
   }
-  quantra::enums::DayCounter day_counter() const {
-    return static_cast<quantra::enums::DayCounter>(GetField<int8_t>(VT_DAY_COUNTER, 1));
+  ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter() const {
+    return GetOptional<int8_t, quantra::enums::DayCounter>(VT_DAY_COUNTER);
   }
-  quantra::enums::CPIInterpolationType observation_interpolation() const {
-    return static_cast<quantra::enums::CPIInterpolationType>(GetField<int8_t>(VT_OBSERVATION_INTERPOLATION, 0));
+  ::flatbuffers::Optional<quantra::enums::CPIInterpolationType> observation_interpolation() const {
+    return GetOptional<int8_t, quantra::enums::CPIInterpolationType>(VT_OBSERVATION_INTERPOLATION);
   }
   bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -512,16 +513,16 @@ struct ZeroCouponInflationSwapHelperBuilder {
     fbb_.AddOffset(ZeroCouponInflationSwapHelper::VT_END_DATE, end_date);
   }
   void add_calendar(quantra::enums::Calendar calendar) {
-    fbb_.AddElement<int8_t>(ZeroCouponInflationSwapHelper::VT_CALENDAR, static_cast<int8_t>(calendar), 32);
+    fbb_.AddElement<int8_t>(ZeroCouponInflationSwapHelper::VT_CALENDAR, static_cast<int8_t>(calendar));
   }
   void add_payment_convention(quantra::enums::BusinessDayConvention payment_convention) {
-    fbb_.AddElement<int8_t>(ZeroCouponInflationSwapHelper::VT_PAYMENT_CONVENTION, static_cast<int8_t>(payment_convention), 2);
+    fbb_.AddElement<int8_t>(ZeroCouponInflationSwapHelper::VT_PAYMENT_CONVENTION, static_cast<int8_t>(payment_convention));
   }
   void add_day_counter(quantra::enums::DayCounter day_counter) {
-    fbb_.AddElement<int8_t>(ZeroCouponInflationSwapHelper::VT_DAY_COUNTER, static_cast<int8_t>(day_counter), 1);
+    fbb_.AddElement<int8_t>(ZeroCouponInflationSwapHelper::VT_DAY_COUNTER, static_cast<int8_t>(day_counter));
   }
   void add_observation_interpolation(quantra::enums::CPIInterpolationType observation_interpolation) {
-    fbb_.AddElement<int8_t>(ZeroCouponInflationSwapHelper::VT_OBSERVATION_INTERPOLATION, static_cast<int8_t>(observation_interpolation), 0);
+    fbb_.AddElement<int8_t>(ZeroCouponInflationSwapHelper::VT_OBSERVATION_INTERPOLATION, static_cast<int8_t>(observation_interpolation));
   }
   explicit ZeroCouponInflationSwapHelperBuilder(::flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
@@ -543,10 +544,10 @@ inline ::flatbuffers::Offset<ZeroCouponInflationSwapHelper> CreateZeroCouponInfl
     ::flatbuffers::Offset<quantra::Period> tenor = 0,
     ::flatbuffers::Offset<::flatbuffers::String> start_date = 0,
     ::flatbuffers::Offset<::flatbuffers::String> end_date = 0,
-    quantra::enums::Calendar calendar = quantra::enums::Calendar_TARGET,
-    quantra::enums::BusinessDayConvention payment_convention = quantra::enums::BusinessDayConvention_ModifiedFollowing,
-    quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual365Fixed,
-    quantra::enums::CPIInterpolationType observation_interpolation = quantra::enums::CPIInterpolationType_AsIndex) {
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> payment_convention = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::CPIInterpolationType> observation_interpolation = ::flatbuffers::nullopt) {
   ZeroCouponInflationSwapHelperBuilder builder_(_fbb);
   if(quote_value) { builder_.add_quote_value(*quote_value); }
   builder_.add_end_date(end_date);
@@ -554,10 +555,10 @@ inline ::flatbuffers::Offset<ZeroCouponInflationSwapHelper> CreateZeroCouponInfl
   builder_.add_tenor(tenor);
   builder_.add_swap_observation_lag(swap_observation_lag);
   builder_.add_quote_id(quote_id);
-  builder_.add_observation_interpolation(observation_interpolation);
-  builder_.add_day_counter(day_counter);
-  builder_.add_payment_convention(payment_convention);
-  builder_.add_calendar(calendar);
+  if(observation_interpolation) { builder_.add_observation_interpolation(*observation_interpolation); }
+  if(day_counter) { builder_.add_day_counter(*day_counter); }
+  if(payment_convention) { builder_.add_payment_convention(*payment_convention); }
+  if(calendar) { builder_.add_calendar(*calendar); }
   return builder_.Finish();
 }
 
@@ -569,10 +570,10 @@ inline ::flatbuffers::Offset<ZeroCouponInflationSwapHelper> CreateZeroCouponInfl
     ::flatbuffers::Offset<quantra::Period> tenor = 0,
     const char *start_date = nullptr,
     const char *end_date = nullptr,
-    quantra::enums::Calendar calendar = quantra::enums::Calendar_TARGET,
-    quantra::enums::BusinessDayConvention payment_convention = quantra::enums::BusinessDayConvention_ModifiedFollowing,
-    quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual365Fixed,
-    quantra::enums::CPIInterpolationType observation_interpolation = quantra::enums::CPIInterpolationType_AsIndex) {
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> payment_convention = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::CPIInterpolationType> observation_interpolation = ::flatbuffers::nullopt) {
   auto quote_id__ = quote_id ? _fbb.CreateString(quote_id) : 0;
   auto start_date__ = start_date ? _fbb.CreateString(start_date) : 0;
   auto end_date__ = end_date ? _fbb.CreateString(end_date) : 0;
@@ -600,10 +601,10 @@ struct YearOnYearInflationSwapHelperT : public ::flatbuffers::NativeTable {
   std::unique_ptr<quantra::PeriodT> tenor{};
   std::string start_date{};
   std::string end_date{};
-  quantra::enums::Calendar calendar = quantra::enums::Calendar_TARGET;
-  quantra::enums::BusinessDayConvention payment_convention = quantra::enums::BusinessDayConvention_ModifiedFollowing;
-  quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual365Fixed;
-  quantra::enums::CPIInterpolationType observation_interpolation = quantra::enums::CPIInterpolationType_AsIndex;
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> payment_convention = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::CPIInterpolationType> observation_interpolation = ::flatbuffers::nullopt;
   std::string nominal_curve_id{};
   YearOnYearInflationSwapHelperT() = default;
   YearOnYearInflationSwapHelperT(const YearOnYearInflationSwapHelperT &o);
@@ -650,17 +651,17 @@ struct YearOnYearInflationSwapHelper FLATBUFFERS_FINAL_CLASS : private ::flatbuf
   const ::flatbuffers::String *end_date() const {
     return GetPointer<const ::flatbuffers::String *>(VT_END_DATE);
   }
-  quantra::enums::Calendar calendar() const {
-    return static_cast<quantra::enums::Calendar>(GetField<int8_t>(VT_CALENDAR, 32));
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar() const {
+    return GetOptional<int8_t, quantra::enums::Calendar>(VT_CALENDAR);
   }
-  quantra::enums::BusinessDayConvention payment_convention() const {
-    return static_cast<quantra::enums::BusinessDayConvention>(GetField<int8_t>(VT_PAYMENT_CONVENTION, 2));
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> payment_convention() const {
+    return GetOptional<int8_t, quantra::enums::BusinessDayConvention>(VT_PAYMENT_CONVENTION);
   }
-  quantra::enums::DayCounter day_counter() const {
-    return static_cast<quantra::enums::DayCounter>(GetField<int8_t>(VT_DAY_COUNTER, 1));
+  ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter() const {
+    return GetOptional<int8_t, quantra::enums::DayCounter>(VT_DAY_COUNTER);
   }
-  quantra::enums::CPIInterpolationType observation_interpolation() const {
-    return static_cast<quantra::enums::CPIInterpolationType>(GetField<int8_t>(VT_OBSERVATION_INTERPOLATION, 0));
+  ::flatbuffers::Optional<quantra::enums::CPIInterpolationType> observation_interpolation() const {
+    return GetOptional<int8_t, quantra::enums::CPIInterpolationType>(VT_OBSERVATION_INTERPOLATION);
   }
   /// QuantLib YoY helper requires a nominal term structure id.
   const ::flatbuffers::String *nominal_curve_id() const {
@@ -715,16 +716,16 @@ struct YearOnYearInflationSwapHelperBuilder {
     fbb_.AddOffset(YearOnYearInflationSwapHelper::VT_END_DATE, end_date);
   }
   void add_calendar(quantra::enums::Calendar calendar) {
-    fbb_.AddElement<int8_t>(YearOnYearInflationSwapHelper::VT_CALENDAR, static_cast<int8_t>(calendar), 32);
+    fbb_.AddElement<int8_t>(YearOnYearInflationSwapHelper::VT_CALENDAR, static_cast<int8_t>(calendar));
   }
   void add_payment_convention(quantra::enums::BusinessDayConvention payment_convention) {
-    fbb_.AddElement<int8_t>(YearOnYearInflationSwapHelper::VT_PAYMENT_CONVENTION, static_cast<int8_t>(payment_convention), 2);
+    fbb_.AddElement<int8_t>(YearOnYearInflationSwapHelper::VT_PAYMENT_CONVENTION, static_cast<int8_t>(payment_convention));
   }
   void add_day_counter(quantra::enums::DayCounter day_counter) {
-    fbb_.AddElement<int8_t>(YearOnYearInflationSwapHelper::VT_DAY_COUNTER, static_cast<int8_t>(day_counter), 1);
+    fbb_.AddElement<int8_t>(YearOnYearInflationSwapHelper::VT_DAY_COUNTER, static_cast<int8_t>(day_counter));
   }
   void add_observation_interpolation(quantra::enums::CPIInterpolationType observation_interpolation) {
-    fbb_.AddElement<int8_t>(YearOnYearInflationSwapHelper::VT_OBSERVATION_INTERPOLATION, static_cast<int8_t>(observation_interpolation), 0);
+    fbb_.AddElement<int8_t>(YearOnYearInflationSwapHelper::VT_OBSERVATION_INTERPOLATION, static_cast<int8_t>(observation_interpolation));
   }
   void add_nominal_curve_id(::flatbuffers::Offset<::flatbuffers::String> nominal_curve_id) {
     fbb_.AddOffset(YearOnYearInflationSwapHelper::VT_NOMINAL_CURVE_ID, nominal_curve_id);
@@ -750,10 +751,10 @@ inline ::flatbuffers::Offset<YearOnYearInflationSwapHelper> CreateYearOnYearInfl
     ::flatbuffers::Offset<quantra::Period> tenor = 0,
     ::flatbuffers::Offset<::flatbuffers::String> start_date = 0,
     ::flatbuffers::Offset<::flatbuffers::String> end_date = 0,
-    quantra::enums::Calendar calendar = quantra::enums::Calendar_TARGET,
-    quantra::enums::BusinessDayConvention payment_convention = quantra::enums::BusinessDayConvention_ModifiedFollowing,
-    quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual365Fixed,
-    quantra::enums::CPIInterpolationType observation_interpolation = quantra::enums::CPIInterpolationType_AsIndex,
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> payment_convention = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::CPIInterpolationType> observation_interpolation = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<::flatbuffers::String> nominal_curve_id = 0) {
   YearOnYearInflationSwapHelperBuilder builder_(_fbb);
   if(quote_value) { builder_.add_quote_value(*quote_value); }
@@ -763,10 +764,10 @@ inline ::flatbuffers::Offset<YearOnYearInflationSwapHelper> CreateYearOnYearInfl
   builder_.add_tenor(tenor);
   builder_.add_swap_observation_lag(swap_observation_lag);
   builder_.add_quote_id(quote_id);
-  builder_.add_observation_interpolation(observation_interpolation);
-  builder_.add_day_counter(day_counter);
-  builder_.add_payment_convention(payment_convention);
-  builder_.add_calendar(calendar);
+  if(observation_interpolation) { builder_.add_observation_interpolation(*observation_interpolation); }
+  if(day_counter) { builder_.add_day_counter(*day_counter); }
+  if(payment_convention) { builder_.add_payment_convention(*payment_convention); }
+  if(calendar) { builder_.add_calendar(*calendar); }
   return builder_.Finish();
 }
 
@@ -778,10 +779,10 @@ inline ::flatbuffers::Offset<YearOnYearInflationSwapHelper> CreateYearOnYearInfl
     ::flatbuffers::Offset<quantra::Period> tenor = 0,
     const char *start_date = nullptr,
     const char *end_date = nullptr,
-    quantra::enums::Calendar calendar = quantra::enums::Calendar_TARGET,
-    quantra::enums::BusinessDayConvention payment_convention = quantra::enums::BusinessDayConvention_ModifiedFollowing,
-    quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual365Fixed,
-    quantra::enums::CPIInterpolationType observation_interpolation = quantra::enums::CPIInterpolationType_AsIndex,
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> payment_convention = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::CPIInterpolationType> observation_interpolation = ::flatbuffers::nullopt,
     const char *nominal_curve_id = nullptr) {
   auto quote_id__ = quote_id ? _fbb.CreateString(quote_id) : 0;
   auto start_date__ = start_date ? _fbb.CreateString(start_date) : 0;
@@ -887,12 +888,12 @@ struct InflationCurveSpecT : public ::flatbuffers::NativeTable {
   typedef InflationCurveSpec TableType;
   std::string id{};
   std::string reference_date{};
-  quantra::enums::Calendar calendar = quantra::enums::Calendar_TARGET;
-  quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_ModifiedFollowing;
-  quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual365Fixed;
-  quantra::enums::Interpolator interpolator = quantra::enums::Interpolator_Linear;
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::Interpolator> interpolator = ::flatbuffers::nullopt;
   double bootstrap_accuracy = 1.0e-12;
-  quantra::enums::InflationCurveKind kind = quantra::enums::InflationCurveKind_ZeroInflation;
+  ::flatbuffers::Optional<quantra::enums::InflationCurveKind> kind = ::flatbuffers::nullopt;
   std::string index_id{};
   std::string discount_curve_id{};
   bool allow_extrapolation = true;
@@ -927,23 +928,24 @@ struct InflationCurveSpec FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table
   const ::flatbuffers::String *reference_date() const {
     return GetPointer<const ::flatbuffers::String *>(VT_REFERENCE_DATE);
   }
-  quantra::enums::Calendar calendar() const {
-    return static_cast<quantra::enums::Calendar>(GetField<int8_t>(VT_CALENDAR, 32));
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar() const {
+    return GetOptional<int8_t, quantra::enums::Calendar>(VT_CALENDAR);
   }
-  quantra::enums::BusinessDayConvention business_day_convention() const {
-    return static_cast<quantra::enums::BusinessDayConvention>(GetField<int8_t>(VT_BUSINESS_DAY_CONVENTION, 2));
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention() const {
+    return GetOptional<int8_t, quantra::enums::BusinessDayConvention>(VT_BUSINESS_DAY_CONVENTION);
   }
-  quantra::enums::DayCounter day_counter() const {
-    return static_cast<quantra::enums::DayCounter>(GetField<int8_t>(VT_DAY_COUNTER, 1));
+  ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter() const {
+    return GetOptional<int8_t, quantra::enums::DayCounter>(VT_DAY_COUNTER);
   }
-  quantra::enums::Interpolator interpolator() const {
-    return static_cast<quantra::enums::Interpolator>(GetField<int8_t>(VT_INTERPOLATOR, 2));
+  ::flatbuffers::Optional<quantra::enums::Interpolator> interpolator() const {
+    return GetOptional<int8_t, quantra::enums::Interpolator>(VT_INTERPOLATOR);
   }
+  /// Numerical bootstrap tolerance (not a market convention): keeps its default.
   double bootstrap_accuracy() const {
     return GetField<double>(VT_BOOTSTRAP_ACCURACY, 1.0e-12);
   }
-  quantra::enums::InflationCurveKind kind() const {
-    return static_cast<quantra::enums::InflationCurveKind>(GetField<int8_t>(VT_KIND, 0));
+  ::flatbuffers::Optional<quantra::enums::InflationCurveKind> kind() const {
+    return GetOptional<int8_t, quantra::enums::InflationCurveKind>(VT_KIND);
   }
   /// Link to InflationIndexSpec.id.
   const ::flatbuffers::String *index_id() const {
@@ -997,22 +999,22 @@ struct InflationCurveSpecBuilder {
     fbb_.AddOffset(InflationCurveSpec::VT_REFERENCE_DATE, reference_date);
   }
   void add_calendar(quantra::enums::Calendar calendar) {
-    fbb_.AddElement<int8_t>(InflationCurveSpec::VT_CALENDAR, static_cast<int8_t>(calendar), 32);
+    fbb_.AddElement<int8_t>(InflationCurveSpec::VT_CALENDAR, static_cast<int8_t>(calendar));
   }
   void add_business_day_convention(quantra::enums::BusinessDayConvention business_day_convention) {
-    fbb_.AddElement<int8_t>(InflationCurveSpec::VT_BUSINESS_DAY_CONVENTION, static_cast<int8_t>(business_day_convention), 2);
+    fbb_.AddElement<int8_t>(InflationCurveSpec::VT_BUSINESS_DAY_CONVENTION, static_cast<int8_t>(business_day_convention));
   }
   void add_day_counter(quantra::enums::DayCounter day_counter) {
-    fbb_.AddElement<int8_t>(InflationCurveSpec::VT_DAY_COUNTER, static_cast<int8_t>(day_counter), 1);
+    fbb_.AddElement<int8_t>(InflationCurveSpec::VT_DAY_COUNTER, static_cast<int8_t>(day_counter));
   }
   void add_interpolator(quantra::enums::Interpolator interpolator) {
-    fbb_.AddElement<int8_t>(InflationCurveSpec::VT_INTERPOLATOR, static_cast<int8_t>(interpolator), 2);
+    fbb_.AddElement<int8_t>(InflationCurveSpec::VT_INTERPOLATOR, static_cast<int8_t>(interpolator));
   }
   void add_bootstrap_accuracy(double bootstrap_accuracy) {
     fbb_.AddElement<double>(InflationCurveSpec::VT_BOOTSTRAP_ACCURACY, bootstrap_accuracy, 1.0e-12);
   }
   void add_kind(quantra::enums::InflationCurveKind kind) {
-    fbb_.AddElement<int8_t>(InflationCurveSpec::VT_KIND, static_cast<int8_t>(kind), 0);
+    fbb_.AddElement<int8_t>(InflationCurveSpec::VT_KIND, static_cast<int8_t>(kind));
   }
   void add_index_id(::flatbuffers::Offset<::flatbuffers::String> index_id) {
     fbb_.AddOffset(InflationCurveSpec::VT_INDEX_ID, index_id);
@@ -1045,12 +1047,12 @@ inline ::flatbuffers::Offset<InflationCurveSpec> CreateInflationCurveSpec(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     ::flatbuffers::Offset<::flatbuffers::String> id = 0,
     ::flatbuffers::Offset<::flatbuffers::String> reference_date = 0,
-    quantra::enums::Calendar calendar = quantra::enums::Calendar_TARGET,
-    quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_ModifiedFollowing,
-    quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual365Fixed,
-    quantra::enums::Interpolator interpolator = quantra::enums::Interpolator_Linear,
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::Interpolator> interpolator = ::flatbuffers::nullopt,
     double bootstrap_accuracy = 1.0e-12,
-    quantra::enums::InflationCurveKind kind = quantra::enums::InflationCurveKind_ZeroInflation,
+    ::flatbuffers::Optional<quantra::enums::InflationCurveKind> kind = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<::flatbuffers::String> index_id = 0,
     ::flatbuffers::Offset<::flatbuffers::String> discount_curve_id = 0,
     bool allow_extrapolation = true,
@@ -1063,11 +1065,11 @@ inline ::flatbuffers::Offset<InflationCurveSpec> CreateInflationCurveSpec(
   builder_.add_reference_date(reference_date);
   builder_.add_id(id);
   builder_.add_allow_extrapolation(allow_extrapolation);
-  builder_.add_kind(kind);
-  builder_.add_interpolator(interpolator);
-  builder_.add_day_counter(day_counter);
-  builder_.add_business_day_convention(business_day_convention);
-  builder_.add_calendar(calendar);
+  if(kind) { builder_.add_kind(*kind); }
+  if(interpolator) { builder_.add_interpolator(*interpolator); }
+  if(day_counter) { builder_.add_day_counter(*day_counter); }
+  if(business_day_convention) { builder_.add_business_day_convention(*business_day_convention); }
+  if(calendar) { builder_.add_calendar(*calendar); }
   return builder_.Finish();
 }
 
@@ -1075,12 +1077,12 @@ inline ::flatbuffers::Offset<InflationCurveSpec> CreateInflationCurveSpecDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     const char *id = nullptr,
     const char *reference_date = nullptr,
-    quantra::enums::Calendar calendar = quantra::enums::Calendar_TARGET,
-    quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_ModifiedFollowing,
-    quantra::enums::DayCounter day_counter = quantra::enums::DayCounter_Actual365Fixed,
-    quantra::enums::Interpolator interpolator = quantra::enums::Interpolator_Linear,
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::DayCounter> day_counter = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::Interpolator> interpolator = ::flatbuffers::nullopt,
     double bootstrap_accuracy = 1.0e-12,
-    quantra::enums::InflationCurveKind kind = quantra::enums::InflationCurveKind_ZeroInflation,
+    ::flatbuffers::Optional<quantra::enums::InflationCurveKind> kind = ::flatbuffers::nullopt,
     const char *index_id = nullptr,
     const char *discount_curve_id = nullptr,
     bool allow_extrapolation = true,

--- a/flatbuffers/cpp/schedule_generated.h
+++ b/flatbuffers/cpp/schedule_generated.h
@@ -30,7 +30,7 @@ struct ScheduleT : public ::flatbuffers::NativeTable {
   ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> convention = ::flatbuffers::nullopt;
   ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> termination_date_convention = ::flatbuffers::nullopt;
   ::flatbuffers::Optional<quantra::enums::DateGenerationRule> date_generation_rule = ::flatbuffers::nullopt;
-  bool end_of_month = false;
+  ::flatbuffers::Optional<bool> end_of_month = ::flatbuffers::nullopt;
   std::string first_date{};
   std::string next_to_last_date{};
 };
@@ -72,8 +72,10 @@ struct Schedule FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   ::flatbuffers::Optional<quantra::enums::DateGenerationRule> date_generation_rule() const {
     return GetOptional<int8_t, quantra::enums::DateGenerationRule>(VT_DATE_GENERATION_RULE);
   }
-  bool end_of_month() const {
-    return GetField<uint8_t>(VT_END_OF_MONTH, 0) != 0;
+  /// Presence-required: absent-vs-false silently changes schedule dates for
+  /// month-end-anchored (money-market) schedules.
+  ::flatbuffers::Optional<bool> end_of_month() const {
+    return GetOptional<uint8_t, bool>(VT_END_OF_MONTH);
   }
   /// Optional. ISO-8601 (YYYY-MM-DD). When present, passed as QuantLib's
   /// firstDate, which controls the FIRST stub coupon: with Backward date
@@ -141,7 +143,7 @@ struct ScheduleBuilder {
     fbb_.AddElement<int8_t>(Schedule::VT_DATE_GENERATION_RULE, static_cast<int8_t>(date_generation_rule));
   }
   void add_end_of_month(bool end_of_month) {
-    fbb_.AddElement<uint8_t>(Schedule::VT_END_OF_MONTH, static_cast<uint8_t>(end_of_month), 0);
+    fbb_.AddElement<uint8_t>(Schedule::VT_END_OF_MONTH, static_cast<uint8_t>(end_of_month));
   }
   void add_first_date(::flatbuffers::Offset<::flatbuffers::String> first_date) {
     fbb_.AddOffset(Schedule::VT_FIRST_DATE, first_date);
@@ -169,7 +171,7 @@ inline ::flatbuffers::Offset<Schedule> CreateSchedule(
     ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> convention = ::flatbuffers::nullopt,
     ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> termination_date_convention = ::flatbuffers::nullopt,
     ::flatbuffers::Optional<quantra::enums::DateGenerationRule> date_generation_rule = ::flatbuffers::nullopt,
-    bool end_of_month = false,
+    ::flatbuffers::Optional<bool> end_of_month = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<::flatbuffers::String> first_date = 0,
     ::flatbuffers::Offset<::flatbuffers::String> next_to_last_date = 0) {
   ScheduleBuilder builder_(_fbb);
@@ -177,7 +179,7 @@ inline ::flatbuffers::Offset<Schedule> CreateSchedule(
   builder_.add_first_date(first_date);
   builder_.add_termination_date(termination_date);
   builder_.add_effective_date(effective_date);
-  builder_.add_end_of_month(end_of_month);
+  if(end_of_month) { builder_.add_end_of_month(*end_of_month); }
   if(date_generation_rule) { builder_.add_date_generation_rule(*date_generation_rule); }
   if(termination_date_convention) { builder_.add_termination_date_convention(*termination_date_convention); }
   if(convention) { builder_.add_convention(*convention); }
@@ -195,7 +197,7 @@ inline ::flatbuffers::Offset<Schedule> CreateScheduleDirect(
     ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> convention = ::flatbuffers::nullopt,
     ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> termination_date_convention = ::flatbuffers::nullopt,
     ::flatbuffers::Optional<quantra::enums::DateGenerationRule> date_generation_rule = ::flatbuffers::nullopt,
-    bool end_of_month = false,
+    ::flatbuffers::Optional<bool> end_of_month = ::flatbuffers::nullopt,
     const char *first_date = nullptr,
     const char *next_to_last_date = nullptr) {
   auto effective_date__ = effective_date ? _fbb.CreateString(effective_date) : 0;

--- a/flatbuffers/cpp/swap_index_generated.h
+++ b/flatbuffers/cpp/swap_index_generated.h
@@ -63,16 +63,16 @@ inline const char *EnumNameSwapIndexKind(SwapIndexKind e) {
 
 struct SwapIndexFixedLegSpecT : public ::flatbuffers::NativeTable {
   typedef SwapIndexFixedLegSpec TableType;
-  quantra::enums::Frequency fixed_frequency = quantra::enums::Frequency_Annual;
-  quantra::enums::DayCounter fixed_day_counter = quantra::enums::DayCounter_Thirty360;
-  quantra::enums::Calendar fixed_calendar = quantra::enums::Calendar_TARGET;
-  quantra::enums::BusinessDayConvention fixed_bdc = quantra::enums::BusinessDayConvention_ModifiedFollowing;
-  quantra::enums::BusinessDayConvention fixed_term_bdc = quantra::enums::BusinessDayConvention_ModifiedFollowing;
-  quantra::enums::DateGenerationRule fixed_date_rule = quantra::enums::DateGenerationRule_Forward;
-  bool fixed_eom = false;
+  ::flatbuffers::Optional<quantra::enums::Frequency> fixed_frequency = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::DayCounter> fixed_day_counter = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::Calendar> fixed_calendar = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> fixed_bdc = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> fixed_term_bdc = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::DateGenerationRule> fixed_date_rule = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<bool> fixed_eom = ::flatbuffers::nullopt;
 };
 
-/// Fixed leg conventions for swap index.
+/// Fixed leg conventions for swap index. Every convention is presence-required.
 struct SwapIndexFixedLegSpec FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   typedef SwapIndexFixedLegSpecT NativeTableType;
   typedef SwapIndexFixedLegSpecBuilder Builder;
@@ -85,26 +85,26 @@ struct SwapIndexFixedLegSpec FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Ta
     VT_FIXED_DATE_RULE = 14,
     VT_FIXED_EOM = 16
   };
-  quantra::enums::Frequency fixed_frequency() const {
-    return static_cast<quantra::enums::Frequency>(GetField<int8_t>(VT_FIXED_FREQUENCY, 0));
+  ::flatbuffers::Optional<quantra::enums::Frequency> fixed_frequency() const {
+    return GetOptional<int8_t, quantra::enums::Frequency>(VT_FIXED_FREQUENCY);
   }
-  quantra::enums::DayCounter fixed_day_counter() const {
-    return static_cast<quantra::enums::DayCounter>(GetField<int8_t>(VT_FIXED_DAY_COUNTER, 14));
+  ::flatbuffers::Optional<quantra::enums::DayCounter> fixed_day_counter() const {
+    return GetOptional<int8_t, quantra::enums::DayCounter>(VT_FIXED_DAY_COUNTER);
   }
-  quantra::enums::Calendar fixed_calendar() const {
-    return static_cast<quantra::enums::Calendar>(GetField<int8_t>(VT_FIXED_CALENDAR, 32));
+  ::flatbuffers::Optional<quantra::enums::Calendar> fixed_calendar() const {
+    return GetOptional<int8_t, quantra::enums::Calendar>(VT_FIXED_CALENDAR);
   }
-  quantra::enums::BusinessDayConvention fixed_bdc() const {
-    return static_cast<quantra::enums::BusinessDayConvention>(GetField<int8_t>(VT_FIXED_BDC, 2));
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> fixed_bdc() const {
+    return GetOptional<int8_t, quantra::enums::BusinessDayConvention>(VT_FIXED_BDC);
   }
-  quantra::enums::BusinessDayConvention fixed_term_bdc() const {
-    return static_cast<quantra::enums::BusinessDayConvention>(GetField<int8_t>(VT_FIXED_TERM_BDC, 2));
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> fixed_term_bdc() const {
+    return GetOptional<int8_t, quantra::enums::BusinessDayConvention>(VT_FIXED_TERM_BDC);
   }
-  quantra::enums::DateGenerationRule fixed_date_rule() const {
-    return static_cast<quantra::enums::DateGenerationRule>(GetField<int8_t>(VT_FIXED_DATE_RULE, 2));
+  ::flatbuffers::Optional<quantra::enums::DateGenerationRule> fixed_date_rule() const {
+    return GetOptional<int8_t, quantra::enums::DateGenerationRule>(VT_FIXED_DATE_RULE);
   }
-  bool fixed_eom() const {
-    return GetField<uint8_t>(VT_FIXED_EOM, 0) != 0;
+  ::flatbuffers::Optional<bool> fixed_eom() const {
+    return GetOptional<uint8_t, bool>(VT_FIXED_EOM);
   }
   bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -127,25 +127,25 @@ struct SwapIndexFixedLegSpecBuilder {
   ::flatbuffers::FlatBufferBuilder &fbb_;
   ::flatbuffers::uoffset_t start_;
   void add_fixed_frequency(quantra::enums::Frequency fixed_frequency) {
-    fbb_.AddElement<int8_t>(SwapIndexFixedLegSpec::VT_FIXED_FREQUENCY, static_cast<int8_t>(fixed_frequency), 0);
+    fbb_.AddElement<int8_t>(SwapIndexFixedLegSpec::VT_FIXED_FREQUENCY, static_cast<int8_t>(fixed_frequency));
   }
   void add_fixed_day_counter(quantra::enums::DayCounter fixed_day_counter) {
-    fbb_.AddElement<int8_t>(SwapIndexFixedLegSpec::VT_FIXED_DAY_COUNTER, static_cast<int8_t>(fixed_day_counter), 14);
+    fbb_.AddElement<int8_t>(SwapIndexFixedLegSpec::VT_FIXED_DAY_COUNTER, static_cast<int8_t>(fixed_day_counter));
   }
   void add_fixed_calendar(quantra::enums::Calendar fixed_calendar) {
-    fbb_.AddElement<int8_t>(SwapIndexFixedLegSpec::VT_FIXED_CALENDAR, static_cast<int8_t>(fixed_calendar), 32);
+    fbb_.AddElement<int8_t>(SwapIndexFixedLegSpec::VT_FIXED_CALENDAR, static_cast<int8_t>(fixed_calendar));
   }
   void add_fixed_bdc(quantra::enums::BusinessDayConvention fixed_bdc) {
-    fbb_.AddElement<int8_t>(SwapIndexFixedLegSpec::VT_FIXED_BDC, static_cast<int8_t>(fixed_bdc), 2);
+    fbb_.AddElement<int8_t>(SwapIndexFixedLegSpec::VT_FIXED_BDC, static_cast<int8_t>(fixed_bdc));
   }
   void add_fixed_term_bdc(quantra::enums::BusinessDayConvention fixed_term_bdc) {
-    fbb_.AddElement<int8_t>(SwapIndexFixedLegSpec::VT_FIXED_TERM_BDC, static_cast<int8_t>(fixed_term_bdc), 2);
+    fbb_.AddElement<int8_t>(SwapIndexFixedLegSpec::VT_FIXED_TERM_BDC, static_cast<int8_t>(fixed_term_bdc));
   }
   void add_fixed_date_rule(quantra::enums::DateGenerationRule fixed_date_rule) {
-    fbb_.AddElement<int8_t>(SwapIndexFixedLegSpec::VT_FIXED_DATE_RULE, static_cast<int8_t>(fixed_date_rule), 2);
+    fbb_.AddElement<int8_t>(SwapIndexFixedLegSpec::VT_FIXED_DATE_RULE, static_cast<int8_t>(fixed_date_rule));
   }
   void add_fixed_eom(bool fixed_eom) {
-    fbb_.AddElement<uint8_t>(SwapIndexFixedLegSpec::VT_FIXED_EOM, static_cast<uint8_t>(fixed_eom), 0);
+    fbb_.AddElement<uint8_t>(SwapIndexFixedLegSpec::VT_FIXED_EOM, static_cast<uint8_t>(fixed_eom));
   }
   explicit SwapIndexFixedLegSpecBuilder(::flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
@@ -160,21 +160,21 @@ struct SwapIndexFixedLegSpecBuilder {
 
 inline ::flatbuffers::Offset<SwapIndexFixedLegSpec> CreateSwapIndexFixedLegSpec(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    quantra::enums::Frequency fixed_frequency = quantra::enums::Frequency_Annual,
-    quantra::enums::DayCounter fixed_day_counter = quantra::enums::DayCounter_Thirty360,
-    quantra::enums::Calendar fixed_calendar = quantra::enums::Calendar_TARGET,
-    quantra::enums::BusinessDayConvention fixed_bdc = quantra::enums::BusinessDayConvention_ModifiedFollowing,
-    quantra::enums::BusinessDayConvention fixed_term_bdc = quantra::enums::BusinessDayConvention_ModifiedFollowing,
-    quantra::enums::DateGenerationRule fixed_date_rule = quantra::enums::DateGenerationRule_Forward,
-    bool fixed_eom = false) {
+    ::flatbuffers::Optional<quantra::enums::Frequency> fixed_frequency = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::DayCounter> fixed_day_counter = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::Calendar> fixed_calendar = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> fixed_bdc = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> fixed_term_bdc = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::DateGenerationRule> fixed_date_rule = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<bool> fixed_eom = ::flatbuffers::nullopt) {
   SwapIndexFixedLegSpecBuilder builder_(_fbb);
-  builder_.add_fixed_eom(fixed_eom);
-  builder_.add_fixed_date_rule(fixed_date_rule);
-  builder_.add_fixed_term_bdc(fixed_term_bdc);
-  builder_.add_fixed_bdc(fixed_bdc);
-  builder_.add_fixed_calendar(fixed_calendar);
-  builder_.add_fixed_day_counter(fixed_day_counter);
-  builder_.add_fixed_frequency(fixed_frequency);
+  if(fixed_eom) { builder_.add_fixed_eom(*fixed_eom); }
+  if(fixed_date_rule) { builder_.add_fixed_date_rule(*fixed_date_rule); }
+  if(fixed_term_bdc) { builder_.add_fixed_term_bdc(*fixed_term_bdc); }
+  if(fixed_bdc) { builder_.add_fixed_bdc(*fixed_bdc); }
+  if(fixed_calendar) { builder_.add_fixed_calendar(*fixed_calendar); }
+  if(fixed_day_counter) { builder_.add_fixed_day_counter(*fixed_day_counter); }
+  if(fixed_frequency) { builder_.add_fixed_frequency(*fixed_frequency); }
   return builder_.Finish();
 }
 
@@ -183,18 +183,19 @@ inline ::flatbuffers::Offset<SwapIndexFixedLegSpec> CreateSwapIndexFixedLegSpec(
 struct SwapIndexFloatLegSpecT : public ::flatbuffers::NativeTable {
   typedef SwapIndexFloatLegSpec TableType;
   std::unique_ptr<quantra::PeriodT> float_tenor{};
-  quantra::enums::Calendar float_calendar = quantra::enums::Calendar_TARGET;
-  quantra::enums::BusinessDayConvention float_bdc = quantra::enums::BusinessDayConvention_ModifiedFollowing;
-  quantra::enums::BusinessDayConvention float_term_bdc = quantra::enums::BusinessDayConvention_ModifiedFollowing;
-  quantra::enums::DateGenerationRule float_date_rule = quantra::enums::DateGenerationRule_Forward;
-  bool float_eom = false;
+  ::flatbuffers::Optional<quantra::enums::Calendar> float_calendar = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> float_bdc = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> float_term_bdc = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::DateGenerationRule> float_date_rule = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<bool> float_eom = ::flatbuffers::nullopt;
   SwapIndexFloatLegSpecT() = default;
   SwapIndexFloatLegSpecT(const SwapIndexFloatLegSpecT &o);
   SwapIndexFloatLegSpecT(SwapIndexFloatLegSpecT&&) FLATBUFFERS_NOEXCEPT = default;
   SwapIndexFloatLegSpecT &operator=(SwapIndexFloatLegSpecT o) FLATBUFFERS_NOEXCEPT;
 };
 
-/// Floating leg conventions for swap index.
+/// Floating leg conventions for swap index. Every convention is
+/// presence-required.
 struct SwapIndexFloatLegSpec FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   typedef SwapIndexFloatLegSpecT NativeTableType;
   typedef SwapIndexFloatLegSpecBuilder Builder;
@@ -209,20 +210,20 @@ struct SwapIndexFloatLegSpec FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Ta
   const quantra::Period *float_tenor() const {
     return GetPointer<const quantra::Period *>(VT_FLOAT_TENOR);
   }
-  quantra::enums::Calendar float_calendar() const {
-    return static_cast<quantra::enums::Calendar>(GetField<int8_t>(VT_FLOAT_CALENDAR, 32));
+  ::flatbuffers::Optional<quantra::enums::Calendar> float_calendar() const {
+    return GetOptional<int8_t, quantra::enums::Calendar>(VT_FLOAT_CALENDAR);
   }
-  quantra::enums::BusinessDayConvention float_bdc() const {
-    return static_cast<quantra::enums::BusinessDayConvention>(GetField<int8_t>(VT_FLOAT_BDC, 2));
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> float_bdc() const {
+    return GetOptional<int8_t, quantra::enums::BusinessDayConvention>(VT_FLOAT_BDC);
   }
-  quantra::enums::BusinessDayConvention float_term_bdc() const {
-    return static_cast<quantra::enums::BusinessDayConvention>(GetField<int8_t>(VT_FLOAT_TERM_BDC, 2));
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> float_term_bdc() const {
+    return GetOptional<int8_t, quantra::enums::BusinessDayConvention>(VT_FLOAT_TERM_BDC);
   }
-  quantra::enums::DateGenerationRule float_date_rule() const {
-    return static_cast<quantra::enums::DateGenerationRule>(GetField<int8_t>(VT_FLOAT_DATE_RULE, 2));
+  ::flatbuffers::Optional<quantra::enums::DateGenerationRule> float_date_rule() const {
+    return GetOptional<int8_t, quantra::enums::DateGenerationRule>(VT_FLOAT_DATE_RULE);
   }
-  bool float_eom() const {
-    return GetField<uint8_t>(VT_FLOAT_EOM, 0) != 0;
+  ::flatbuffers::Optional<bool> float_eom() const {
+    return GetOptional<uint8_t, bool>(VT_FLOAT_EOM);
   }
   bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -248,19 +249,19 @@ struct SwapIndexFloatLegSpecBuilder {
     fbb_.AddOffset(SwapIndexFloatLegSpec::VT_FLOAT_TENOR, float_tenor);
   }
   void add_float_calendar(quantra::enums::Calendar float_calendar) {
-    fbb_.AddElement<int8_t>(SwapIndexFloatLegSpec::VT_FLOAT_CALENDAR, static_cast<int8_t>(float_calendar), 32);
+    fbb_.AddElement<int8_t>(SwapIndexFloatLegSpec::VT_FLOAT_CALENDAR, static_cast<int8_t>(float_calendar));
   }
   void add_float_bdc(quantra::enums::BusinessDayConvention float_bdc) {
-    fbb_.AddElement<int8_t>(SwapIndexFloatLegSpec::VT_FLOAT_BDC, static_cast<int8_t>(float_bdc), 2);
+    fbb_.AddElement<int8_t>(SwapIndexFloatLegSpec::VT_FLOAT_BDC, static_cast<int8_t>(float_bdc));
   }
   void add_float_term_bdc(quantra::enums::BusinessDayConvention float_term_bdc) {
-    fbb_.AddElement<int8_t>(SwapIndexFloatLegSpec::VT_FLOAT_TERM_BDC, static_cast<int8_t>(float_term_bdc), 2);
+    fbb_.AddElement<int8_t>(SwapIndexFloatLegSpec::VT_FLOAT_TERM_BDC, static_cast<int8_t>(float_term_bdc));
   }
   void add_float_date_rule(quantra::enums::DateGenerationRule float_date_rule) {
-    fbb_.AddElement<int8_t>(SwapIndexFloatLegSpec::VT_FLOAT_DATE_RULE, static_cast<int8_t>(float_date_rule), 2);
+    fbb_.AddElement<int8_t>(SwapIndexFloatLegSpec::VT_FLOAT_DATE_RULE, static_cast<int8_t>(float_date_rule));
   }
   void add_float_eom(bool float_eom) {
-    fbb_.AddElement<uint8_t>(SwapIndexFloatLegSpec::VT_FLOAT_EOM, static_cast<uint8_t>(float_eom), 0);
+    fbb_.AddElement<uint8_t>(SwapIndexFloatLegSpec::VT_FLOAT_EOM, static_cast<uint8_t>(float_eom));
   }
   explicit SwapIndexFloatLegSpecBuilder(::flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
@@ -276,18 +277,18 @@ struct SwapIndexFloatLegSpecBuilder {
 inline ::flatbuffers::Offset<SwapIndexFloatLegSpec> CreateSwapIndexFloatLegSpec(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     ::flatbuffers::Offset<quantra::Period> float_tenor = 0,
-    quantra::enums::Calendar float_calendar = quantra::enums::Calendar_TARGET,
-    quantra::enums::BusinessDayConvention float_bdc = quantra::enums::BusinessDayConvention_ModifiedFollowing,
-    quantra::enums::BusinessDayConvention float_term_bdc = quantra::enums::BusinessDayConvention_ModifiedFollowing,
-    quantra::enums::DateGenerationRule float_date_rule = quantra::enums::DateGenerationRule_Forward,
-    bool float_eom = false) {
+    ::flatbuffers::Optional<quantra::enums::Calendar> float_calendar = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> float_bdc = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> float_term_bdc = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::DateGenerationRule> float_date_rule = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<bool> float_eom = ::flatbuffers::nullopt) {
   SwapIndexFloatLegSpecBuilder builder_(_fbb);
   builder_.add_float_tenor(float_tenor);
-  builder_.add_float_eom(float_eom);
-  builder_.add_float_date_rule(float_date_rule);
-  builder_.add_float_term_bdc(float_term_bdc);
-  builder_.add_float_bdc(float_bdc);
-  builder_.add_float_calendar(float_calendar);
+  if(float_eom) { builder_.add_float_eom(*float_eom); }
+  if(float_date_rule) { builder_.add_float_date_rule(*float_date_rule); }
+  if(float_term_bdc) { builder_.add_float_term_bdc(*float_term_bdc); }
+  if(float_bdc) { builder_.add_float_bdc(*float_bdc); }
+  if(float_calendar) { builder_.add_float_calendar(*float_calendar); }
   return builder_.Finish();
 }
 
@@ -296,11 +297,11 @@ inline ::flatbuffers::Offset<SwapIndexFloatLegSpec> CreateSwapIndexFloatLegSpec(
 struct SwapIndexDefT : public ::flatbuffers::NativeTable {
   typedef SwapIndexDef TableType;
   std::string id{};
-  quantra::SwapIndexKind kind = quantra::SwapIndexKind_IborSwapIndex;
-  int32_t spot_days = 2;
-  quantra::enums::Calendar calendar = quantra::enums::Calendar_TARGET;
-  quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_ModifiedFollowing;
-  bool end_of_month = false;
+  ::flatbuffers::Optional<quantra::SwapIndexKind> kind = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<int32_t> spot_days = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<bool> end_of_month = ::flatbuffers::nullopt;
   std::unique_ptr<quantra::SwapIndexFixedLegSpecT> fixed_leg{};
   std::string float_index_id{};
   std::unique_ptr<quantra::SwapIndexFloatLegSpecT> float_leg{};
@@ -328,24 +329,24 @@ struct SwapIndexDef FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   const ::flatbuffers::String *id() const {
     return GetPointer<const ::flatbuffers::String *>(VT_ID);
   }
-  quantra::SwapIndexKind kind() const {
-    return static_cast<quantra::SwapIndexKind>(GetField<int8_t>(VT_KIND, 0));
+  ::flatbuffers::Optional<quantra::SwapIndexKind> kind() const {
+    return GetOptional<int8_t, quantra::SwapIndexKind>(VT_KIND);
   }
   /// Spot/effective-date lag used for exercise-to-swap-start advancement.
-  int32_t spot_days() const {
-    return GetField<int32_t>(VT_SPOT_DAYS, 2);
+  ::flatbuffers::Optional<int32_t> spot_days() const {
+    return GetOptional<int32_t, int32_t>(VT_SPOT_DAYS);
   }
   /// Metadata only; pricing uses fixed_leg/float_leg conventions.
-  quantra::enums::Calendar calendar() const {
-    return static_cast<quantra::enums::Calendar>(GetField<int8_t>(VT_CALENDAR, 32));
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar() const {
+    return GetOptional<int8_t, quantra::enums::Calendar>(VT_CALENDAR);
   }
   /// Metadata only; pricing uses fixed_leg/float_leg conventions.
-  quantra::enums::BusinessDayConvention business_day_convention() const {
-    return static_cast<quantra::enums::BusinessDayConvention>(GetField<int8_t>(VT_BUSINESS_DAY_CONVENTION, 2));
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention() const {
+    return GetOptional<int8_t, quantra::enums::BusinessDayConvention>(VT_BUSINESS_DAY_CONVENTION);
   }
   /// Metadata only; pricing uses fixed_leg/float_leg conventions.
-  bool end_of_month() const {
-    return GetField<uint8_t>(VT_END_OF_MONTH, 0) != 0;
+  ::flatbuffers::Optional<bool> end_of_month() const {
+    return GetOptional<uint8_t, bool>(VT_END_OF_MONTH);
   }
   const quantra::SwapIndexFixedLegSpec *fixed_leg() const {
     return GetPointer<const quantra::SwapIndexFixedLegSpec *>(VT_FIXED_LEG);
@@ -387,19 +388,19 @@ struct SwapIndexDefBuilder {
     fbb_.AddOffset(SwapIndexDef::VT_ID, id);
   }
   void add_kind(quantra::SwapIndexKind kind) {
-    fbb_.AddElement<int8_t>(SwapIndexDef::VT_KIND, static_cast<int8_t>(kind), 0);
+    fbb_.AddElement<int8_t>(SwapIndexDef::VT_KIND, static_cast<int8_t>(kind));
   }
   void add_spot_days(int32_t spot_days) {
-    fbb_.AddElement<int32_t>(SwapIndexDef::VT_SPOT_DAYS, spot_days, 2);
+    fbb_.AddElement<int32_t>(SwapIndexDef::VT_SPOT_DAYS, spot_days);
   }
   void add_calendar(quantra::enums::Calendar calendar) {
-    fbb_.AddElement<int8_t>(SwapIndexDef::VT_CALENDAR, static_cast<int8_t>(calendar), 32);
+    fbb_.AddElement<int8_t>(SwapIndexDef::VT_CALENDAR, static_cast<int8_t>(calendar));
   }
   void add_business_day_convention(quantra::enums::BusinessDayConvention business_day_convention) {
-    fbb_.AddElement<int8_t>(SwapIndexDef::VT_BUSINESS_DAY_CONVENTION, static_cast<int8_t>(business_day_convention), 2);
+    fbb_.AddElement<int8_t>(SwapIndexDef::VT_BUSINESS_DAY_CONVENTION, static_cast<int8_t>(business_day_convention));
   }
   void add_end_of_month(bool end_of_month) {
-    fbb_.AddElement<uint8_t>(SwapIndexDef::VT_END_OF_MONTH, static_cast<uint8_t>(end_of_month), 0);
+    fbb_.AddElement<uint8_t>(SwapIndexDef::VT_END_OF_MONTH, static_cast<uint8_t>(end_of_month));
   }
   void add_fixed_leg(::flatbuffers::Offset<quantra::SwapIndexFixedLegSpec> fixed_leg) {
     fbb_.AddOffset(SwapIndexDef::VT_FIXED_LEG, fixed_leg);
@@ -426,11 +427,11 @@ struct SwapIndexDefBuilder {
 inline ::flatbuffers::Offset<SwapIndexDef> CreateSwapIndexDef(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     ::flatbuffers::Offset<::flatbuffers::String> id = 0,
-    quantra::SwapIndexKind kind = quantra::SwapIndexKind_IborSwapIndex,
-    int32_t spot_days = 2,
-    quantra::enums::Calendar calendar = quantra::enums::Calendar_TARGET,
-    quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_ModifiedFollowing,
-    bool end_of_month = false,
+    ::flatbuffers::Optional<quantra::SwapIndexKind> kind = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<int32_t> spot_days = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<bool> end_of_month = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::SwapIndexFixedLegSpec> fixed_leg = 0,
     ::flatbuffers::Offset<::flatbuffers::String> float_index_id = 0,
     ::flatbuffers::Offset<quantra::SwapIndexFloatLegSpec> float_leg = 0) {
@@ -438,23 +439,23 @@ inline ::flatbuffers::Offset<SwapIndexDef> CreateSwapIndexDef(
   builder_.add_float_leg(float_leg);
   builder_.add_float_index_id(float_index_id);
   builder_.add_fixed_leg(fixed_leg);
-  builder_.add_spot_days(spot_days);
+  if(spot_days) { builder_.add_spot_days(*spot_days); }
   builder_.add_id(id);
-  builder_.add_end_of_month(end_of_month);
-  builder_.add_business_day_convention(business_day_convention);
-  builder_.add_calendar(calendar);
-  builder_.add_kind(kind);
+  if(end_of_month) { builder_.add_end_of_month(*end_of_month); }
+  if(business_day_convention) { builder_.add_business_day_convention(*business_day_convention); }
+  if(calendar) { builder_.add_calendar(*calendar); }
+  if(kind) { builder_.add_kind(*kind); }
   return builder_.Finish();
 }
 
 inline ::flatbuffers::Offset<SwapIndexDef> CreateSwapIndexDefDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     const char *id = nullptr,
-    quantra::SwapIndexKind kind = quantra::SwapIndexKind_IborSwapIndex,
-    int32_t spot_days = 2,
-    quantra::enums::Calendar calendar = quantra::enums::Calendar_TARGET,
-    quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_ModifiedFollowing,
-    bool end_of_month = false,
+    ::flatbuffers::Optional<quantra::SwapIndexKind> kind = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<int32_t> spot_days = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<bool> end_of_month = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::SwapIndexFixedLegSpec> fixed_leg = 0,
     const char *float_index_id = nullptr,
     ::flatbuffers::Offset<quantra::SwapIndexFloatLegSpec> float_leg = 0) {

--- a/flatbuffers/cpp/term_structure_generated.h
+++ b/flatbuffers/cpp/term_structure_generated.h
@@ -1478,11 +1478,11 @@ struct OISHelperT : public ::flatbuffers::NativeTable {
   ::flatbuffers::Optional<double> rate = ::flatbuffers::nullopt;
   std::unique_ptr<quantra::PeriodT> tenor{};
   std::unique_ptr<quantra::IndexRefT> overnight_index{};
-  int32_t settlement_days = 2;
-  quantra::enums::Calendar calendar = quantra::enums::Calendar_TARGET;
-  quantra::enums::Frequency fixed_leg_frequency = quantra::enums::Frequency_Annual;
-  quantra::enums::BusinessDayConvention fixed_leg_convention = quantra::enums::BusinessDayConvention_ModifiedFollowing;
-  quantra::enums::DayCounter fixed_leg_day_counter = quantra::enums::DayCounter_Actual360;
+  ::flatbuffers::Optional<int32_t> settlement_days = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::Frequency> fixed_leg_frequency = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> fixed_leg_convention = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::DayCounter> fixed_leg_day_counter = ::flatbuffers::nullopt;
   std::unique_ptr<quantra::HelperDependenciesT> deps{};
   std::string quote_id{};
   OISHelperT() = default;
@@ -1518,20 +1518,20 @@ struct OISHelper FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   const quantra::IndexRef *overnight_index() const {
     return GetPointer<const quantra::IndexRef *>(VT_OVERNIGHT_INDEX);
   }
-  int32_t settlement_days() const {
-    return GetField<int32_t>(VT_SETTLEMENT_DAYS, 2);
+  ::flatbuffers::Optional<int32_t> settlement_days() const {
+    return GetOptional<int32_t, int32_t>(VT_SETTLEMENT_DAYS);
   }
-  quantra::enums::Calendar calendar() const {
-    return static_cast<quantra::enums::Calendar>(GetField<int8_t>(VT_CALENDAR, 32));
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar() const {
+    return GetOptional<int8_t, quantra::enums::Calendar>(VT_CALENDAR);
   }
-  quantra::enums::Frequency fixed_leg_frequency() const {
-    return static_cast<quantra::enums::Frequency>(GetField<int8_t>(VT_FIXED_LEG_FREQUENCY, 0));
+  ::flatbuffers::Optional<quantra::enums::Frequency> fixed_leg_frequency() const {
+    return GetOptional<int8_t, quantra::enums::Frequency>(VT_FIXED_LEG_FREQUENCY);
   }
-  quantra::enums::BusinessDayConvention fixed_leg_convention() const {
-    return static_cast<quantra::enums::BusinessDayConvention>(GetField<int8_t>(VT_FIXED_LEG_CONVENTION, 2));
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> fixed_leg_convention() const {
+    return GetOptional<int8_t, quantra::enums::BusinessDayConvention>(VT_FIXED_LEG_CONVENTION);
   }
-  quantra::enums::DayCounter fixed_leg_day_counter() const {
-    return static_cast<quantra::enums::DayCounter>(GetField<int8_t>(VT_FIXED_LEG_DAY_COUNTER, 0));
+  ::flatbuffers::Optional<quantra::enums::DayCounter> fixed_leg_day_counter() const {
+    return GetOptional<int8_t, quantra::enums::DayCounter>(VT_FIXED_LEG_DAY_COUNTER);
   }
   /// Exogenous discount curve for dual-curve OIS bootstrapping.
   const quantra::HelperDependencies *deps() const {
@@ -1577,19 +1577,19 @@ struct OISHelperBuilder {
     fbb_.AddOffset(OISHelper::VT_OVERNIGHT_INDEX, overnight_index);
   }
   void add_settlement_days(int32_t settlement_days) {
-    fbb_.AddElement<int32_t>(OISHelper::VT_SETTLEMENT_DAYS, settlement_days, 2);
+    fbb_.AddElement<int32_t>(OISHelper::VT_SETTLEMENT_DAYS, settlement_days);
   }
   void add_calendar(quantra::enums::Calendar calendar) {
-    fbb_.AddElement<int8_t>(OISHelper::VT_CALENDAR, static_cast<int8_t>(calendar), 32);
+    fbb_.AddElement<int8_t>(OISHelper::VT_CALENDAR, static_cast<int8_t>(calendar));
   }
   void add_fixed_leg_frequency(quantra::enums::Frequency fixed_leg_frequency) {
-    fbb_.AddElement<int8_t>(OISHelper::VT_FIXED_LEG_FREQUENCY, static_cast<int8_t>(fixed_leg_frequency), 0);
+    fbb_.AddElement<int8_t>(OISHelper::VT_FIXED_LEG_FREQUENCY, static_cast<int8_t>(fixed_leg_frequency));
   }
   void add_fixed_leg_convention(quantra::enums::BusinessDayConvention fixed_leg_convention) {
-    fbb_.AddElement<int8_t>(OISHelper::VT_FIXED_LEG_CONVENTION, static_cast<int8_t>(fixed_leg_convention), 2);
+    fbb_.AddElement<int8_t>(OISHelper::VT_FIXED_LEG_CONVENTION, static_cast<int8_t>(fixed_leg_convention));
   }
   void add_fixed_leg_day_counter(quantra::enums::DayCounter fixed_leg_day_counter) {
-    fbb_.AddElement<int8_t>(OISHelper::VT_FIXED_LEG_DAY_COUNTER, static_cast<int8_t>(fixed_leg_day_counter), 0);
+    fbb_.AddElement<int8_t>(OISHelper::VT_FIXED_LEG_DAY_COUNTER, static_cast<int8_t>(fixed_leg_day_counter));
   }
   void add_deps(::flatbuffers::Offset<quantra::HelperDependencies> deps) {
     fbb_.AddOffset(OISHelper::VT_DEPS, deps);
@@ -1614,24 +1614,24 @@ inline ::flatbuffers::Offset<OISHelper> CreateOISHelper(
     ::flatbuffers::Optional<double> rate = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::Period> tenor = 0,
     ::flatbuffers::Offset<quantra::IndexRef> overnight_index = 0,
-    int32_t settlement_days = 2,
-    quantra::enums::Calendar calendar = quantra::enums::Calendar_TARGET,
-    quantra::enums::Frequency fixed_leg_frequency = quantra::enums::Frequency_Annual,
-    quantra::enums::BusinessDayConvention fixed_leg_convention = quantra::enums::BusinessDayConvention_ModifiedFollowing,
-    quantra::enums::DayCounter fixed_leg_day_counter = quantra::enums::DayCounter_Actual360,
+    ::flatbuffers::Optional<int32_t> settlement_days = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::Frequency> fixed_leg_frequency = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> fixed_leg_convention = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::DayCounter> fixed_leg_day_counter = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::HelperDependencies> deps = 0,
     ::flatbuffers::Offset<::flatbuffers::String> quote_id = 0) {
   OISHelperBuilder builder_(_fbb);
   if(rate) { builder_.add_rate(*rate); }
   builder_.add_quote_id(quote_id);
   builder_.add_deps(deps);
-  builder_.add_settlement_days(settlement_days);
+  if(settlement_days) { builder_.add_settlement_days(*settlement_days); }
   builder_.add_overnight_index(overnight_index);
   builder_.add_tenor(tenor);
-  builder_.add_fixed_leg_day_counter(fixed_leg_day_counter);
-  builder_.add_fixed_leg_convention(fixed_leg_convention);
-  builder_.add_fixed_leg_frequency(fixed_leg_frequency);
-  builder_.add_calendar(calendar);
+  if(fixed_leg_day_counter) { builder_.add_fixed_leg_day_counter(*fixed_leg_day_counter); }
+  if(fixed_leg_convention) { builder_.add_fixed_leg_convention(*fixed_leg_convention); }
+  if(fixed_leg_frequency) { builder_.add_fixed_leg_frequency(*fixed_leg_frequency); }
+  if(calendar) { builder_.add_calendar(*calendar); }
   return builder_.Finish();
 }
 
@@ -1640,11 +1640,11 @@ inline ::flatbuffers::Offset<OISHelper> CreateOISHelperDirect(
     ::flatbuffers::Optional<double> rate = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::Period> tenor = 0,
     ::flatbuffers::Offset<quantra::IndexRef> overnight_index = 0,
-    int32_t settlement_days = 2,
-    quantra::enums::Calendar calendar = quantra::enums::Calendar_TARGET,
-    quantra::enums::Frequency fixed_leg_frequency = quantra::enums::Frequency_Annual,
-    quantra::enums::BusinessDayConvention fixed_leg_convention = quantra::enums::BusinessDayConvention_ModifiedFollowing,
-    quantra::enums::DayCounter fixed_leg_day_counter = quantra::enums::DayCounter_Actual360,
+    ::flatbuffers::Optional<int32_t> settlement_days = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::Frequency> fixed_leg_frequency = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> fixed_leg_convention = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::DayCounter> fixed_leg_day_counter = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::HelperDependencies> deps = 0,
     const char *quote_id = nullptr) {
   auto quote_id__ = quote_id ? _fbb.CreateString(quote_id) : 0;
@@ -1670,10 +1670,10 @@ struct DatedOISHelperT : public ::flatbuffers::NativeTable {
   std::string start_date{};
   std::string end_date{};
   std::unique_ptr<quantra::IndexRefT> overnight_index{};
-  int32_t settlement_days = 2;
-  quantra::enums::Calendar calendar = quantra::enums::Calendar_TARGET;
-  quantra::enums::BusinessDayConvention fixed_leg_convention = quantra::enums::BusinessDayConvention_ModifiedFollowing;
-  quantra::enums::DayCounter fixed_leg_day_counter = quantra::enums::DayCounter_Actual360;
+  ::flatbuffers::Optional<int32_t> settlement_days = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> fixed_leg_convention = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::DayCounter> fixed_leg_day_counter = ::flatbuffers::nullopt;
   std::unique_ptr<quantra::HelperDependenciesT> deps{};
   std::string quote_id{};
   DatedOISHelperT() = default;
@@ -1712,17 +1712,17 @@ struct DatedOISHelper FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   const quantra::IndexRef *overnight_index() const {
     return GetPointer<const quantra::IndexRef *>(VT_OVERNIGHT_INDEX);
   }
-  int32_t settlement_days() const {
-    return GetField<int32_t>(VT_SETTLEMENT_DAYS, 2);
+  ::flatbuffers::Optional<int32_t> settlement_days() const {
+    return GetOptional<int32_t, int32_t>(VT_SETTLEMENT_DAYS);
   }
-  quantra::enums::Calendar calendar() const {
-    return static_cast<quantra::enums::Calendar>(GetField<int8_t>(VT_CALENDAR, 32));
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar() const {
+    return GetOptional<int8_t, quantra::enums::Calendar>(VT_CALENDAR);
   }
-  quantra::enums::BusinessDayConvention fixed_leg_convention() const {
-    return static_cast<quantra::enums::BusinessDayConvention>(GetField<int8_t>(VT_FIXED_LEG_CONVENTION, 2));
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> fixed_leg_convention() const {
+    return GetOptional<int8_t, quantra::enums::BusinessDayConvention>(VT_FIXED_LEG_CONVENTION);
   }
-  quantra::enums::DayCounter fixed_leg_day_counter() const {
-    return static_cast<quantra::enums::DayCounter>(GetField<int8_t>(VT_FIXED_LEG_DAY_COUNTER, 0));
+  ::flatbuffers::Optional<quantra::enums::DayCounter> fixed_leg_day_counter() const {
+    return GetOptional<int8_t, quantra::enums::DayCounter>(VT_FIXED_LEG_DAY_COUNTER);
   }
   /// Exogenous discount curve for dual-curve OIS bootstrapping.
   const quantra::HelperDependencies *deps() const {
@@ -1772,16 +1772,16 @@ struct DatedOISHelperBuilder {
     fbb_.AddOffset(DatedOISHelper::VT_OVERNIGHT_INDEX, overnight_index);
   }
   void add_settlement_days(int32_t settlement_days) {
-    fbb_.AddElement<int32_t>(DatedOISHelper::VT_SETTLEMENT_DAYS, settlement_days, 2);
+    fbb_.AddElement<int32_t>(DatedOISHelper::VT_SETTLEMENT_DAYS, settlement_days);
   }
   void add_calendar(quantra::enums::Calendar calendar) {
-    fbb_.AddElement<int8_t>(DatedOISHelper::VT_CALENDAR, static_cast<int8_t>(calendar), 32);
+    fbb_.AddElement<int8_t>(DatedOISHelper::VT_CALENDAR, static_cast<int8_t>(calendar));
   }
   void add_fixed_leg_convention(quantra::enums::BusinessDayConvention fixed_leg_convention) {
-    fbb_.AddElement<int8_t>(DatedOISHelper::VT_FIXED_LEG_CONVENTION, static_cast<int8_t>(fixed_leg_convention), 2);
+    fbb_.AddElement<int8_t>(DatedOISHelper::VT_FIXED_LEG_CONVENTION, static_cast<int8_t>(fixed_leg_convention));
   }
   void add_fixed_leg_day_counter(quantra::enums::DayCounter fixed_leg_day_counter) {
-    fbb_.AddElement<int8_t>(DatedOISHelper::VT_FIXED_LEG_DAY_COUNTER, static_cast<int8_t>(fixed_leg_day_counter), 0);
+    fbb_.AddElement<int8_t>(DatedOISHelper::VT_FIXED_LEG_DAY_COUNTER, static_cast<int8_t>(fixed_leg_day_counter));
   }
   void add_deps(::flatbuffers::Offset<quantra::HelperDependencies> deps) {
     fbb_.AddOffset(DatedOISHelper::VT_DEPS, deps);
@@ -1809,23 +1809,23 @@ inline ::flatbuffers::Offset<DatedOISHelper> CreateDatedOISHelper(
     ::flatbuffers::Offset<::flatbuffers::String> start_date = 0,
     ::flatbuffers::Offset<::flatbuffers::String> end_date = 0,
     ::flatbuffers::Offset<quantra::IndexRef> overnight_index = 0,
-    int32_t settlement_days = 2,
-    quantra::enums::Calendar calendar = quantra::enums::Calendar_TARGET,
-    quantra::enums::BusinessDayConvention fixed_leg_convention = quantra::enums::BusinessDayConvention_ModifiedFollowing,
-    quantra::enums::DayCounter fixed_leg_day_counter = quantra::enums::DayCounter_Actual360,
+    ::flatbuffers::Optional<int32_t> settlement_days = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> fixed_leg_convention = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::DayCounter> fixed_leg_day_counter = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::HelperDependencies> deps = 0,
     ::flatbuffers::Offset<::flatbuffers::String> quote_id = 0) {
   DatedOISHelperBuilder builder_(_fbb);
   if(rate) { builder_.add_rate(*rate); }
   builder_.add_quote_id(quote_id);
   builder_.add_deps(deps);
-  builder_.add_settlement_days(settlement_days);
+  if(settlement_days) { builder_.add_settlement_days(*settlement_days); }
   builder_.add_overnight_index(overnight_index);
   builder_.add_end_date(end_date);
   builder_.add_start_date(start_date);
-  builder_.add_fixed_leg_day_counter(fixed_leg_day_counter);
-  builder_.add_fixed_leg_convention(fixed_leg_convention);
-  builder_.add_calendar(calendar);
+  if(fixed_leg_day_counter) { builder_.add_fixed_leg_day_counter(*fixed_leg_day_counter); }
+  if(fixed_leg_convention) { builder_.add_fixed_leg_convention(*fixed_leg_convention); }
+  if(calendar) { builder_.add_calendar(*calendar); }
   return builder_.Finish();
 }
 
@@ -1835,10 +1835,10 @@ inline ::flatbuffers::Offset<DatedOISHelper> CreateDatedOISHelperDirect(
     const char *start_date = nullptr,
     const char *end_date = nullptr,
     ::flatbuffers::Offset<quantra::IndexRef> overnight_index = 0,
-    int32_t settlement_days = 2,
-    quantra::enums::Calendar calendar = quantra::enums::Calendar_TARGET,
-    quantra::enums::BusinessDayConvention fixed_leg_convention = quantra::enums::BusinessDayConvention_ModifiedFollowing,
-    quantra::enums::DayCounter fixed_leg_day_counter = quantra::enums::DayCounter_Actual360,
+    ::flatbuffers::Optional<int32_t> settlement_days = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> fixed_leg_convention = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::DayCounter> fixed_leg_day_counter = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::HelperDependencies> deps = 0,
     const char *quote_id = nullptr) {
   auto start_date__ = start_date ? _fbb.CreateString(start_date) : 0;
@@ -1864,11 +1864,11 @@ struct ZeroRatePointT : public ::flatbuffers::NativeTable {
   typedef ZeroRatePoint TableType;
   std::string date{};
   std::unique_ptr<quantra::PeriodT> tenor{};
-  quantra::enums::Calendar calendar = quantra::enums::Calendar_TARGET;
-  quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_ModifiedFollowing;
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt;
   ::flatbuffers::Optional<double> zero_rate = ::flatbuffers::nullopt;
-  quantra::enums::Compounding compounding = quantra::enums::Compounding_Continuous;
-  quantra::enums::Frequency frequency = quantra::enums::Frequency_Annual;
+  ::flatbuffers::Optional<quantra::enums::Compounding> compounding = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::Frequency> frequency = ::flatbuffers::nullopt;
   ZeroRatePointT() = default;
   ZeroRatePointT(const ZeroRatePointT &o);
   ZeroRatePointT(ZeroRatePointT&&) FLATBUFFERS_NOEXCEPT = default;
@@ -1896,23 +1896,23 @@ struct ZeroRatePoint FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   const quantra::Period *tenor() const {
     return GetPointer<const quantra::Period *>(VT_TENOR);
   }
-  quantra::enums::Calendar calendar() const {
-    return static_cast<quantra::enums::Calendar>(GetField<int8_t>(VT_CALENDAR, 32));
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar() const {
+    return GetOptional<int8_t, quantra::enums::Calendar>(VT_CALENDAR);
   }
-  quantra::enums::BusinessDayConvention business_day_convention() const {
-    return static_cast<quantra::enums::BusinessDayConvention>(GetField<int8_t>(VT_BUSINESS_DAY_CONVENTION, 2));
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention() const {
+    return GetOptional<int8_t, quantra::enums::BusinessDayConvention>(VT_BUSINESS_DAY_CONVENTION);
   }
   /// Zero rate for this maturity. Required.
   ::flatbuffers::Optional<double> zero_rate() const {
     return GetOptional<double, double>(VT_ZERO_RATE);
   }
   /// Compounding convention for the zero rate.
-  quantra::enums::Compounding compounding() const {
-    return static_cast<quantra::enums::Compounding>(GetField<int8_t>(VT_COMPOUNDING, 1));
+  ::flatbuffers::Optional<quantra::enums::Compounding> compounding() const {
+    return GetOptional<int8_t, quantra::enums::Compounding>(VT_COMPOUNDING);
   }
   /// Frequency (used when compounding != Continuous).
-  quantra::enums::Frequency frequency() const {
-    return static_cast<quantra::enums::Frequency>(GetField<int8_t>(VT_FREQUENCY, 0));
+  ::flatbuffers::Optional<quantra::enums::Frequency> frequency() const {
+    return GetOptional<int8_t, quantra::enums::Frequency>(VT_FREQUENCY);
   }
   bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -1943,19 +1943,19 @@ struct ZeroRatePointBuilder {
     fbb_.AddOffset(ZeroRatePoint::VT_TENOR, tenor);
   }
   void add_calendar(quantra::enums::Calendar calendar) {
-    fbb_.AddElement<int8_t>(ZeroRatePoint::VT_CALENDAR, static_cast<int8_t>(calendar), 32);
+    fbb_.AddElement<int8_t>(ZeroRatePoint::VT_CALENDAR, static_cast<int8_t>(calendar));
   }
   void add_business_day_convention(quantra::enums::BusinessDayConvention business_day_convention) {
-    fbb_.AddElement<int8_t>(ZeroRatePoint::VT_BUSINESS_DAY_CONVENTION, static_cast<int8_t>(business_day_convention), 2);
+    fbb_.AddElement<int8_t>(ZeroRatePoint::VT_BUSINESS_DAY_CONVENTION, static_cast<int8_t>(business_day_convention));
   }
   void add_zero_rate(double zero_rate) {
     fbb_.AddElement<double>(ZeroRatePoint::VT_ZERO_RATE, zero_rate);
   }
   void add_compounding(quantra::enums::Compounding compounding) {
-    fbb_.AddElement<int8_t>(ZeroRatePoint::VT_COMPOUNDING, static_cast<int8_t>(compounding), 1);
+    fbb_.AddElement<int8_t>(ZeroRatePoint::VT_COMPOUNDING, static_cast<int8_t>(compounding));
   }
   void add_frequency(quantra::enums::Frequency frequency) {
-    fbb_.AddElement<int8_t>(ZeroRatePoint::VT_FREQUENCY, static_cast<int8_t>(frequency), 0);
+    fbb_.AddElement<int8_t>(ZeroRatePoint::VT_FREQUENCY, static_cast<int8_t>(frequency));
   }
   explicit ZeroRatePointBuilder(::flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
@@ -1972,19 +1972,19 @@ inline ::flatbuffers::Offset<ZeroRatePoint> CreateZeroRatePoint(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     ::flatbuffers::Offset<::flatbuffers::String> date = 0,
     ::flatbuffers::Offset<quantra::Period> tenor = 0,
-    quantra::enums::Calendar calendar = quantra::enums::Calendar_TARGET,
-    quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_ModifiedFollowing,
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt,
     ::flatbuffers::Optional<double> zero_rate = ::flatbuffers::nullopt,
-    quantra::enums::Compounding compounding = quantra::enums::Compounding_Continuous,
-    quantra::enums::Frequency frequency = quantra::enums::Frequency_Annual) {
+    ::flatbuffers::Optional<quantra::enums::Compounding> compounding = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::Frequency> frequency = ::flatbuffers::nullopt) {
   ZeroRatePointBuilder builder_(_fbb);
   if(zero_rate) { builder_.add_zero_rate(*zero_rate); }
   builder_.add_tenor(tenor);
   builder_.add_date(date);
-  builder_.add_frequency(frequency);
-  builder_.add_compounding(compounding);
-  builder_.add_business_day_convention(business_day_convention);
-  builder_.add_calendar(calendar);
+  if(frequency) { builder_.add_frequency(*frequency); }
+  if(compounding) { builder_.add_compounding(*compounding); }
+  if(business_day_convention) { builder_.add_business_day_convention(*business_day_convention); }
+  if(calendar) { builder_.add_calendar(*calendar); }
   return builder_.Finish();
 }
 
@@ -1992,11 +1992,11 @@ inline ::flatbuffers::Offset<ZeroRatePoint> CreateZeroRatePointDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     const char *date = nullptr,
     ::flatbuffers::Offset<quantra::Period> tenor = 0,
-    quantra::enums::Calendar calendar = quantra::enums::Calendar_TARGET,
-    quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_ModifiedFollowing,
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt,
     ::flatbuffers::Optional<double> zero_rate = ::flatbuffers::nullopt,
-    quantra::enums::Compounding compounding = quantra::enums::Compounding_Continuous,
-    quantra::enums::Frequency frequency = quantra::enums::Frequency_Annual) {
+    ::flatbuffers::Optional<quantra::enums::Compounding> compounding = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::Frequency> frequency = ::flatbuffers::nullopt) {
   auto date__ = date ? _fbb.CreateString(date) : 0;
   return quantra::CreateZeroRatePoint(
       _fbb,
@@ -2015,8 +2015,8 @@ struct DiscountFactorPointT : public ::flatbuffers::NativeTable {
   typedef DiscountFactorPoint TableType;
   std::string date{};
   std::unique_ptr<quantra::PeriodT> tenor{};
-  quantra::enums::Calendar calendar = quantra::enums::Calendar_TARGET;
-  quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_ModifiedFollowing;
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt;
   ::flatbuffers::Optional<double> discount_factor = ::flatbuffers::nullopt;
   DiscountFactorPointT() = default;
   DiscountFactorPointT(const DiscountFactorPointT &o);
@@ -2045,11 +2045,11 @@ struct DiscountFactorPoint FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Tabl
   const quantra::Period *tenor() const {
     return GetPointer<const quantra::Period *>(VT_TENOR);
   }
-  quantra::enums::Calendar calendar() const {
-    return static_cast<quantra::enums::Calendar>(GetField<int8_t>(VT_CALENDAR, 32));
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar() const {
+    return GetOptional<int8_t, quantra::enums::Calendar>(VT_CALENDAR);
   }
-  quantra::enums::BusinessDayConvention business_day_convention() const {
-    return static_cast<quantra::enums::BusinessDayConvention>(GetField<int8_t>(VT_BUSINESS_DAY_CONVENTION, 2));
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention() const {
+    return GetOptional<int8_t, quantra::enums::BusinessDayConvention>(VT_BUSINESS_DAY_CONVENTION);
   }
   /// Discount factor to this maturity. Required; must be in (0, 1]. The first
   /// point (reference date) must carry a discount factor of exactly 1.0.
@@ -2083,10 +2083,10 @@ struct DiscountFactorPointBuilder {
     fbb_.AddOffset(DiscountFactorPoint::VT_TENOR, tenor);
   }
   void add_calendar(quantra::enums::Calendar calendar) {
-    fbb_.AddElement<int8_t>(DiscountFactorPoint::VT_CALENDAR, static_cast<int8_t>(calendar), 32);
+    fbb_.AddElement<int8_t>(DiscountFactorPoint::VT_CALENDAR, static_cast<int8_t>(calendar));
   }
   void add_business_day_convention(quantra::enums::BusinessDayConvention business_day_convention) {
-    fbb_.AddElement<int8_t>(DiscountFactorPoint::VT_BUSINESS_DAY_CONVENTION, static_cast<int8_t>(business_day_convention), 2);
+    fbb_.AddElement<int8_t>(DiscountFactorPoint::VT_BUSINESS_DAY_CONVENTION, static_cast<int8_t>(business_day_convention));
   }
   void add_discount_factor(double discount_factor) {
     fbb_.AddElement<double>(DiscountFactorPoint::VT_DISCOUNT_FACTOR, discount_factor);
@@ -2106,15 +2106,15 @@ inline ::flatbuffers::Offset<DiscountFactorPoint> CreateDiscountFactorPoint(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     ::flatbuffers::Offset<::flatbuffers::String> date = 0,
     ::flatbuffers::Offset<quantra::Period> tenor = 0,
-    quantra::enums::Calendar calendar = quantra::enums::Calendar_TARGET,
-    quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_ModifiedFollowing,
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt,
     ::flatbuffers::Optional<double> discount_factor = ::flatbuffers::nullopt) {
   DiscountFactorPointBuilder builder_(_fbb);
   if(discount_factor) { builder_.add_discount_factor(*discount_factor); }
   builder_.add_tenor(tenor);
   builder_.add_date(date);
-  builder_.add_business_day_convention(business_day_convention);
-  builder_.add_calendar(calendar);
+  if(business_day_convention) { builder_.add_business_day_convention(*business_day_convention); }
+  if(calendar) { builder_.add_calendar(*calendar); }
   return builder_.Finish();
 }
 
@@ -2122,8 +2122,8 @@ inline ::flatbuffers::Offset<DiscountFactorPoint> CreateDiscountFactorPointDirec
     ::flatbuffers::FlatBufferBuilder &_fbb,
     const char *date = nullptr,
     ::flatbuffers::Offset<quantra::Period> tenor = 0,
-    quantra::enums::Calendar calendar = quantra::enums::Calendar_TARGET,
-    quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_ModifiedFollowing,
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt,
     ::flatbuffers::Optional<double> discount_factor = ::flatbuffers::nullopt) {
   auto date__ = date ? _fbb.CreateString(date) : 0;
   return quantra::CreateDiscountFactorPoint(
@@ -2141,8 +2141,8 @@ struct ForwardRatePointT : public ::flatbuffers::NativeTable {
   typedef ForwardRatePoint TableType;
   std::string date{};
   std::unique_ptr<quantra::PeriodT> tenor{};
-  quantra::enums::Calendar calendar = quantra::enums::Calendar_TARGET;
-  quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_ModifiedFollowing;
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt;
   ::flatbuffers::Optional<double> forward_rate = ::flatbuffers::nullopt;
   ForwardRatePointT() = default;
   ForwardRatePointT(const ForwardRatePointT &o);
@@ -2175,11 +2175,11 @@ struct ForwardRatePoint FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   const quantra::Period *tenor() const {
     return GetPointer<const quantra::Period *>(VT_TENOR);
   }
-  quantra::enums::Calendar calendar() const {
-    return static_cast<quantra::enums::Calendar>(GetField<int8_t>(VT_CALENDAR, 32));
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar() const {
+    return GetOptional<int8_t, quantra::enums::Calendar>(VT_CALENDAR);
   }
-  quantra::enums::BusinessDayConvention business_day_convention() const {
-    return static_cast<quantra::enums::BusinessDayConvention>(GetField<int8_t>(VT_BUSINESS_DAY_CONVENTION, 2));
+  ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention() const {
+    return GetOptional<int8_t, quantra::enums::BusinessDayConvention>(VT_BUSINESS_DAY_CONVENTION);
   }
   /// Instantaneous, continuously-compounded forward rate at this node.
   /// Required. May be negative in some markets; only non-finite is rejected.
@@ -2213,10 +2213,10 @@ struct ForwardRatePointBuilder {
     fbb_.AddOffset(ForwardRatePoint::VT_TENOR, tenor);
   }
   void add_calendar(quantra::enums::Calendar calendar) {
-    fbb_.AddElement<int8_t>(ForwardRatePoint::VT_CALENDAR, static_cast<int8_t>(calendar), 32);
+    fbb_.AddElement<int8_t>(ForwardRatePoint::VT_CALENDAR, static_cast<int8_t>(calendar));
   }
   void add_business_day_convention(quantra::enums::BusinessDayConvention business_day_convention) {
-    fbb_.AddElement<int8_t>(ForwardRatePoint::VT_BUSINESS_DAY_CONVENTION, static_cast<int8_t>(business_day_convention), 2);
+    fbb_.AddElement<int8_t>(ForwardRatePoint::VT_BUSINESS_DAY_CONVENTION, static_cast<int8_t>(business_day_convention));
   }
   void add_forward_rate(double forward_rate) {
     fbb_.AddElement<double>(ForwardRatePoint::VT_FORWARD_RATE, forward_rate);
@@ -2236,15 +2236,15 @@ inline ::flatbuffers::Offset<ForwardRatePoint> CreateForwardRatePoint(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     ::flatbuffers::Offset<::flatbuffers::String> date = 0,
     ::flatbuffers::Offset<quantra::Period> tenor = 0,
-    quantra::enums::Calendar calendar = quantra::enums::Calendar_TARGET,
-    quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_ModifiedFollowing,
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt,
     ::flatbuffers::Optional<double> forward_rate = ::flatbuffers::nullopt) {
   ForwardRatePointBuilder builder_(_fbb);
   if(forward_rate) { builder_.add_forward_rate(*forward_rate); }
   builder_.add_tenor(tenor);
   builder_.add_date(date);
-  builder_.add_business_day_convention(business_day_convention);
-  builder_.add_calendar(calendar);
+  if(business_day_convention) { builder_.add_business_day_convention(*business_day_convention); }
+  if(calendar) { builder_.add_calendar(*calendar); }
   return builder_.Finish();
 }
 
@@ -2252,8 +2252,8 @@ inline ::flatbuffers::Offset<ForwardRatePoint> CreateForwardRatePointDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     const char *date = nullptr,
     ::flatbuffers::Offset<quantra::Period> tenor = 0,
-    quantra::enums::Calendar calendar = quantra::enums::Calendar_TARGET,
-    quantra::enums::BusinessDayConvention business_day_convention = quantra::enums::BusinessDayConvention_ModifiedFollowing,
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::BusinessDayConvention> business_day_convention = ::flatbuffers::nullopt,
     ::flatbuffers::Optional<double> forward_rate = ::flatbuffers::nullopt) {
   auto date__ = date ? _fbb.CreateString(date) : 0;
   return quantra::CreateForwardRatePoint(
@@ -2425,9 +2425,9 @@ struct FxSwapHelperT : public ::flatbuffers::NativeTable {
   typedef FxSwapHelper TableType;
   ::flatbuffers::Optional<double> fx_points = ::flatbuffers::nullopt;
   std::unique_ptr<quantra::PeriodT> tenor{};
-  int32_t spot_days = 2;
-  quantra::enums::Calendar calendar_domestic = quantra::enums::Calendar_TARGET;
-  quantra::enums::Calendar calendar_foreign = quantra::enums::Calendar_TARGET;
+  ::flatbuffers::Optional<int32_t> spot_days = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar_domestic = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar_foreign = ::flatbuffers::nullopt;
   std::unique_ptr<quantra::HelperDependenciesT> deps{};
   std::string quote_id{};
   FxSwapHelperT() = default;
@@ -2456,14 +2456,14 @@ struct FxSwapHelper FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   const quantra::Period *tenor() const {
     return GetPointer<const quantra::Period *>(VT_TENOR);
   }
-  int32_t spot_days() const {
-    return GetField<int32_t>(VT_SPOT_DAYS, 2);
+  ::flatbuffers::Optional<int32_t> spot_days() const {
+    return GetOptional<int32_t, int32_t>(VT_SPOT_DAYS);
   }
-  quantra::enums::Calendar calendar_domestic() const {
-    return static_cast<quantra::enums::Calendar>(GetField<int8_t>(VT_CALENDAR_DOMESTIC, 32));
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar_domestic() const {
+    return GetOptional<int8_t, quantra::enums::Calendar>(VT_CALENDAR_DOMESTIC);
   }
-  quantra::enums::Calendar calendar_foreign() const {
-    return static_cast<quantra::enums::Calendar>(GetField<int8_t>(VT_CALENDAR_FOREIGN, 32));
+  ::flatbuffers::Optional<quantra::enums::Calendar> calendar_foreign() const {
+    return GetOptional<int8_t, quantra::enums::Calendar>(VT_CALENDAR_FOREIGN);
   }
   const quantra::HelperDependencies *deps() const {
     return GetPointer<const quantra::HelperDependencies *>(VT_DEPS);
@@ -2501,13 +2501,13 @@ struct FxSwapHelperBuilder {
     fbb_.AddOffset(FxSwapHelper::VT_TENOR, tenor);
   }
   void add_spot_days(int32_t spot_days) {
-    fbb_.AddElement<int32_t>(FxSwapHelper::VT_SPOT_DAYS, spot_days, 2);
+    fbb_.AddElement<int32_t>(FxSwapHelper::VT_SPOT_DAYS, spot_days);
   }
   void add_calendar_domestic(quantra::enums::Calendar calendar_domestic) {
-    fbb_.AddElement<int8_t>(FxSwapHelper::VT_CALENDAR_DOMESTIC, static_cast<int8_t>(calendar_domestic), 32);
+    fbb_.AddElement<int8_t>(FxSwapHelper::VT_CALENDAR_DOMESTIC, static_cast<int8_t>(calendar_domestic));
   }
   void add_calendar_foreign(quantra::enums::Calendar calendar_foreign) {
-    fbb_.AddElement<int8_t>(FxSwapHelper::VT_CALENDAR_FOREIGN, static_cast<int8_t>(calendar_foreign), 32);
+    fbb_.AddElement<int8_t>(FxSwapHelper::VT_CALENDAR_FOREIGN, static_cast<int8_t>(calendar_foreign));
   }
   void add_deps(::flatbuffers::Offset<quantra::HelperDependencies> deps) {
     fbb_.AddOffset(FxSwapHelper::VT_DEPS, deps);
@@ -2530,19 +2530,19 @@ inline ::flatbuffers::Offset<FxSwapHelper> CreateFxSwapHelper(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     ::flatbuffers::Optional<double> fx_points = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::Period> tenor = 0,
-    int32_t spot_days = 2,
-    quantra::enums::Calendar calendar_domestic = quantra::enums::Calendar_TARGET,
-    quantra::enums::Calendar calendar_foreign = quantra::enums::Calendar_TARGET,
+    ::flatbuffers::Optional<int32_t> spot_days = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar_domestic = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar_foreign = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::HelperDependencies> deps = 0,
     ::flatbuffers::Offset<::flatbuffers::String> quote_id = 0) {
   FxSwapHelperBuilder builder_(_fbb);
   if(fx_points) { builder_.add_fx_points(*fx_points); }
   builder_.add_quote_id(quote_id);
   builder_.add_deps(deps);
-  builder_.add_spot_days(spot_days);
+  if(spot_days) { builder_.add_spot_days(*spot_days); }
   builder_.add_tenor(tenor);
-  builder_.add_calendar_foreign(calendar_foreign);
-  builder_.add_calendar_domestic(calendar_domestic);
+  if(calendar_foreign) { builder_.add_calendar_foreign(*calendar_foreign); }
+  if(calendar_domestic) { builder_.add_calendar_domestic(*calendar_domestic); }
   return builder_.Finish();
 }
 
@@ -2550,9 +2550,9 @@ inline ::flatbuffers::Offset<FxSwapHelper> CreateFxSwapHelperDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     ::flatbuffers::Optional<double> fx_points = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::Period> tenor = 0,
-    int32_t spot_days = 2,
-    quantra::enums::Calendar calendar_domestic = quantra::enums::Calendar_TARGET,
-    quantra::enums::Calendar calendar_foreign = quantra::enums::Calendar_TARGET,
+    ::flatbuffers::Optional<int32_t> spot_days = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar_domestic = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<quantra::enums::Calendar> calendar_foreign = ::flatbuffers::nullopt,
     ::flatbuffers::Offset<quantra::HelperDependencies> deps = 0,
     const char *quote_id = nullptr) {
   auto quote_id__ = quote_id ? _fbb.CreateString(quote_id) : 0;

--- a/flatbuffers/fbs/cds.fbs
+++ b/flatbuffers/fbs/cds.fbs
@@ -18,14 +18,16 @@ table CDS {
     upfront:double = null;
     day_counter:enums.DayCounter = null;
     business_day_convention:enums.BusinessDayConvention = null;
-    settles_accrual:bool = true;
-    pays_at_default_time:bool = true;
-    rebates_accrual:bool = true;
+    /// ISDA settlement conventions. Presence-required: each is a deliberate
+    /// choice (false round-trips) so an omission is a 400, never a silent true.
+    settles_accrual:bool = null;
+    pays_at_default_time:bool = null;
+    rebates_accrual:bool = null;
     protection_start:string;
     upfront_date:string;
-    last_period_day_counter:enums.DayCounter = Actual360;
+    last_period_day_counter:enums.DayCounter = null;
     trade_date:string;
-    cash_settlement_days:int = 3;
+    cash_settlement_days:int = null;
 }
 
 root_type CDS;

--- a/flatbuffers/fbs/common.fbs
+++ b/flatbuffers/fbs/common.fbs
@@ -2,10 +2,13 @@ include "enums.fbs";
 
 namespace quantra;
 
-/// Canonical period type used across APIs.
+/// Canonical period type used across APIs. Both fields are presence-required:
+/// a bare `n` would silently default to 0 and an omitted `unit` would silently
+/// mean Months, so a forgotten value is a 400 naming the field rather than a
+/// silent (0 Months) tenor.
 table Period {
-    n:int;
-    unit:enums.TimeUnit = Months;
+    n:int = null;
+    unit:enums.TimeUnit = null;
 }
 
 /// Yield/compounding convention specification.

--- a/flatbuffers/fbs/credit_curve.fbs
+++ b/flatbuffers/fbs/credit_curve.fbs
@@ -21,27 +21,29 @@ table CdsQuote {
     running_coupon:double = null;
 }
 
-/// CDS helper conventions for curve building.
+/// CDS helper conventions for curve building. Every convention is
+/// presence-required: an omitted value is a 400 naming the field, never a
+/// silent market-default assumption.
 table CdsHelperConventions {
-    settlement_days:int = 0;
-    frequency:enums.Frequency = Quarterly;
-    business_day_convention:enums.BusinessDayConvention = Following;
-    date_generation_rule:enums.DateGenerationRule = TwentiethIMM;
-    last_period_day_counter:enums.DayCounter = Actual365Fixed;
-    settles_accrual:bool = true;
-    pays_at_default_time:bool = true;
-    rebates_accrual:bool = true;
-    helper_model:enums.CdsHelperModel = MidPoint;
+    settlement_days:int = null;
+    frequency:enums.Frequency = null;
+    business_day_convention:enums.BusinessDayConvention = null;
+    date_generation_rule:enums.DateGenerationRule = null;
+    last_period_day_counter:enums.DayCounter = null;
+    settles_accrual:bool = null;
+    pays_at_default_time:bool = null;
+    rebates_accrual:bool = null;
+    helper_model:enums.CdsHelperModel = null;
 }
 
 /// Default probability curve specification for CDS pricing.
 table CreditCurveSpec {
     id:string (required);
     reference_date:string (required);
-    calendar:enums.Calendar = NullCalendar;
-    day_counter:enums.DayCounter = Actual365Fixed;
-    recovery_rate:double = 0.4;
-    curve_interpolator:enums.Interpolator = LogLinear;
+    calendar:enums.Calendar = null;
+    day_counter:enums.DayCounter = null;
+    recovery_rate:double = null;
+    curve_interpolator:enums.Interpolator = null;
     helper_conventions:CdsHelperConventions;
     /// Build from CDS market quotes.
     quotes:[CdsQuote];

--- a/flatbuffers/fbs/index.fbs
+++ b/flatbuffers/fbs/index.fbs
@@ -21,20 +21,22 @@ table IndexDef {
     id:string (required);
     /// Human-readable name / family label (e.g., "Euribor", "SOFR").
     name:string (required);
-    /// IBOR or Overnight. Determines QuantLib class used.
-    index_type:IndexType = Ibor;
+    /// IBOR or Overnight. Determines QuantLib class used. Presence-required: an
+    /// omitted value is a 400, never the silent Ibor default.
+    index_type:IndexType = null;
     /// Tenor period (e.g., 6 Months for Euribor 6M, 0 Days for overnight).
     tenor:Period;
-    /// Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR).
-    fixing_days:int = 2;
-    /// Calendar for fixing/payment dates.
-    calendar:enums.Calendar = TARGET;
-    /// Business day convention.
-    business_day_convention:enums.BusinessDayConvention = ModifiedFollowing;
-    /// Day count convention.
-    day_counter:enums.DayCounter = Actual360;
-    /// End of month rule (IBOR only, ignored for overnight).
-    end_of_month:bool = true;
+    /// Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR). Presence-required.
+    fixing_days:int = null;
+    /// Calendar for fixing/payment dates. Presence-required.
+    calendar:enums.Calendar = null;
+    /// Business day convention. Presence-required.
+    business_day_convention:enums.BusinessDayConvention = null;
+    /// Day count convention. Presence-required.
+    day_counter:enums.DayCounter = null;
+    /// End of month rule (IBOR only, ignored for overnight). Presence-required:
+    /// absent-vs-false silently changes money-market schedule dates.
+    end_of_month:bool = null;
     /// ISO currency code (e.g., "EUR", "USD", "GBP", "JPY").
     currency:string;
     /// Past fixings needed for seasoned instruments.

--- a/flatbuffers/fbs/inflation.fbs
+++ b/flatbuffers/fbs/inflation.fbs
@@ -13,20 +13,21 @@ table InflationIndexSpec {
     family_name:string;
     /// ISO currency code (e.g., "GBP", "EUR", "USD").
     currency:string;
-    calendar:enums.Calendar = TARGET;
-    day_counter:enums.DayCounter = Actual365Fixed;
-    frequency:enums.Frequency = Monthly;
+    calendar:enums.Calendar = null;
+    day_counter:enums.DayCounter = null;
+    frequency:enums.Frequency = null;
 
     /// Publication availability lag (e.g., 2 Months).
     availability_lag:Period;
     /// Observation lag used for swaps (e.g., 3 Months).
     observation_lag:Period;
-    /// Whether the index is interpolated between fixings.
-    interpolated:bool = true;
-    /// Whether index values can be revised (rare; defaults to false).
-    revised:bool = false;
+    /// Whether the index is interpolated between fixings. Presence-required:
+    /// absent-vs-false silently changes the observed CPI.
+    interpolated:bool = null;
+    /// Whether index values can be revised (rare). Presence-required.
+    revised:bool = null;
 
-    kind:enums.InflationCurveKind = ZeroInflation;
+    kind:enums.InflationCurveKind = null;
     /// For ratio-based YoY indices, link to the underlying zero inflation index id.
     underlying_zero_index_id:string;
     /// Historical CPI/YoY fixings needed for helper-based bootstrap and forecasting.
@@ -49,10 +50,10 @@ table ZeroCouponInflationSwapHelper {
     start_date:string;
     /// Optional explicit end/maturity date for dated helper construction.
     end_date:string;
-    calendar:enums.Calendar = TARGET;
-    payment_convention:enums.BusinessDayConvention = ModifiedFollowing;
-    day_counter:enums.DayCounter = Actual365Fixed;
-    observation_interpolation:enums.CPIInterpolationType = AsIndex;
+    calendar:enums.Calendar = null;
+    payment_convention:enums.BusinessDayConvention = null;
+    day_counter:enums.DayCounter = null;
+    observation_interpolation:enums.CPIInterpolationType = null;
 }
 
 /// Year-on-year inflation swap helper point.
@@ -67,10 +68,10 @@ table YearOnYearInflationSwapHelper {
     tenor:Period;
     start_date:string;
     end_date:string;
-    calendar:enums.Calendar = TARGET;
-    payment_convention:enums.BusinessDayConvention = ModifiedFollowing;
-    day_counter:enums.DayCounter = Actual365Fixed;
-    observation_interpolation:enums.CPIInterpolationType = AsIndex;
+    calendar:enums.Calendar = null;
+    payment_convention:enums.BusinessDayConvention = null;
+    day_counter:enums.DayCounter = null;
+    observation_interpolation:enums.CPIInterpolationType = null;
     /// QuantLib YoY helper requires a nominal term structure id.
     nominal_curve_id:string (required);
 }
@@ -90,13 +91,14 @@ table InflationPointWrapper {
 table InflationCurveSpec {
     id:string (required);
     reference_date:string (required);
-    calendar:enums.Calendar = TARGET;
-    business_day_convention:enums.BusinessDayConvention = ModifiedFollowing;
-    day_counter:enums.DayCounter = Actual365Fixed;
-    interpolator:enums.Interpolator = Linear;
+    calendar:enums.Calendar = null;
+    business_day_convention:enums.BusinessDayConvention = null;
+    day_counter:enums.DayCounter = null;
+    interpolator:enums.Interpolator = null;
+    /// Numerical bootstrap tolerance (not a market convention): keeps its default.
     bootstrap_accuracy:double = 1.0e-12;
 
-    kind:enums.InflationCurveKind = ZeroInflation;
+    kind:enums.InflationCurveKind = null;
     /// Link to InflationIndexSpec.id.
     index_id:string (required);
     /// Optional discount curve id for inflation-leg projection/discounting models.

--- a/flatbuffers/fbs/schedule.fbs
+++ b/flatbuffers/fbs/schedule.fbs
@@ -11,7 +11,9 @@ table Schedule {
     convention:enums.BusinessDayConvention = null;
     termination_date_convention:enums.BusinessDayConvention = null;
     date_generation_rule:enums.DateGenerationRule = null;
-    end_of_month:bool;
+    /// Presence-required: absent-vs-false silently changes schedule dates for
+    /// month-end-anchored (money-market) schedules.
+    end_of_month:bool = null;
     /// Optional. ISO-8601 (YYYY-MM-DD). When present, passed as QuantLib's
     /// firstDate, which controls the FIRST stub coupon: with Backward date
     /// generation a first_date after effective_date creates a short/long first

--- a/flatbuffers/fbs/swap_index.fbs
+++ b/flatbuffers/fbs/swap_index.fbs
@@ -9,39 +9,40 @@ enum SwapIndexKind : byte {
     OisSwapIndex = 1
 }
 
-/// Fixed leg conventions for swap index.
+/// Fixed leg conventions for swap index. Every convention is presence-required.
 table SwapIndexFixedLegSpec {
-    fixed_frequency:enums.Frequency = Annual;
-    fixed_day_counter:enums.DayCounter = Thirty360;
-    fixed_calendar:enums.Calendar = TARGET;
-    fixed_bdc:enums.BusinessDayConvention = ModifiedFollowing;
-    fixed_term_bdc:enums.BusinessDayConvention = ModifiedFollowing;
-    fixed_date_rule:enums.DateGenerationRule = Forward;
-    fixed_eom:bool = false;
+    fixed_frequency:enums.Frequency = null;
+    fixed_day_counter:enums.DayCounter = null;
+    fixed_calendar:enums.Calendar = null;
+    fixed_bdc:enums.BusinessDayConvention = null;
+    fixed_term_bdc:enums.BusinessDayConvention = null;
+    fixed_date_rule:enums.DateGenerationRule = null;
+    fixed_eom:bool = null;
 }
 
-/// Floating leg conventions for swap index.
+/// Floating leg conventions for swap index. Every convention is
+/// presence-required.
 table SwapIndexFloatLegSpec {
     float_tenor:Period;
-    float_calendar:enums.Calendar = TARGET;
-    float_bdc:enums.BusinessDayConvention = ModifiedFollowing;
-    float_term_bdc:enums.BusinessDayConvention = ModifiedFollowing;
-    float_date_rule:enums.DateGenerationRule = Forward;
-    float_eom:bool = false;
+    float_calendar:enums.Calendar = null;
+    float_bdc:enums.BusinessDayConvention = null;
+    float_term_bdc:enums.BusinessDayConvention = null;
+    float_date_rule:enums.DateGenerationRule = null;
+    float_eom:bool = null;
 }
 
 /// Swap index definition for swaption smile conventions.
 table SwapIndexDef {
     id:string (required);
-    kind:SwapIndexKind = IborSwapIndex;
+    kind:SwapIndexKind = null;
     /// Spot/effective-date lag used for exercise-to-swap-start advancement.
-    spot_days:int = 2;
+    spot_days:int = null;
     /// Metadata only; pricing uses fixed_leg/float_leg conventions.
-    calendar:enums.Calendar = TARGET;
+    calendar:enums.Calendar = null;
     /// Metadata only; pricing uses fixed_leg/float_leg conventions.
-    business_day_convention:enums.BusinessDayConvention = ModifiedFollowing;
+    business_day_convention:enums.BusinessDayConvention = null;
     /// Metadata only; pricing uses fixed_leg/float_leg conventions.
-    end_of_month:bool = false;
+    end_of_month:bool = null;
     fixed_leg:SwapIndexFixedLegSpec;
     /// Reference to IndexDef by id.
     float_index_id:string (required);

--- a/flatbuffers/fbs/term_structure.fbs
+++ b/flatbuffers/fbs/term_structure.fbs
@@ -115,11 +115,11 @@ table OISHelper {
     tenor:Period;
     /// Reference to an overnight IndexDef by id (e.g., "USD_SOFR").
     overnight_index:IndexRef (required);
-    settlement_days:int = 2;
-    calendar:enums.Calendar = TARGET;
-    fixed_leg_frequency:enums.Frequency = Annual;
-    fixed_leg_convention:enums.BusinessDayConvention = ModifiedFollowing;
-    fixed_leg_day_counter:enums.DayCounter = Actual360;
+    settlement_days:int = null;
+    calendar:enums.Calendar = null;
+    fixed_leg_frequency:enums.Frequency = null;
+    fixed_leg_convention:enums.BusinessDayConvention = null;
+    fixed_leg_day_counter:enums.DayCounter = null;
     /// Exogenous discount curve for dual-curve OIS bootstrapping.
     deps:HelperDependencies;
     quote_id:string;
@@ -133,10 +133,10 @@ table DatedOISHelper {
     end_date:string (required);
     /// Reference to an overnight IndexDef by id.
     overnight_index:IndexRef (required);
-    settlement_days:int = 2;
-    calendar:enums.Calendar = TARGET;
-    fixed_leg_convention:enums.BusinessDayConvention = ModifiedFollowing;
-    fixed_leg_day_counter:enums.DayCounter = Actual360;
+    settlement_days:int = null;
+    calendar:enums.Calendar = null;
+    fixed_leg_convention:enums.BusinessDayConvention = null;
+    fixed_leg_day_counter:enums.DayCounter = null;
     /// Exogenous discount curve for dual-curve OIS bootstrapping.
     deps:HelperDependencies;
     quote_id:string;
@@ -148,14 +148,14 @@ table ZeroRatePoint {
     date:string;
     /// Alternative: tenor from reference date.
     tenor:Period;
-    calendar:enums.Calendar = TARGET;
-    business_day_convention:enums.BusinessDayConvention = ModifiedFollowing;
+    calendar:enums.Calendar = null;
+    business_day_convention:enums.BusinessDayConvention = null;
     /// Zero rate for this maturity. Required.
     zero_rate:double = null;
     /// Compounding convention for the zero rate.
-    compounding:enums.Compounding = Continuous;
+    compounding:enums.Compounding = null;
     /// Frequency (used when compounding != Continuous).
-    frequency:enums.Frequency = Annual;
+    frequency:enums.Frequency = null;
 }
 
 /// Discount-factor point for direct curve construction (no bootstrapping).
@@ -166,8 +166,8 @@ table DiscountFactorPoint {
     date:string;
     /// Alternative: tenor from reference date.
     tenor:Period;
-    calendar:enums.Calendar = TARGET;
-    business_day_convention:enums.BusinessDayConvention = ModifiedFollowing;
+    calendar:enums.Calendar = null;
+    business_day_convention:enums.BusinessDayConvention = null;
     /// Discount factor to this maturity. Required; must be in (0, 1]. The first
     /// point (reference date) must carry a discount factor of exactly 1.0.
     discount_factor:double = null;
@@ -185,8 +185,8 @@ table ForwardRatePoint {
     date:string;
     /// Alternative: tenor from reference date.
     tenor:Period;
-    calendar:enums.Calendar = TARGET;
-    business_day_convention:enums.BusinessDayConvention = ModifiedFollowing;
+    calendar:enums.Calendar = null;
+    business_day_convention:enums.BusinessDayConvention = null;
     /// Instantaneous, continuously-compounded forward rate at this node.
     /// Required. May be negative in some markets; only non-finite is rejected.
     forward_rate:double = null;
@@ -211,9 +211,9 @@ table FxSwapHelper {
     /// FX forward points. One of fx_points or quote_id must be provided.
     fx_points:double = null;
     tenor:Period;
-    spot_days:int = 2;
-    calendar_domestic:enums.Calendar = TARGET;
-    calendar_foreign:enums.Calendar = TARGET;
+    spot_days:int = null;
+    calendar_domestic:enums.Calendar = null;
+    calendar_foreign:enums.Calendar = null;
     deps:HelperDependencies;
     quote_id:string;
 }

--- a/flatbuffers/json/basis_swap.schema.json
+++ b/flatbuffers/json/basis_swap.schema.json
@@ -207,7 +207,8 @@
                 "$ref" : "#/definitions/quantra_enums_DateGenerationRule"
               },
         "end_of_month" : {
-                "type" : "boolean"
+                "type" : "boolean",
+                "description" : "Presence-required: absent-vs-false silently changes schedule dates for\nmonth-end-anchored (money-market) schedules."
               },
         "first_date" : {
                 "type" : "string",
@@ -222,7 +223,7 @@
     },
     "quantra_Period" : {
       "type" : "object",
-      "description" : "Canonical period type used across APIs.",
+      "description" : "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
       "properties" : {
         "n" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -369,7 +370,7 @@
               },
         "index_type" : {
                 "$ref" : "#/definitions/quantra_IndexType",
-                "description" : "IBOR or Overnight. Determines QuantLib class used."
+                "description" : "IBOR or Overnight. Determines QuantLib class used. Presence-required: an\nomitted value is a 400, never the silent Ibor default."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -377,23 +378,23 @@
               },
         "fixing_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647,
-                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR)."
+                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR). Presence-required."
               },
         "calendar" : {
                 "$ref" : "#/definitions/quantra_enums_Calendar",
-                "description" : "Calendar for fixing/payment dates."
+                "description" : "Calendar for fixing/payment dates. Presence-required."
               },
         "business_day_convention" : {
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention",
-                "description" : "Business day convention."
+                "description" : "Business day convention. Presence-required."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter",
-                "description" : "Day count convention."
+                "description" : "Day count convention. Presence-required."
               },
         "end_of_month" : {
                 "type" : "boolean",
-                "description" : "End of month rule (IBOR only, ignored for overnight)."
+                "description" : "End of month rule (IBOR only, ignored for overnight). Presence-required:\nabsent-vs-false silently changes money-market schedule dates."
               },
         "currency" : {
                 "type" : "string",

--- a/flatbuffers/json/basis_swap_response.schema.json
+++ b/flatbuffers/json/basis_swap_response.schema.json
@@ -179,7 +179,7 @@
     },
     "quantra_Period" : {
       "type" : "object",
-      "description" : "Canonical period type used across APIs.",
+      "description" : "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
       "properties" : {
         "n" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647

--- a/flatbuffers/json/bootstrap_curves_request.schema.json
+++ b/flatbuffers/json/bootstrap_curves_request.schema.json
@@ -235,7 +235,7 @@
     },
     "quantra_Period" : {
       "type" : "object",
-      "description" : "Canonical period type used across APIs.",
+      "description" : "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
       "properties" : {
         "n" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -380,7 +380,8 @@
                 "$ref" : "#/definitions/quantra_enums_DateGenerationRule"
               },
         "end_of_month" : {
-                "type" : "boolean"
+                "type" : "boolean",
+                "description" : "Presence-required: absent-vs-false silently changes schedule dates for\nmonth-end-anchored (money-market) schedules."
               },
         "first_date" : {
                 "type" : "string",
@@ -421,7 +422,7 @@
               },
         "index_type" : {
                 "$ref" : "#/definitions/quantra_IndexType",
-                "description" : "IBOR or Overnight. Determines QuantLib class used."
+                "description" : "IBOR or Overnight. Determines QuantLib class used. Presence-required: an\nomitted value is a 400, never the silent Ibor default."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -429,23 +430,23 @@
               },
         "fixing_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647,
-                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR)."
+                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR). Presence-required."
               },
         "calendar" : {
                 "$ref" : "#/definitions/quantra_enums_Calendar",
-                "description" : "Calendar for fixing/payment dates."
+                "description" : "Calendar for fixing/payment dates. Presence-required."
               },
         "business_day_convention" : {
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention",
-                "description" : "Business day convention."
+                "description" : "Business day convention. Presence-required."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter",
-                "description" : "Day count convention."
+                "description" : "Day count convention. Presence-required."
               },
         "end_of_month" : {
                 "type" : "boolean",
-                "description" : "End of month rule (IBOR only, ignored for overnight)."
+                "description" : "End of month rule (IBOR only, ignored for overnight). Presence-required:\nabsent-vs-false silently changes money-market schedule dates."
               },
         "currency" : {
                 "type" : "string",
@@ -1628,7 +1629,7 @@
     },
     "quantra_SwapIndexFixedLegSpec" : {
       "type" : "object",
-      "description" : "Fixed leg conventions for swap index.",
+      "description" : "Fixed leg conventions for swap index. Every convention is presence-required.",
       "properties" : {
         "fixed_frequency" : {
                 "$ref" : "#/definitions/quantra_enums_Frequency"
@@ -1656,7 +1657,7 @@
     },
     "quantra_SwapIndexFloatLegSpec" : {
       "type" : "object",
-      "description" : "Floating leg conventions for swap index.",
+      "description" : "Floating leg conventions for swap index. Every convention is\npresence-required.",
       "properties" : {
         "float_tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -1751,7 +1752,7 @@
     },
     "quantra_CdsHelperConventions" : {
       "type" : "object",
-      "description" : "CDS helper conventions for curve building.",
+      "description" : "CDS helper conventions for curve building. Every convention is\npresence-required: an omitted value is a 400 naming the field, never a\nsilent market-default assumption.",
       "properties" : {
         "settlement_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -2027,11 +2028,11 @@
               },
         "interpolated" : {
                 "type" : "boolean",
-                "description" : "Whether the index is interpolated between fixings."
+                "description" : "Whether the index is interpolated between fixings. Presence-required:\nabsent-vs-false silently changes the observed CPI."
               },
         "revised" : {
                 "type" : "boolean",
-                "description" : "Whether index values can be revised (rare; defaults to false)."
+                "description" : "Whether index values can be revised (rare). Presence-required."
               },
         "kind" : {
                 "$ref" : "#/definitions/quantra_enums_InflationCurveKind"
@@ -2172,7 +2173,8 @@
                 "$ref" : "#/definitions/quantra_enums_Interpolator"
               },
         "bootstrap_accuracy" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Numerical bootstrap tolerance (not a market convention): keeps its default."
               },
         "kind" : {
                 "$ref" : "#/definitions/quantra_enums_InflationCurveKind"

--- a/flatbuffers/json/bootstrap_curves_response.schema.json
+++ b/flatbuffers/json/bootstrap_curves_response.schema.json
@@ -191,7 +191,7 @@
     },
     "quantra_Period" : {
       "type" : "object",
-      "description" : "Canonical period type used across APIs.",
+      "description" : "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
       "properties" : {
         "n" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647

--- a/flatbuffers/json/bootstrap_inflation_curves_request.schema.json
+++ b/flatbuffers/json/bootstrap_inflation_curves_request.schema.json
@@ -227,7 +227,7 @@
     },
     "quantra_Period" : {
       "type" : "object",
-      "description" : "Canonical period type used across APIs.",
+      "description" : "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
       "properties" : {
         "n" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -372,7 +372,8 @@
                 "$ref" : "#/definitions/quantra_enums_DateGenerationRule"
               },
         "end_of_month" : {
-                "type" : "boolean"
+                "type" : "boolean",
+                "description" : "Presence-required: absent-vs-false silently changes schedule dates for\nmonth-end-anchored (money-market) schedules."
               },
         "first_date" : {
                 "type" : "string",
@@ -413,7 +414,7 @@
               },
         "index_type" : {
                 "$ref" : "#/definitions/quantra_IndexType",
-                "description" : "IBOR or Overnight. Determines QuantLib class used."
+                "description" : "IBOR or Overnight. Determines QuantLib class used. Presence-required: an\nomitted value is a 400, never the silent Ibor default."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -421,23 +422,23 @@
               },
         "fixing_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647,
-                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR)."
+                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR). Presence-required."
               },
         "calendar" : {
                 "$ref" : "#/definitions/quantra_enums_Calendar",
-                "description" : "Calendar for fixing/payment dates."
+                "description" : "Calendar for fixing/payment dates. Presence-required."
               },
         "business_day_convention" : {
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention",
-                "description" : "Business day convention."
+                "description" : "Business day convention. Presence-required."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter",
-                "description" : "Day count convention."
+                "description" : "Day count convention. Presence-required."
               },
         "end_of_month" : {
                 "type" : "boolean",
-                "description" : "End of month rule (IBOR only, ignored for overnight)."
+                "description" : "End of month rule (IBOR only, ignored for overnight). Presence-required:\nabsent-vs-false silently changes money-market schedule dates."
               },
         "currency" : {
                 "type" : "string",
@@ -1620,7 +1621,7 @@
     },
     "quantra_SwapIndexFixedLegSpec" : {
       "type" : "object",
-      "description" : "Fixed leg conventions for swap index.",
+      "description" : "Fixed leg conventions for swap index. Every convention is presence-required.",
       "properties" : {
         "fixed_frequency" : {
                 "$ref" : "#/definitions/quantra_enums_Frequency"
@@ -1648,7 +1649,7 @@
     },
     "quantra_SwapIndexFloatLegSpec" : {
       "type" : "object",
-      "description" : "Floating leg conventions for swap index.",
+      "description" : "Floating leg conventions for swap index. Every convention is\npresence-required.",
       "properties" : {
         "float_tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -1743,7 +1744,7 @@
     },
     "quantra_CdsHelperConventions" : {
       "type" : "object",
-      "description" : "CDS helper conventions for curve building.",
+      "description" : "CDS helper conventions for curve building. Every convention is\npresence-required: an omitted value is a 400 naming the field, never a\nsilent market-default assumption.",
       "properties" : {
         "settlement_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -2019,11 +2020,11 @@
               },
         "interpolated" : {
                 "type" : "boolean",
-                "description" : "Whether the index is interpolated between fixings."
+                "description" : "Whether the index is interpolated between fixings. Presence-required:\nabsent-vs-false silently changes the observed CPI."
               },
         "revised" : {
                 "type" : "boolean",
-                "description" : "Whether index values can be revised (rare; defaults to false)."
+                "description" : "Whether index values can be revised (rare). Presence-required."
               },
         "kind" : {
                 "$ref" : "#/definitions/quantra_enums_InflationCurveKind"
@@ -2164,7 +2165,8 @@
                 "$ref" : "#/definitions/quantra_enums_Interpolator"
               },
         "bootstrap_accuracy" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Numerical bootstrap tolerance (not a market convention): keeps its default."
               },
         "kind" : {
                 "$ref" : "#/definitions/quantra_enums_InflationCurveKind"

--- a/flatbuffers/json/bootstrap_inflation_curves_response.schema.json
+++ b/flatbuffers/json/bootstrap_inflation_curves_response.schema.json
@@ -179,7 +179,7 @@
     },
     "quantra_Period" : {
       "type" : "object",
-      "description" : "Canonical period type used across APIs.",
+      "description" : "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
       "properties" : {
         "n" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647

--- a/flatbuffers/json/calibrate_swaption_model_request.schema.json
+++ b/flatbuffers/json/calibrate_swaption_model_request.schema.json
@@ -247,7 +247,8 @@
                 "$ref" : "#/definitions/quantra_enums_DateGenerationRule"
               },
         "end_of_month" : {
-                "type" : "boolean"
+                "type" : "boolean",
+                "description" : "Presence-required: absent-vs-false silently changes schedule dates for\nmonth-end-anchored (money-market) schedules."
               },
         "first_date" : {
                 "type" : "string",
@@ -262,7 +263,7 @@
     },
     "quantra_Period" : {
       "type" : "object",
-      "description" : "Canonical period type used across APIs.",
+      "description" : "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
       "properties" : {
         "n" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -409,7 +410,7 @@
               },
         "index_type" : {
                 "$ref" : "#/definitions/quantra_IndexType",
-                "description" : "IBOR or Overnight. Determines QuantLib class used."
+                "description" : "IBOR or Overnight. Determines QuantLib class used. Presence-required: an\nomitted value is a 400, never the silent Ibor default."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -417,23 +418,23 @@
               },
         "fixing_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647,
-                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR)."
+                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR). Presence-required."
               },
         "calendar" : {
                 "$ref" : "#/definitions/quantra_enums_Calendar",
-                "description" : "Calendar for fixing/payment dates."
+                "description" : "Calendar for fixing/payment dates. Presence-required."
               },
         "business_day_convention" : {
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention",
-                "description" : "Business day convention."
+                "description" : "Business day convention. Presence-required."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter",
-                "description" : "Day count convention."
+                "description" : "Day count convention. Presence-required."
               },
         "end_of_month" : {
                 "type" : "boolean",
-                "description" : "End of month rule (IBOR only, ignored for overnight)."
+                "description" : "End of month rule (IBOR only, ignored for overnight). Presence-required:\nabsent-vs-false silently changes money-market schedule dates."
               },
         "currency" : {
                 "type" : "string",
@@ -1616,7 +1617,7 @@
     },
     "quantra_SwapIndexFixedLegSpec" : {
       "type" : "object",
-      "description" : "Fixed leg conventions for swap index.",
+      "description" : "Fixed leg conventions for swap index. Every convention is presence-required.",
       "properties" : {
         "fixed_frequency" : {
                 "$ref" : "#/definitions/quantra_enums_Frequency"
@@ -1644,7 +1645,7 @@
     },
     "quantra_SwapIndexFloatLegSpec" : {
       "type" : "object",
-      "description" : "Floating leg conventions for swap index.",
+      "description" : "Floating leg conventions for swap index. Every convention is\npresence-required.",
       "properties" : {
         "float_tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -1739,7 +1740,7 @@
     },
     "quantra_CdsHelperConventions" : {
       "type" : "object",
-      "description" : "CDS helper conventions for curve building.",
+      "description" : "CDS helper conventions for curve building. Every convention is\npresence-required: an omitted value is a 400 naming the field, never a\nsilent market-default assumption.",
       "properties" : {
         "settlement_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -2015,11 +2016,11 @@
               },
         "interpolated" : {
                 "type" : "boolean",
-                "description" : "Whether the index is interpolated between fixings."
+                "description" : "Whether the index is interpolated between fixings. Presence-required:\nabsent-vs-false silently changes the observed CPI."
               },
         "revised" : {
                 "type" : "boolean",
-                "description" : "Whether index values can be revised (rare; defaults to false)."
+                "description" : "Whether index values can be revised (rare). Presence-required."
               },
         "kind" : {
                 "$ref" : "#/definitions/quantra_enums_InflationCurveKind"
@@ -2160,7 +2161,8 @@
                 "$ref" : "#/definitions/quantra_enums_Interpolator"
               },
         "bootstrap_accuracy" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Numerical bootstrap tolerance (not a market convention): keeps its default."
               },
         "kind" : {
                 "$ref" : "#/definitions/quantra_enums_InflationCurveKind"

--- a/flatbuffers/json/calibrate_swaption_vol_request.schema.json
+++ b/flatbuffers/json/calibrate_swaption_vol_request.schema.json
@@ -247,7 +247,8 @@
                 "$ref" : "#/definitions/quantra_enums_DateGenerationRule"
               },
         "end_of_month" : {
-                "type" : "boolean"
+                "type" : "boolean",
+                "description" : "Presence-required: absent-vs-false silently changes schedule dates for\nmonth-end-anchored (money-market) schedules."
               },
         "first_date" : {
                 "type" : "string",
@@ -262,7 +263,7 @@
     },
     "quantra_Period" : {
       "type" : "object",
-      "description" : "Canonical period type used across APIs.",
+      "description" : "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
       "properties" : {
         "n" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -409,7 +410,7 @@
               },
         "index_type" : {
                 "$ref" : "#/definitions/quantra_IndexType",
-                "description" : "IBOR or Overnight. Determines QuantLib class used."
+                "description" : "IBOR or Overnight. Determines QuantLib class used. Presence-required: an\nomitted value is a 400, never the silent Ibor default."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -417,23 +418,23 @@
               },
         "fixing_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647,
-                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR)."
+                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR). Presence-required."
               },
         "calendar" : {
                 "$ref" : "#/definitions/quantra_enums_Calendar",
-                "description" : "Calendar for fixing/payment dates."
+                "description" : "Calendar for fixing/payment dates. Presence-required."
               },
         "business_day_convention" : {
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention",
-                "description" : "Business day convention."
+                "description" : "Business day convention. Presence-required."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter",
-                "description" : "Day count convention."
+                "description" : "Day count convention. Presence-required."
               },
         "end_of_month" : {
                 "type" : "boolean",
-                "description" : "End of month rule (IBOR only, ignored for overnight)."
+                "description" : "End of month rule (IBOR only, ignored for overnight). Presence-required:\nabsent-vs-false silently changes money-market schedule dates."
               },
         "currency" : {
                 "type" : "string",
@@ -1616,7 +1617,7 @@
     },
     "quantra_SwapIndexFixedLegSpec" : {
       "type" : "object",
-      "description" : "Fixed leg conventions for swap index.",
+      "description" : "Fixed leg conventions for swap index. Every convention is presence-required.",
       "properties" : {
         "fixed_frequency" : {
                 "$ref" : "#/definitions/quantra_enums_Frequency"
@@ -1644,7 +1645,7 @@
     },
     "quantra_SwapIndexFloatLegSpec" : {
       "type" : "object",
-      "description" : "Floating leg conventions for swap index.",
+      "description" : "Floating leg conventions for swap index. Every convention is\npresence-required.",
       "properties" : {
         "float_tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -1739,7 +1740,7 @@
     },
     "quantra_CdsHelperConventions" : {
       "type" : "object",
-      "description" : "CDS helper conventions for curve building.",
+      "description" : "CDS helper conventions for curve building. Every convention is\npresence-required: an omitted value is a 400 naming the field, never a\nsilent market-default assumption.",
       "properties" : {
         "settlement_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -2015,11 +2016,11 @@
               },
         "interpolated" : {
                 "type" : "boolean",
-                "description" : "Whether the index is interpolated between fixings."
+                "description" : "Whether the index is interpolated between fixings. Presence-required:\nabsent-vs-false silently changes the observed CPI."
               },
         "revised" : {
                 "type" : "boolean",
-                "description" : "Whether index values can be revised (rare; defaults to false)."
+                "description" : "Whether index values can be revised (rare). Presence-required."
               },
         "kind" : {
                 "$ref" : "#/definitions/quantra_enums_InflationCurveKind"
@@ -2160,7 +2161,8 @@
                 "$ref" : "#/definitions/quantra_enums_Interpolator"
               },
         "bootstrap_accuracy" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Numerical bootstrap tolerance (not a market convention): keeps its default."
               },
         "kind" : {
                 "$ref" : "#/definitions/quantra_enums_InflationCurveKind"

--- a/flatbuffers/json/calibrate_swaption_vol_response.schema.json
+++ b/flatbuffers/json/calibrate_swaption_vol_response.schema.json
@@ -179,7 +179,7 @@
     },
     "quantra_Period" : {
       "type" : "object",
-      "description" : "Canonical period type used across APIs.",
+      "description" : "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
       "properties" : {
         "n" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647

--- a/flatbuffers/json/callable_fixed_rate_bond.schema.json
+++ b/flatbuffers/json/callable_fixed_rate_bond.schema.json
@@ -199,7 +199,8 @@
                 "$ref" : "#/definitions/quantra_enums_DateGenerationRule"
               },
         "end_of_month" : {
-                "type" : "boolean"
+                "type" : "boolean",
+                "description" : "Presence-required: absent-vs-false silently changes schedule dates for\nmonth-end-anchored (money-market) schedules."
               },
         "first_date" : {
                 "type" : "string",

--- a/flatbuffers/json/cap_floor.schema.json
+++ b/flatbuffers/json/cap_floor.schema.json
@@ -183,7 +183,7 @@
     },
     "quantra_Period" : {
       "type" : "object",
-      "description" : "Canonical period type used across APIs.",
+      "description" : "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
       "properties" : {
         "n" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -330,7 +330,7 @@
               },
         "index_type" : {
                 "$ref" : "#/definitions/quantra_IndexType",
-                "description" : "IBOR or Overnight. Determines QuantLib class used."
+                "description" : "IBOR or Overnight. Determines QuantLib class used. Presence-required: an\nomitted value is a 400, never the silent Ibor default."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -338,23 +338,23 @@
               },
         "fixing_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647,
-                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR)."
+                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR). Presence-required."
               },
         "calendar" : {
                 "$ref" : "#/definitions/quantra_enums_Calendar",
-                "description" : "Calendar for fixing/payment dates."
+                "description" : "Calendar for fixing/payment dates. Presence-required."
               },
         "business_day_convention" : {
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention",
-                "description" : "Business day convention."
+                "description" : "Business day convention. Presence-required."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter",
-                "description" : "Day count convention."
+                "description" : "Day count convention. Presence-required."
               },
         "end_of_month" : {
                 "type" : "boolean",
-                "description" : "End of month rule (IBOR only, ignored for overnight)."
+                "description" : "End of month rule (IBOR only, ignored for overnight). Presence-required:\nabsent-vs-false silently changes money-market schedule dates."
               },
         "currency" : {
                 "type" : "string",
@@ -405,7 +405,8 @@
                 "$ref" : "#/definitions/quantra_enums_DateGenerationRule"
               },
         "end_of_month" : {
-                "type" : "boolean"
+                "type" : "boolean",
+                "description" : "Presence-required: absent-vs-false silently changes schedule dates for\nmonth-end-anchored (money-market) schedules."
               },
         "first_date" : {
                 "type" : "string",

--- a/flatbuffers/json/cds.schema.json
+++ b/flatbuffers/json/cds.schema.json
@@ -199,7 +199,8 @@
                 "$ref" : "#/definitions/quantra_enums_DateGenerationRule"
               },
         "end_of_month" : {
-                "type" : "boolean"
+                "type" : "boolean",
+                "description" : "Presence-required: absent-vs-false silently changes schedule dates for\nmonth-end-anchored (money-market) schedules."
               },
         "first_date" : {
                 "type" : "string",
@@ -241,7 +242,8 @@
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention"
               },
         "settles_accrual" : {
-                "type" : "boolean"
+                "type" : "boolean",
+                "description" : "ISDA settlement conventions. Presence-required: each is a deliberate\nchoice (false round-trips) so an omission is a 400, never a silent true."
               },
         "pays_at_default_time" : {
                 "type" : "boolean"

--- a/flatbuffers/json/cds_response.schema.json
+++ b/flatbuffers/json/cds_response.schema.json
@@ -179,7 +179,7 @@
     },
     "quantra_Period" : {
       "type" : "object",
-      "description" : "Canonical period type used across APIs.",
+      "description" : "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
       "properties" : {
         "n" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647

--- a/flatbuffers/json/fixed_rate_bond.schema.json
+++ b/flatbuffers/json/fixed_rate_bond.schema.json
@@ -199,7 +199,8 @@
                 "$ref" : "#/definitions/quantra_enums_DateGenerationRule"
               },
         "end_of_month" : {
-                "type" : "boolean"
+                "type" : "boolean",
+                "description" : "Presence-required: absent-vs-false silently changes schedule dates for\nmonth-end-anchored (money-market) schedules."
               },
         "first_date" : {
                 "type" : "string",

--- a/flatbuffers/json/fixed_rate_bond_response.schema.json
+++ b/flatbuffers/json/fixed_rate_bond_response.schema.json
@@ -179,7 +179,7 @@
     },
     "quantra_Period" : {
       "type" : "object",
-      "description" : "Canonical period type used across APIs.",
+      "description" : "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
       "properties" : {
         "n" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647

--- a/flatbuffers/json/floating_rate_bond.schema.json
+++ b/flatbuffers/json/floating_rate_bond.schema.json
@@ -207,7 +207,8 @@
                 "$ref" : "#/definitions/quantra_enums_DateGenerationRule"
               },
         "end_of_month" : {
-                "type" : "boolean"
+                "type" : "boolean",
+                "description" : "Presence-required: absent-vs-false silently changes schedule dates for\nmonth-end-anchored (money-market) schedules."
               },
         "first_date" : {
                 "type" : "string",
@@ -222,7 +223,7 @@
     },
     "quantra_Period" : {
       "type" : "object",
-      "description" : "Canonical period type used across APIs.",
+      "description" : "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
       "properties" : {
         "n" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -369,7 +370,7 @@
               },
         "index_type" : {
                 "$ref" : "#/definitions/quantra_IndexType",
-                "description" : "IBOR or Overnight. Determines QuantLib class used."
+                "description" : "IBOR or Overnight. Determines QuantLib class used. Presence-required: an\nomitted value is a 400, never the silent Ibor default."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -377,23 +378,23 @@
               },
         "fixing_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647,
-                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR)."
+                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR). Presence-required."
               },
         "calendar" : {
                 "$ref" : "#/definitions/quantra_enums_Calendar",
-                "description" : "Calendar for fixing/payment dates."
+                "description" : "Calendar for fixing/payment dates. Presence-required."
               },
         "business_day_convention" : {
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention",
-                "description" : "Business day convention."
+                "description" : "Business day convention. Presence-required."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter",
-                "description" : "Day count convention."
+                "description" : "Day count convention. Presence-required."
               },
         "end_of_month" : {
                 "type" : "boolean",
-                "description" : "End of month rule (IBOR only, ignored for overnight)."
+                "description" : "End of month rule (IBOR only, ignored for overnight). Presence-required:\nabsent-vs-false silently changes money-market schedule dates."
               },
         "currency" : {
                 "type" : "string",

--- a/flatbuffers/json/floating_rate_bond_response.schema.json
+++ b/flatbuffers/json/floating_rate_bond_response.schema.json
@@ -179,7 +179,7 @@
     },
     "quantra_Period" : {
       "type" : "object",
-      "description" : "Canonical period type used across APIs.",
+      "description" : "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
       "properties" : {
         "n" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647

--- a/flatbuffers/json/fra.schema.json
+++ b/flatbuffers/json/fra.schema.json
@@ -183,7 +183,7 @@
     },
     "quantra_Period" : {
       "type" : "object",
-      "description" : "Canonical period type used across APIs.",
+      "description" : "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
       "properties" : {
         "n" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -330,7 +330,7 @@
               },
         "index_type" : {
                 "$ref" : "#/definitions/quantra_IndexType",
-                "description" : "IBOR or Overnight. Determines QuantLib class used."
+                "description" : "IBOR or Overnight. Determines QuantLib class used. Presence-required: an\nomitted value is a 400, never the silent Ibor default."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -338,23 +338,23 @@
               },
         "fixing_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647,
-                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR)."
+                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR). Presence-required."
               },
         "calendar" : {
                 "$ref" : "#/definitions/quantra_enums_Calendar",
-                "description" : "Calendar for fixing/payment dates."
+                "description" : "Calendar for fixing/payment dates. Presence-required."
               },
         "business_day_convention" : {
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention",
-                "description" : "Business day convention."
+                "description" : "Business day convention. Presence-required."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter",
-                "description" : "Day count convention."
+                "description" : "Day count convention. Presence-required."
               },
         "end_of_month" : {
                 "type" : "boolean",
-                "description" : "End of month rule (IBOR only, ignored for overnight)."
+                "description" : "End of month rule (IBOR only, ignored for overnight). Presence-required:\nabsent-vs-false silently changes money-market schedule dates."
               },
         "currency" : {
                 "type" : "string",

--- a/flatbuffers/json/index.schema.json
+++ b/flatbuffers/json/index.schema.json
@@ -183,7 +183,7 @@
     },
     "quantra_Period" : {
       "type" : "object",
-      "description" : "Canonical period type used across APIs.",
+      "description" : "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
       "properties" : {
         "n" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -330,7 +330,7 @@
               },
         "index_type" : {
                 "$ref" : "#/definitions/quantra_IndexType",
-                "description" : "IBOR or Overnight. Determines QuantLib class used."
+                "description" : "IBOR or Overnight. Determines QuantLib class used. Presence-required: an\nomitted value is a 400, never the silent Ibor default."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -338,23 +338,23 @@
               },
         "fixing_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647,
-                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR)."
+                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR). Presence-required."
               },
         "calendar" : {
                 "$ref" : "#/definitions/quantra_enums_Calendar",
-                "description" : "Calendar for fixing/payment dates."
+                "description" : "Calendar for fixing/payment dates. Presence-required."
               },
         "business_day_convention" : {
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention",
-                "description" : "Business day convention."
+                "description" : "Business day convention. Presence-required."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter",
-                "description" : "Day count convention."
+                "description" : "Day count convention. Presence-required."
               },
         "end_of_month" : {
                 "type" : "boolean",
-                "description" : "End of month rule (IBOR only, ignored for overnight)."
+                "description" : "End of month rule (IBOR only, ignored for overnight). Presence-required:\nabsent-vs-false silently changes money-market schedule dates."
               },
         "currency" : {
                 "type" : "string",

--- a/flatbuffers/json/ois_swap_response.schema.json
+++ b/flatbuffers/json/ois_swap_response.schema.json
@@ -179,7 +179,7 @@
     },
     "quantra_Period" : {
       "type" : "object",
-      "description" : "Canonical period type used across APIs.",
+      "description" : "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
       "properties" : {
         "n" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647

--- a/flatbuffers/json/price_basis_swap_request.schema.json
+++ b/flatbuffers/json/price_basis_swap_request.schema.json
@@ -247,7 +247,8 @@
                 "$ref" : "#/definitions/quantra_enums_DateGenerationRule"
               },
         "end_of_month" : {
-                "type" : "boolean"
+                "type" : "boolean",
+                "description" : "Presence-required: absent-vs-false silently changes schedule dates for\nmonth-end-anchored (money-market) schedules."
               },
         "first_date" : {
                 "type" : "string",
@@ -262,7 +263,7 @@
     },
     "quantra_Period" : {
       "type" : "object",
-      "description" : "Canonical period type used across APIs.",
+      "description" : "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
       "properties" : {
         "n" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -409,7 +410,7 @@
               },
         "index_type" : {
                 "$ref" : "#/definitions/quantra_IndexType",
-                "description" : "IBOR or Overnight. Determines QuantLib class used."
+                "description" : "IBOR or Overnight. Determines QuantLib class used. Presence-required: an\nomitted value is a 400, never the silent Ibor default."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -417,23 +418,23 @@
               },
         "fixing_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647,
-                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR)."
+                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR). Presence-required."
               },
         "calendar" : {
                 "$ref" : "#/definitions/quantra_enums_Calendar",
-                "description" : "Calendar for fixing/payment dates."
+                "description" : "Calendar for fixing/payment dates. Presence-required."
               },
         "business_day_convention" : {
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention",
-                "description" : "Business day convention."
+                "description" : "Business day convention. Presence-required."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter",
-                "description" : "Day count convention."
+                "description" : "Day count convention. Presence-required."
               },
         "end_of_month" : {
                 "type" : "boolean",
-                "description" : "End of month rule (IBOR only, ignored for overnight)."
+                "description" : "End of month rule (IBOR only, ignored for overnight). Presence-required:\nabsent-vs-false silently changes money-market schedule dates."
               },
         "currency" : {
                 "type" : "string",
@@ -1616,7 +1617,7 @@
     },
     "quantra_SwapIndexFixedLegSpec" : {
       "type" : "object",
-      "description" : "Fixed leg conventions for swap index.",
+      "description" : "Fixed leg conventions for swap index. Every convention is presence-required.",
       "properties" : {
         "fixed_frequency" : {
                 "$ref" : "#/definitions/quantra_enums_Frequency"
@@ -1644,7 +1645,7 @@
     },
     "quantra_SwapIndexFloatLegSpec" : {
       "type" : "object",
-      "description" : "Floating leg conventions for swap index.",
+      "description" : "Floating leg conventions for swap index. Every convention is\npresence-required.",
       "properties" : {
         "float_tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -1739,7 +1740,7 @@
     },
     "quantra_CdsHelperConventions" : {
       "type" : "object",
-      "description" : "CDS helper conventions for curve building.",
+      "description" : "CDS helper conventions for curve building. Every convention is\npresence-required: an omitted value is a 400 naming the field, never a\nsilent market-default assumption.",
       "properties" : {
         "settlement_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -2015,11 +2016,11 @@
               },
         "interpolated" : {
                 "type" : "boolean",
-                "description" : "Whether the index is interpolated between fixings."
+                "description" : "Whether the index is interpolated between fixings. Presence-required:\nabsent-vs-false silently changes the observed CPI."
               },
         "revised" : {
                 "type" : "boolean",
-                "description" : "Whether index values can be revised (rare; defaults to false)."
+                "description" : "Whether index values can be revised (rare). Presence-required."
               },
         "kind" : {
                 "$ref" : "#/definitions/quantra_enums_InflationCurveKind"
@@ -2160,7 +2161,8 @@
                 "$ref" : "#/definitions/quantra_enums_Interpolator"
               },
         "bootstrap_accuracy" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Numerical bootstrap tolerance (not a market convention): keeps its default."
               },
         "kind" : {
                 "$ref" : "#/definitions/quantra_enums_InflationCurveKind"

--- a/flatbuffers/json/price_callable_fixed_rate_bond_request.schema.json
+++ b/flatbuffers/json/price_callable_fixed_rate_bond_request.schema.json
@@ -247,7 +247,8 @@
                 "$ref" : "#/definitions/quantra_enums_DateGenerationRule"
               },
         "end_of_month" : {
-                "type" : "boolean"
+                "type" : "boolean",
+                "description" : "Presence-required: absent-vs-false silently changes schedule dates for\nmonth-end-anchored (money-market) schedules."
               },
         "first_date" : {
                 "type" : "string",
@@ -262,7 +263,7 @@
     },
     "quantra_Period" : {
       "type" : "object",
-      "description" : "Canonical period type used across APIs.",
+      "description" : "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
       "properties" : {
         "n" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -409,7 +410,7 @@
               },
         "index_type" : {
                 "$ref" : "#/definitions/quantra_IndexType",
-                "description" : "IBOR or Overnight. Determines QuantLib class used."
+                "description" : "IBOR or Overnight. Determines QuantLib class used. Presence-required: an\nomitted value is a 400, never the silent Ibor default."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -417,23 +418,23 @@
               },
         "fixing_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647,
-                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR)."
+                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR). Presence-required."
               },
         "calendar" : {
                 "$ref" : "#/definitions/quantra_enums_Calendar",
-                "description" : "Calendar for fixing/payment dates."
+                "description" : "Calendar for fixing/payment dates. Presence-required."
               },
         "business_day_convention" : {
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention",
-                "description" : "Business day convention."
+                "description" : "Business day convention. Presence-required."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter",
-                "description" : "Day count convention."
+                "description" : "Day count convention. Presence-required."
               },
         "end_of_month" : {
                 "type" : "boolean",
-                "description" : "End of month rule (IBOR only, ignored for overnight)."
+                "description" : "End of month rule (IBOR only, ignored for overnight). Presence-required:\nabsent-vs-false silently changes money-market schedule dates."
               },
         "currency" : {
                 "type" : "string",
@@ -1616,7 +1617,7 @@
     },
     "quantra_SwapIndexFixedLegSpec" : {
       "type" : "object",
-      "description" : "Fixed leg conventions for swap index.",
+      "description" : "Fixed leg conventions for swap index. Every convention is presence-required.",
       "properties" : {
         "fixed_frequency" : {
                 "$ref" : "#/definitions/quantra_enums_Frequency"
@@ -1644,7 +1645,7 @@
     },
     "quantra_SwapIndexFloatLegSpec" : {
       "type" : "object",
-      "description" : "Floating leg conventions for swap index.",
+      "description" : "Floating leg conventions for swap index. Every convention is\npresence-required.",
       "properties" : {
         "float_tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -1739,7 +1740,7 @@
     },
     "quantra_CdsHelperConventions" : {
       "type" : "object",
-      "description" : "CDS helper conventions for curve building.",
+      "description" : "CDS helper conventions for curve building. Every convention is\npresence-required: an omitted value is a 400 naming the field, never a\nsilent market-default assumption.",
       "properties" : {
         "settlement_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -2015,11 +2016,11 @@
               },
         "interpolated" : {
                 "type" : "boolean",
-                "description" : "Whether the index is interpolated between fixings."
+                "description" : "Whether the index is interpolated between fixings. Presence-required:\nabsent-vs-false silently changes the observed CPI."
               },
         "revised" : {
                 "type" : "boolean",
-                "description" : "Whether index values can be revised (rare; defaults to false)."
+                "description" : "Whether index values can be revised (rare). Presence-required."
               },
         "kind" : {
                 "$ref" : "#/definitions/quantra_enums_InflationCurveKind"
@@ -2160,7 +2161,8 @@
                 "$ref" : "#/definitions/quantra_enums_Interpolator"
               },
         "bootstrap_accuracy" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Numerical bootstrap tolerance (not a market convention): keeps its default."
               },
         "kind" : {
                 "$ref" : "#/definitions/quantra_enums_InflationCurveKind"

--- a/flatbuffers/json/price_cap_floor_request.schema.json
+++ b/flatbuffers/json/price_cap_floor_request.schema.json
@@ -223,7 +223,7 @@
     },
     "quantra_Period" : {
       "type" : "object",
-      "description" : "Canonical period type used across APIs.",
+      "description" : "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
       "properties" : {
         "n" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -368,7 +368,8 @@
                 "$ref" : "#/definitions/quantra_enums_DateGenerationRule"
               },
         "end_of_month" : {
-                "type" : "boolean"
+                "type" : "boolean",
+                "description" : "Presence-required: absent-vs-false silently changes schedule dates for\nmonth-end-anchored (money-market) schedules."
               },
         "first_date" : {
                 "type" : "string",
@@ -409,7 +410,7 @@
               },
         "index_type" : {
                 "$ref" : "#/definitions/quantra_IndexType",
-                "description" : "IBOR or Overnight. Determines QuantLib class used."
+                "description" : "IBOR or Overnight. Determines QuantLib class used. Presence-required: an\nomitted value is a 400, never the silent Ibor default."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -417,23 +418,23 @@
               },
         "fixing_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647,
-                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR)."
+                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR). Presence-required."
               },
         "calendar" : {
                 "$ref" : "#/definitions/quantra_enums_Calendar",
-                "description" : "Calendar for fixing/payment dates."
+                "description" : "Calendar for fixing/payment dates. Presence-required."
               },
         "business_day_convention" : {
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention",
-                "description" : "Business day convention."
+                "description" : "Business day convention. Presence-required."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter",
-                "description" : "Day count convention."
+                "description" : "Day count convention. Presence-required."
               },
         "end_of_month" : {
                 "type" : "boolean",
-                "description" : "End of month rule (IBOR only, ignored for overnight)."
+                "description" : "End of month rule (IBOR only, ignored for overnight). Presence-required:\nabsent-vs-false silently changes money-market schedule dates."
               },
         "currency" : {
                 "type" : "string",
@@ -1616,7 +1617,7 @@
     },
     "quantra_SwapIndexFixedLegSpec" : {
       "type" : "object",
-      "description" : "Fixed leg conventions for swap index.",
+      "description" : "Fixed leg conventions for swap index. Every convention is presence-required.",
       "properties" : {
         "fixed_frequency" : {
                 "$ref" : "#/definitions/quantra_enums_Frequency"
@@ -1644,7 +1645,7 @@
     },
     "quantra_SwapIndexFloatLegSpec" : {
       "type" : "object",
-      "description" : "Floating leg conventions for swap index.",
+      "description" : "Floating leg conventions for swap index. Every convention is\npresence-required.",
       "properties" : {
         "float_tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -1739,7 +1740,7 @@
     },
     "quantra_CdsHelperConventions" : {
       "type" : "object",
-      "description" : "CDS helper conventions for curve building.",
+      "description" : "CDS helper conventions for curve building. Every convention is\npresence-required: an omitted value is a 400 naming the field, never a\nsilent market-default assumption.",
       "properties" : {
         "settlement_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -2015,11 +2016,11 @@
               },
         "interpolated" : {
                 "type" : "boolean",
-                "description" : "Whether the index is interpolated between fixings."
+                "description" : "Whether the index is interpolated between fixings. Presence-required:\nabsent-vs-false silently changes the observed CPI."
               },
         "revised" : {
                 "type" : "boolean",
-                "description" : "Whether index values can be revised (rare; defaults to false)."
+                "description" : "Whether index values can be revised (rare). Presence-required."
               },
         "kind" : {
                 "$ref" : "#/definitions/quantra_enums_InflationCurveKind"
@@ -2160,7 +2161,8 @@
                 "$ref" : "#/definitions/quantra_enums_Interpolator"
               },
         "bootstrap_accuracy" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Numerical bootstrap tolerance (not a market convention): keeps its default."
               },
         "kind" : {
                 "$ref" : "#/definitions/quantra_enums_InflationCurveKind"

--- a/flatbuffers/json/price_cds_request.schema.json
+++ b/flatbuffers/json/price_cds_request.schema.json
@@ -223,7 +223,7 @@
     },
     "quantra_Period" : {
       "type" : "object",
-      "description" : "Canonical period type used across APIs.",
+      "description" : "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
       "properties" : {
         "n" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -368,7 +368,8 @@
                 "$ref" : "#/definitions/quantra_enums_DateGenerationRule"
               },
         "end_of_month" : {
-                "type" : "boolean"
+                "type" : "boolean",
+                "description" : "Presence-required: absent-vs-false silently changes schedule dates for\nmonth-end-anchored (money-market) schedules."
               },
         "first_date" : {
                 "type" : "string",
@@ -409,7 +410,7 @@
               },
         "index_type" : {
                 "$ref" : "#/definitions/quantra_IndexType",
-                "description" : "IBOR or Overnight. Determines QuantLib class used."
+                "description" : "IBOR or Overnight. Determines QuantLib class used. Presence-required: an\nomitted value is a 400, never the silent Ibor default."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -417,23 +418,23 @@
               },
         "fixing_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647,
-                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR)."
+                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR). Presence-required."
               },
         "calendar" : {
                 "$ref" : "#/definitions/quantra_enums_Calendar",
-                "description" : "Calendar for fixing/payment dates."
+                "description" : "Calendar for fixing/payment dates. Presence-required."
               },
         "business_day_convention" : {
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention",
-                "description" : "Business day convention."
+                "description" : "Business day convention. Presence-required."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter",
-                "description" : "Day count convention."
+                "description" : "Day count convention. Presence-required."
               },
         "end_of_month" : {
                 "type" : "boolean",
-                "description" : "End of month rule (IBOR only, ignored for overnight)."
+                "description" : "End of month rule (IBOR only, ignored for overnight). Presence-required:\nabsent-vs-false silently changes money-market schedule dates."
               },
         "currency" : {
                 "type" : "string",
@@ -1616,7 +1617,7 @@
     },
     "quantra_SwapIndexFixedLegSpec" : {
       "type" : "object",
-      "description" : "Fixed leg conventions for swap index.",
+      "description" : "Fixed leg conventions for swap index. Every convention is presence-required.",
       "properties" : {
         "fixed_frequency" : {
                 "$ref" : "#/definitions/quantra_enums_Frequency"
@@ -1644,7 +1645,7 @@
     },
     "quantra_SwapIndexFloatLegSpec" : {
       "type" : "object",
-      "description" : "Floating leg conventions for swap index.",
+      "description" : "Floating leg conventions for swap index. Every convention is\npresence-required.",
       "properties" : {
         "float_tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -1739,7 +1740,7 @@
     },
     "quantra_CdsHelperConventions" : {
       "type" : "object",
-      "description" : "CDS helper conventions for curve building.",
+      "description" : "CDS helper conventions for curve building. Every convention is\npresence-required: an omitted value is a 400 naming the field, never a\nsilent market-default assumption.",
       "properties" : {
         "settlement_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -2015,11 +2016,11 @@
               },
         "interpolated" : {
                 "type" : "boolean",
-                "description" : "Whether the index is interpolated between fixings."
+                "description" : "Whether the index is interpolated between fixings. Presence-required:\nabsent-vs-false silently changes the observed CPI."
               },
         "revised" : {
                 "type" : "boolean",
-                "description" : "Whether index values can be revised (rare; defaults to false)."
+                "description" : "Whether index values can be revised (rare). Presence-required."
               },
         "kind" : {
                 "$ref" : "#/definitions/quantra_enums_InflationCurveKind"
@@ -2160,7 +2161,8 @@
                 "$ref" : "#/definitions/quantra_enums_Interpolator"
               },
         "bootstrap_accuracy" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Numerical bootstrap tolerance (not a market convention): keeps its default."
               },
         "kind" : {
                 "$ref" : "#/definitions/quantra_enums_InflationCurveKind"
@@ -2347,7 +2349,8 @@
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention"
               },
         "settles_accrual" : {
-                "type" : "boolean"
+                "type" : "boolean",
+                "description" : "ISDA settlement conventions. Presence-required: each is a deliberate\nchoice (false round-trips) so an omission is a 400, never a silent true."
               },
         "pays_at_default_time" : {
                 "type" : "boolean"

--- a/flatbuffers/json/price_equity_option_request.schema.json
+++ b/flatbuffers/json/price_equity_option_request.schema.json
@@ -247,7 +247,8 @@
                 "$ref" : "#/definitions/quantra_enums_DateGenerationRule"
               },
         "end_of_month" : {
-                "type" : "boolean"
+                "type" : "boolean",
+                "description" : "Presence-required: absent-vs-false silently changes schedule dates for\nmonth-end-anchored (money-market) schedules."
               },
         "first_date" : {
                 "type" : "string",
@@ -262,7 +263,7 @@
     },
     "quantra_Period" : {
       "type" : "object",
-      "description" : "Canonical period type used across APIs.",
+      "description" : "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
       "properties" : {
         "n" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -409,7 +410,7 @@
               },
         "index_type" : {
                 "$ref" : "#/definitions/quantra_IndexType",
-                "description" : "IBOR or Overnight. Determines QuantLib class used."
+                "description" : "IBOR or Overnight. Determines QuantLib class used. Presence-required: an\nomitted value is a 400, never the silent Ibor default."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -417,23 +418,23 @@
               },
         "fixing_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647,
-                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR)."
+                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR). Presence-required."
               },
         "calendar" : {
                 "$ref" : "#/definitions/quantra_enums_Calendar",
-                "description" : "Calendar for fixing/payment dates."
+                "description" : "Calendar for fixing/payment dates. Presence-required."
               },
         "business_day_convention" : {
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention",
-                "description" : "Business day convention."
+                "description" : "Business day convention. Presence-required."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter",
-                "description" : "Day count convention."
+                "description" : "Day count convention. Presence-required."
               },
         "end_of_month" : {
                 "type" : "boolean",
-                "description" : "End of month rule (IBOR only, ignored for overnight)."
+                "description" : "End of month rule (IBOR only, ignored for overnight). Presence-required:\nabsent-vs-false silently changes money-market schedule dates."
               },
         "currency" : {
                 "type" : "string",
@@ -1616,7 +1617,7 @@
     },
     "quantra_SwapIndexFixedLegSpec" : {
       "type" : "object",
-      "description" : "Fixed leg conventions for swap index.",
+      "description" : "Fixed leg conventions for swap index. Every convention is presence-required.",
       "properties" : {
         "fixed_frequency" : {
                 "$ref" : "#/definitions/quantra_enums_Frequency"
@@ -1644,7 +1645,7 @@
     },
     "quantra_SwapIndexFloatLegSpec" : {
       "type" : "object",
-      "description" : "Floating leg conventions for swap index.",
+      "description" : "Floating leg conventions for swap index. Every convention is\npresence-required.",
       "properties" : {
         "float_tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -1739,7 +1740,7 @@
     },
     "quantra_CdsHelperConventions" : {
       "type" : "object",
-      "description" : "CDS helper conventions for curve building.",
+      "description" : "CDS helper conventions for curve building. Every convention is\npresence-required: an omitted value is a 400 naming the field, never a\nsilent market-default assumption.",
       "properties" : {
         "settlement_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -2015,11 +2016,11 @@
               },
         "interpolated" : {
                 "type" : "boolean",
-                "description" : "Whether the index is interpolated between fixings."
+                "description" : "Whether the index is interpolated between fixings. Presence-required:\nabsent-vs-false silently changes the observed CPI."
               },
         "revised" : {
                 "type" : "boolean",
-                "description" : "Whether index values can be revised (rare; defaults to false)."
+                "description" : "Whether index values can be revised (rare). Presence-required."
               },
         "kind" : {
                 "$ref" : "#/definitions/quantra_enums_InflationCurveKind"
@@ -2160,7 +2161,8 @@
                 "$ref" : "#/definitions/quantra_enums_Interpolator"
               },
         "bootstrap_accuracy" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Numerical bootstrap tolerance (not a market convention): keeps its default."
               },
         "kind" : {
                 "$ref" : "#/definitions/quantra_enums_InflationCurveKind"

--- a/flatbuffers/json/price_fixed_rate_bond_request.schema.json
+++ b/flatbuffers/json/price_fixed_rate_bond_request.schema.json
@@ -223,7 +223,7 @@
     },
     "quantra_Period" : {
       "type" : "object",
-      "description" : "Canonical period type used across APIs.",
+      "description" : "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
       "properties" : {
         "n" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -368,7 +368,8 @@
                 "$ref" : "#/definitions/quantra_enums_DateGenerationRule"
               },
         "end_of_month" : {
-                "type" : "boolean"
+                "type" : "boolean",
+                "description" : "Presence-required: absent-vs-false silently changes schedule dates for\nmonth-end-anchored (money-market) schedules."
               },
         "first_date" : {
                 "type" : "string",
@@ -409,7 +410,7 @@
               },
         "index_type" : {
                 "$ref" : "#/definitions/quantra_IndexType",
-                "description" : "IBOR or Overnight. Determines QuantLib class used."
+                "description" : "IBOR or Overnight. Determines QuantLib class used. Presence-required: an\nomitted value is a 400, never the silent Ibor default."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -417,23 +418,23 @@
               },
         "fixing_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647,
-                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR)."
+                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR). Presence-required."
               },
         "calendar" : {
                 "$ref" : "#/definitions/quantra_enums_Calendar",
-                "description" : "Calendar for fixing/payment dates."
+                "description" : "Calendar for fixing/payment dates. Presence-required."
               },
         "business_day_convention" : {
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention",
-                "description" : "Business day convention."
+                "description" : "Business day convention. Presence-required."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter",
-                "description" : "Day count convention."
+                "description" : "Day count convention. Presence-required."
               },
         "end_of_month" : {
                 "type" : "boolean",
-                "description" : "End of month rule (IBOR only, ignored for overnight)."
+                "description" : "End of month rule (IBOR only, ignored for overnight). Presence-required:\nabsent-vs-false silently changes money-market schedule dates."
               },
         "currency" : {
                 "type" : "string",
@@ -1616,7 +1617,7 @@
     },
     "quantra_SwapIndexFixedLegSpec" : {
       "type" : "object",
-      "description" : "Fixed leg conventions for swap index.",
+      "description" : "Fixed leg conventions for swap index. Every convention is presence-required.",
       "properties" : {
         "fixed_frequency" : {
                 "$ref" : "#/definitions/quantra_enums_Frequency"
@@ -1644,7 +1645,7 @@
     },
     "quantra_SwapIndexFloatLegSpec" : {
       "type" : "object",
-      "description" : "Floating leg conventions for swap index.",
+      "description" : "Floating leg conventions for swap index. Every convention is\npresence-required.",
       "properties" : {
         "float_tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -1739,7 +1740,7 @@
     },
     "quantra_CdsHelperConventions" : {
       "type" : "object",
-      "description" : "CDS helper conventions for curve building.",
+      "description" : "CDS helper conventions for curve building. Every convention is\npresence-required: an omitted value is a 400 naming the field, never a\nsilent market-default assumption.",
       "properties" : {
         "settlement_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -2015,11 +2016,11 @@
               },
         "interpolated" : {
                 "type" : "boolean",
-                "description" : "Whether the index is interpolated between fixings."
+                "description" : "Whether the index is interpolated between fixings. Presence-required:\nabsent-vs-false silently changes the observed CPI."
               },
         "revised" : {
                 "type" : "boolean",
-                "description" : "Whether index values can be revised (rare; defaults to false)."
+                "description" : "Whether index values can be revised (rare). Presence-required."
               },
         "kind" : {
                 "$ref" : "#/definitions/quantra_enums_InflationCurveKind"
@@ -2160,7 +2161,8 @@
                 "$ref" : "#/definitions/quantra_enums_Interpolator"
               },
         "bootstrap_accuracy" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Numerical bootstrap tolerance (not a market convention): keeps its default."
               },
         "kind" : {
                 "$ref" : "#/definitions/quantra_enums_InflationCurveKind"

--- a/flatbuffers/json/price_floating_rate_bond_request.schema.json
+++ b/flatbuffers/json/price_floating_rate_bond_request.schema.json
@@ -223,7 +223,7 @@
     },
     "quantra_Period" : {
       "type" : "object",
-      "description" : "Canonical period type used across APIs.",
+      "description" : "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
       "properties" : {
         "n" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -368,7 +368,8 @@
                 "$ref" : "#/definitions/quantra_enums_DateGenerationRule"
               },
         "end_of_month" : {
-                "type" : "boolean"
+                "type" : "boolean",
+                "description" : "Presence-required: absent-vs-false silently changes schedule dates for\nmonth-end-anchored (money-market) schedules."
               },
         "first_date" : {
                 "type" : "string",
@@ -409,7 +410,7 @@
               },
         "index_type" : {
                 "$ref" : "#/definitions/quantra_IndexType",
-                "description" : "IBOR or Overnight. Determines QuantLib class used."
+                "description" : "IBOR or Overnight. Determines QuantLib class used. Presence-required: an\nomitted value is a 400, never the silent Ibor default."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -417,23 +418,23 @@
               },
         "fixing_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647,
-                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR)."
+                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR). Presence-required."
               },
         "calendar" : {
                 "$ref" : "#/definitions/quantra_enums_Calendar",
-                "description" : "Calendar for fixing/payment dates."
+                "description" : "Calendar for fixing/payment dates. Presence-required."
               },
         "business_day_convention" : {
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention",
-                "description" : "Business day convention."
+                "description" : "Business day convention. Presence-required."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter",
-                "description" : "Day count convention."
+                "description" : "Day count convention. Presence-required."
               },
         "end_of_month" : {
                 "type" : "boolean",
-                "description" : "End of month rule (IBOR only, ignored for overnight)."
+                "description" : "End of month rule (IBOR only, ignored for overnight). Presence-required:\nabsent-vs-false silently changes money-market schedule dates."
               },
         "currency" : {
                 "type" : "string",
@@ -1616,7 +1617,7 @@
     },
     "quantra_SwapIndexFixedLegSpec" : {
       "type" : "object",
-      "description" : "Fixed leg conventions for swap index.",
+      "description" : "Fixed leg conventions for swap index. Every convention is presence-required.",
       "properties" : {
         "fixed_frequency" : {
                 "$ref" : "#/definitions/quantra_enums_Frequency"
@@ -1644,7 +1645,7 @@
     },
     "quantra_SwapIndexFloatLegSpec" : {
       "type" : "object",
-      "description" : "Floating leg conventions for swap index.",
+      "description" : "Floating leg conventions for swap index. Every convention is\npresence-required.",
       "properties" : {
         "float_tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -1739,7 +1740,7 @@
     },
     "quantra_CdsHelperConventions" : {
       "type" : "object",
-      "description" : "CDS helper conventions for curve building.",
+      "description" : "CDS helper conventions for curve building. Every convention is\npresence-required: an omitted value is a 400 naming the field, never a\nsilent market-default assumption.",
       "properties" : {
         "settlement_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -2015,11 +2016,11 @@
               },
         "interpolated" : {
                 "type" : "boolean",
-                "description" : "Whether the index is interpolated between fixings."
+                "description" : "Whether the index is interpolated between fixings. Presence-required:\nabsent-vs-false silently changes the observed CPI."
               },
         "revised" : {
                 "type" : "boolean",
-                "description" : "Whether index values can be revised (rare; defaults to false)."
+                "description" : "Whether index values can be revised (rare). Presence-required."
               },
         "kind" : {
                 "$ref" : "#/definitions/quantra_enums_InflationCurveKind"
@@ -2160,7 +2161,8 @@
                 "$ref" : "#/definitions/quantra_enums_Interpolator"
               },
         "bootstrap_accuracy" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Numerical bootstrap tolerance (not a market convention): keeps its default."
               },
         "kind" : {
                 "$ref" : "#/definitions/quantra_enums_InflationCurveKind"

--- a/flatbuffers/json/price_fra_request.schema.json
+++ b/flatbuffers/json/price_fra_request.schema.json
@@ -223,7 +223,7 @@
     },
     "quantra_Period" : {
       "type" : "object",
-      "description" : "Canonical period type used across APIs.",
+      "description" : "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
       "properties" : {
         "n" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -368,7 +368,8 @@
                 "$ref" : "#/definitions/quantra_enums_DateGenerationRule"
               },
         "end_of_month" : {
-                "type" : "boolean"
+                "type" : "boolean",
+                "description" : "Presence-required: absent-vs-false silently changes schedule dates for\nmonth-end-anchored (money-market) schedules."
               },
         "first_date" : {
                 "type" : "string",
@@ -409,7 +410,7 @@
               },
         "index_type" : {
                 "$ref" : "#/definitions/quantra_IndexType",
-                "description" : "IBOR or Overnight. Determines QuantLib class used."
+                "description" : "IBOR or Overnight. Determines QuantLib class used. Presence-required: an\nomitted value is a 400, never the silent Ibor default."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -417,23 +418,23 @@
               },
         "fixing_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647,
-                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR)."
+                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR). Presence-required."
               },
         "calendar" : {
                 "$ref" : "#/definitions/quantra_enums_Calendar",
-                "description" : "Calendar for fixing/payment dates."
+                "description" : "Calendar for fixing/payment dates. Presence-required."
               },
         "business_day_convention" : {
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention",
-                "description" : "Business day convention."
+                "description" : "Business day convention. Presence-required."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter",
-                "description" : "Day count convention."
+                "description" : "Day count convention. Presence-required."
               },
         "end_of_month" : {
                 "type" : "boolean",
-                "description" : "End of month rule (IBOR only, ignored for overnight)."
+                "description" : "End of month rule (IBOR only, ignored for overnight). Presence-required:\nabsent-vs-false silently changes money-market schedule dates."
               },
         "currency" : {
                 "type" : "string",
@@ -1616,7 +1617,7 @@
     },
     "quantra_SwapIndexFixedLegSpec" : {
       "type" : "object",
-      "description" : "Fixed leg conventions for swap index.",
+      "description" : "Fixed leg conventions for swap index. Every convention is presence-required.",
       "properties" : {
         "fixed_frequency" : {
                 "$ref" : "#/definitions/quantra_enums_Frequency"
@@ -1644,7 +1645,7 @@
     },
     "quantra_SwapIndexFloatLegSpec" : {
       "type" : "object",
-      "description" : "Floating leg conventions for swap index.",
+      "description" : "Floating leg conventions for swap index. Every convention is\npresence-required.",
       "properties" : {
         "float_tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -1739,7 +1740,7 @@
     },
     "quantra_CdsHelperConventions" : {
       "type" : "object",
-      "description" : "CDS helper conventions for curve building.",
+      "description" : "CDS helper conventions for curve building. Every convention is\npresence-required: an omitted value is a 400 naming the field, never a\nsilent market-default assumption.",
       "properties" : {
         "settlement_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -2015,11 +2016,11 @@
               },
         "interpolated" : {
                 "type" : "boolean",
-                "description" : "Whether the index is interpolated between fixings."
+                "description" : "Whether the index is interpolated between fixings. Presence-required:\nabsent-vs-false silently changes the observed CPI."
               },
         "revised" : {
                 "type" : "boolean",
-                "description" : "Whether index values can be revised (rare; defaults to false)."
+                "description" : "Whether index values can be revised (rare). Presence-required."
               },
         "kind" : {
                 "$ref" : "#/definitions/quantra_enums_InflationCurveKind"
@@ -2160,7 +2161,8 @@
                 "$ref" : "#/definitions/quantra_enums_Interpolator"
               },
         "bootstrap_accuracy" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Numerical bootstrap tolerance (not a market convention): keeps its default."
               },
         "kind" : {
                 "$ref" : "#/definitions/quantra_enums_InflationCurveKind"

--- a/flatbuffers/json/price_ois_swap_request.schema.json
+++ b/flatbuffers/json/price_ois_swap_request.schema.json
@@ -247,7 +247,8 @@
                 "$ref" : "#/definitions/quantra_enums_DateGenerationRule"
               },
         "end_of_month" : {
-                "type" : "boolean"
+                "type" : "boolean",
+                "description" : "Presence-required: absent-vs-false silently changes schedule dates for\nmonth-end-anchored (money-market) schedules."
               },
         "first_date" : {
                 "type" : "string",
@@ -262,7 +263,7 @@
     },
     "quantra_Period" : {
       "type" : "object",
-      "description" : "Canonical period type used across APIs.",
+      "description" : "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
       "properties" : {
         "n" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -409,7 +410,7 @@
               },
         "index_type" : {
                 "$ref" : "#/definitions/quantra_IndexType",
-                "description" : "IBOR or Overnight. Determines QuantLib class used."
+                "description" : "IBOR or Overnight. Determines QuantLib class used. Presence-required: an\nomitted value is a 400, never the silent Ibor default."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -417,23 +418,23 @@
               },
         "fixing_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647,
-                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR)."
+                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR). Presence-required."
               },
         "calendar" : {
                 "$ref" : "#/definitions/quantra_enums_Calendar",
-                "description" : "Calendar for fixing/payment dates."
+                "description" : "Calendar for fixing/payment dates. Presence-required."
               },
         "business_day_convention" : {
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention",
-                "description" : "Business day convention."
+                "description" : "Business day convention. Presence-required."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter",
-                "description" : "Day count convention."
+                "description" : "Day count convention. Presence-required."
               },
         "end_of_month" : {
                 "type" : "boolean",
-                "description" : "End of month rule (IBOR only, ignored for overnight)."
+                "description" : "End of month rule (IBOR only, ignored for overnight). Presence-required:\nabsent-vs-false silently changes money-market schedule dates."
               },
         "currency" : {
                 "type" : "string",
@@ -1616,7 +1617,7 @@
     },
     "quantra_SwapIndexFixedLegSpec" : {
       "type" : "object",
-      "description" : "Fixed leg conventions for swap index.",
+      "description" : "Fixed leg conventions for swap index. Every convention is presence-required.",
       "properties" : {
         "fixed_frequency" : {
                 "$ref" : "#/definitions/quantra_enums_Frequency"
@@ -1644,7 +1645,7 @@
     },
     "quantra_SwapIndexFloatLegSpec" : {
       "type" : "object",
-      "description" : "Floating leg conventions for swap index.",
+      "description" : "Floating leg conventions for swap index. Every convention is\npresence-required.",
       "properties" : {
         "float_tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -1739,7 +1740,7 @@
     },
     "quantra_CdsHelperConventions" : {
       "type" : "object",
-      "description" : "CDS helper conventions for curve building.",
+      "description" : "CDS helper conventions for curve building. Every convention is\npresence-required: an omitted value is a 400 naming the field, never a\nsilent market-default assumption.",
       "properties" : {
         "settlement_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -2015,11 +2016,11 @@
               },
         "interpolated" : {
                 "type" : "boolean",
-                "description" : "Whether the index is interpolated between fixings."
+                "description" : "Whether the index is interpolated between fixings. Presence-required:\nabsent-vs-false silently changes the observed CPI."
               },
         "revised" : {
                 "type" : "boolean",
-                "description" : "Whether index values can be revised (rare; defaults to false)."
+                "description" : "Whether index values can be revised (rare). Presence-required."
               },
         "kind" : {
                 "$ref" : "#/definitions/quantra_enums_InflationCurveKind"
@@ -2160,7 +2161,8 @@
                 "$ref" : "#/definitions/quantra_enums_Interpolator"
               },
         "bootstrap_accuracy" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Numerical bootstrap tolerance (not a market convention): keeps its default."
               },
         "kind" : {
                 "$ref" : "#/definitions/quantra_enums_InflationCurveKind"

--- a/flatbuffers/json/price_swaption_request.schema.json
+++ b/flatbuffers/json/price_swaption_request.schema.json
@@ -227,7 +227,7 @@
     },
     "quantra_Period" : {
       "type" : "object",
-      "description" : "Canonical period type used across APIs.",
+      "description" : "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
       "properties" : {
         "n" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -372,7 +372,8 @@
                 "$ref" : "#/definitions/quantra_enums_DateGenerationRule"
               },
         "end_of_month" : {
-                "type" : "boolean"
+                "type" : "boolean",
+                "description" : "Presence-required: absent-vs-false silently changes schedule dates for\nmonth-end-anchored (money-market) schedules."
               },
         "first_date" : {
                 "type" : "string",
@@ -413,7 +414,7 @@
               },
         "index_type" : {
                 "$ref" : "#/definitions/quantra_IndexType",
-                "description" : "IBOR or Overnight. Determines QuantLib class used."
+                "description" : "IBOR or Overnight. Determines QuantLib class used. Presence-required: an\nomitted value is a 400, never the silent Ibor default."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -421,23 +422,23 @@
               },
         "fixing_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647,
-                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR)."
+                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR). Presence-required."
               },
         "calendar" : {
                 "$ref" : "#/definitions/quantra_enums_Calendar",
-                "description" : "Calendar for fixing/payment dates."
+                "description" : "Calendar for fixing/payment dates. Presence-required."
               },
         "business_day_convention" : {
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention",
-                "description" : "Business day convention."
+                "description" : "Business day convention. Presence-required."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter",
-                "description" : "Day count convention."
+                "description" : "Day count convention. Presence-required."
               },
         "end_of_month" : {
                 "type" : "boolean",
-                "description" : "End of month rule (IBOR only, ignored for overnight)."
+                "description" : "End of month rule (IBOR only, ignored for overnight). Presence-required:\nabsent-vs-false silently changes money-market schedule dates."
               },
         "currency" : {
                 "type" : "string",
@@ -1620,7 +1621,7 @@
     },
     "quantra_SwapIndexFixedLegSpec" : {
       "type" : "object",
-      "description" : "Fixed leg conventions for swap index.",
+      "description" : "Fixed leg conventions for swap index. Every convention is presence-required.",
       "properties" : {
         "fixed_frequency" : {
                 "$ref" : "#/definitions/quantra_enums_Frequency"
@@ -1648,7 +1649,7 @@
     },
     "quantra_SwapIndexFloatLegSpec" : {
       "type" : "object",
-      "description" : "Floating leg conventions for swap index.",
+      "description" : "Floating leg conventions for swap index. Every convention is\npresence-required.",
       "properties" : {
         "float_tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -1743,7 +1744,7 @@
     },
     "quantra_CdsHelperConventions" : {
       "type" : "object",
-      "description" : "CDS helper conventions for curve building.",
+      "description" : "CDS helper conventions for curve building. Every convention is\npresence-required: an omitted value is a 400 naming the field, never a\nsilent market-default assumption.",
       "properties" : {
         "settlement_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -2019,11 +2020,11 @@
               },
         "interpolated" : {
                 "type" : "boolean",
-                "description" : "Whether the index is interpolated between fixings."
+                "description" : "Whether the index is interpolated between fixings. Presence-required:\nabsent-vs-false silently changes the observed CPI."
               },
         "revised" : {
                 "type" : "boolean",
-                "description" : "Whether index values can be revised (rare; defaults to false)."
+                "description" : "Whether index values can be revised (rare). Presence-required."
               },
         "kind" : {
                 "$ref" : "#/definitions/quantra_enums_InflationCurveKind"
@@ -2164,7 +2165,8 @@
                 "$ref" : "#/definitions/quantra_enums_Interpolator"
               },
         "bootstrap_accuracy" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Numerical bootstrap tolerance (not a market convention): keeps its default."
               },
         "kind" : {
                 "$ref" : "#/definitions/quantra_enums_InflationCurveKind"

--- a/flatbuffers/json/price_vanilla_swap_request.schema.json
+++ b/flatbuffers/json/price_vanilla_swap_request.schema.json
@@ -223,7 +223,7 @@
     },
     "quantra_Period" : {
       "type" : "object",
-      "description" : "Canonical period type used across APIs.",
+      "description" : "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
       "properties" : {
         "n" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -368,7 +368,8 @@
                 "$ref" : "#/definitions/quantra_enums_DateGenerationRule"
               },
         "end_of_month" : {
-                "type" : "boolean"
+                "type" : "boolean",
+                "description" : "Presence-required: absent-vs-false silently changes schedule dates for\nmonth-end-anchored (money-market) schedules."
               },
         "first_date" : {
                 "type" : "string",
@@ -409,7 +410,7 @@
               },
         "index_type" : {
                 "$ref" : "#/definitions/quantra_IndexType",
-                "description" : "IBOR or Overnight. Determines QuantLib class used."
+                "description" : "IBOR or Overnight. Determines QuantLib class used. Presence-required: an\nomitted value is a 400, never the silent Ibor default."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -417,23 +418,23 @@
               },
         "fixing_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647,
-                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR)."
+                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR). Presence-required."
               },
         "calendar" : {
                 "$ref" : "#/definitions/quantra_enums_Calendar",
-                "description" : "Calendar for fixing/payment dates."
+                "description" : "Calendar for fixing/payment dates. Presence-required."
               },
         "business_day_convention" : {
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention",
-                "description" : "Business day convention."
+                "description" : "Business day convention. Presence-required."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter",
-                "description" : "Day count convention."
+                "description" : "Day count convention. Presence-required."
               },
         "end_of_month" : {
                 "type" : "boolean",
-                "description" : "End of month rule (IBOR only, ignored for overnight)."
+                "description" : "End of month rule (IBOR only, ignored for overnight). Presence-required:\nabsent-vs-false silently changes money-market schedule dates."
               },
         "currency" : {
                 "type" : "string",
@@ -1616,7 +1617,7 @@
     },
     "quantra_SwapIndexFixedLegSpec" : {
       "type" : "object",
-      "description" : "Fixed leg conventions for swap index.",
+      "description" : "Fixed leg conventions for swap index. Every convention is presence-required.",
       "properties" : {
         "fixed_frequency" : {
                 "$ref" : "#/definitions/quantra_enums_Frequency"
@@ -1644,7 +1645,7 @@
     },
     "quantra_SwapIndexFloatLegSpec" : {
       "type" : "object",
-      "description" : "Floating leg conventions for swap index.",
+      "description" : "Floating leg conventions for swap index. Every convention is\npresence-required.",
       "properties" : {
         "float_tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -1739,7 +1740,7 @@
     },
     "quantra_CdsHelperConventions" : {
       "type" : "object",
-      "description" : "CDS helper conventions for curve building.",
+      "description" : "CDS helper conventions for curve building. Every convention is\npresence-required: an omitted value is a 400 naming the field, never a\nsilent market-default assumption.",
       "properties" : {
         "settlement_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -2015,11 +2016,11 @@
               },
         "interpolated" : {
                 "type" : "boolean",
-                "description" : "Whether the index is interpolated between fixings."
+                "description" : "Whether the index is interpolated between fixings. Presence-required:\nabsent-vs-false silently changes the observed CPI."
               },
         "revised" : {
                 "type" : "boolean",
-                "description" : "Whether index values can be revised (rare; defaults to false)."
+                "description" : "Whether index values can be revised (rare). Presence-required."
               },
         "kind" : {
                 "$ref" : "#/definitions/quantra_enums_InflationCurveKind"
@@ -2160,7 +2161,8 @@
                 "$ref" : "#/definitions/quantra_enums_Interpolator"
               },
         "bootstrap_accuracy" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Numerical bootstrap tolerance (not a market convention): keeps its default."
               },
         "kind" : {
                 "$ref" : "#/definitions/quantra_enums_InflationCurveKind"

--- a/flatbuffers/json/price_year_on_year_inflation_cap_floor_request.schema.json
+++ b/flatbuffers/json/price_year_on_year_inflation_cap_floor_request.schema.json
@@ -247,7 +247,8 @@
                 "$ref" : "#/definitions/quantra_enums_DateGenerationRule"
               },
         "end_of_month" : {
-                "type" : "boolean"
+                "type" : "boolean",
+                "description" : "Presence-required: absent-vs-false silently changes schedule dates for\nmonth-end-anchored (money-market) schedules."
               },
         "first_date" : {
                 "type" : "string",
@@ -262,7 +263,7 @@
     },
     "quantra_Period" : {
       "type" : "object",
-      "description" : "Canonical period type used across APIs.",
+      "description" : "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
       "properties" : {
         "n" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -409,7 +410,7 @@
               },
         "index_type" : {
                 "$ref" : "#/definitions/quantra_IndexType",
-                "description" : "IBOR or Overnight. Determines QuantLib class used."
+                "description" : "IBOR or Overnight. Determines QuantLib class used. Presence-required: an\nomitted value is a 400, never the silent Ibor default."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -417,23 +418,23 @@
               },
         "fixing_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647,
-                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR)."
+                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR). Presence-required."
               },
         "calendar" : {
                 "$ref" : "#/definitions/quantra_enums_Calendar",
-                "description" : "Calendar for fixing/payment dates."
+                "description" : "Calendar for fixing/payment dates. Presence-required."
               },
         "business_day_convention" : {
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention",
-                "description" : "Business day convention."
+                "description" : "Business day convention. Presence-required."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter",
-                "description" : "Day count convention."
+                "description" : "Day count convention. Presence-required."
               },
         "end_of_month" : {
                 "type" : "boolean",
-                "description" : "End of month rule (IBOR only, ignored for overnight)."
+                "description" : "End of month rule (IBOR only, ignored for overnight). Presence-required:\nabsent-vs-false silently changes money-market schedule dates."
               },
         "currency" : {
                 "type" : "string",
@@ -1616,7 +1617,7 @@
     },
     "quantra_SwapIndexFixedLegSpec" : {
       "type" : "object",
-      "description" : "Fixed leg conventions for swap index.",
+      "description" : "Fixed leg conventions for swap index. Every convention is presence-required.",
       "properties" : {
         "fixed_frequency" : {
                 "$ref" : "#/definitions/quantra_enums_Frequency"
@@ -1644,7 +1645,7 @@
     },
     "quantra_SwapIndexFloatLegSpec" : {
       "type" : "object",
-      "description" : "Floating leg conventions for swap index.",
+      "description" : "Floating leg conventions for swap index. Every convention is\npresence-required.",
       "properties" : {
         "float_tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -1739,7 +1740,7 @@
     },
     "quantra_CdsHelperConventions" : {
       "type" : "object",
-      "description" : "CDS helper conventions for curve building.",
+      "description" : "CDS helper conventions for curve building. Every convention is\npresence-required: an omitted value is a 400 naming the field, never a\nsilent market-default assumption.",
       "properties" : {
         "settlement_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -2015,11 +2016,11 @@
               },
         "interpolated" : {
                 "type" : "boolean",
-                "description" : "Whether the index is interpolated between fixings."
+                "description" : "Whether the index is interpolated between fixings. Presence-required:\nabsent-vs-false silently changes the observed CPI."
               },
         "revised" : {
                 "type" : "boolean",
-                "description" : "Whether index values can be revised (rare; defaults to false)."
+                "description" : "Whether index values can be revised (rare). Presence-required."
               },
         "kind" : {
                 "$ref" : "#/definitions/quantra_enums_InflationCurveKind"
@@ -2160,7 +2161,8 @@
                 "$ref" : "#/definitions/quantra_enums_Interpolator"
               },
         "bootstrap_accuracy" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Numerical bootstrap tolerance (not a market convention): keeps its default."
               },
         "kind" : {
                 "$ref" : "#/definitions/quantra_enums_InflationCurveKind"

--- a/flatbuffers/json/price_year_on_year_inflation_swap_request.schema.json
+++ b/flatbuffers/json/price_year_on_year_inflation_swap_request.schema.json
@@ -247,7 +247,8 @@
                 "$ref" : "#/definitions/quantra_enums_DateGenerationRule"
               },
         "end_of_month" : {
-                "type" : "boolean"
+                "type" : "boolean",
+                "description" : "Presence-required: absent-vs-false silently changes schedule dates for\nmonth-end-anchored (money-market) schedules."
               },
         "first_date" : {
                 "type" : "string",
@@ -262,7 +263,7 @@
     },
     "quantra_Period" : {
       "type" : "object",
-      "description" : "Canonical period type used across APIs.",
+      "description" : "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
       "properties" : {
         "n" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -409,7 +410,7 @@
               },
         "index_type" : {
                 "$ref" : "#/definitions/quantra_IndexType",
-                "description" : "IBOR or Overnight. Determines QuantLib class used."
+                "description" : "IBOR or Overnight. Determines QuantLib class used. Presence-required: an\nomitted value is a 400, never the silent Ibor default."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -417,23 +418,23 @@
               },
         "fixing_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647,
-                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR)."
+                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR). Presence-required."
               },
         "calendar" : {
                 "$ref" : "#/definitions/quantra_enums_Calendar",
-                "description" : "Calendar for fixing/payment dates."
+                "description" : "Calendar for fixing/payment dates. Presence-required."
               },
         "business_day_convention" : {
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention",
-                "description" : "Business day convention."
+                "description" : "Business day convention. Presence-required."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter",
-                "description" : "Day count convention."
+                "description" : "Day count convention. Presence-required."
               },
         "end_of_month" : {
                 "type" : "boolean",
-                "description" : "End of month rule (IBOR only, ignored for overnight)."
+                "description" : "End of month rule (IBOR only, ignored for overnight). Presence-required:\nabsent-vs-false silently changes money-market schedule dates."
               },
         "currency" : {
                 "type" : "string",
@@ -1616,7 +1617,7 @@
     },
     "quantra_SwapIndexFixedLegSpec" : {
       "type" : "object",
-      "description" : "Fixed leg conventions for swap index.",
+      "description" : "Fixed leg conventions for swap index. Every convention is presence-required.",
       "properties" : {
         "fixed_frequency" : {
                 "$ref" : "#/definitions/quantra_enums_Frequency"
@@ -1644,7 +1645,7 @@
     },
     "quantra_SwapIndexFloatLegSpec" : {
       "type" : "object",
-      "description" : "Floating leg conventions for swap index.",
+      "description" : "Floating leg conventions for swap index. Every convention is\npresence-required.",
       "properties" : {
         "float_tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -1739,7 +1740,7 @@
     },
     "quantra_CdsHelperConventions" : {
       "type" : "object",
-      "description" : "CDS helper conventions for curve building.",
+      "description" : "CDS helper conventions for curve building. Every convention is\npresence-required: an omitted value is a 400 naming the field, never a\nsilent market-default assumption.",
       "properties" : {
         "settlement_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -2015,11 +2016,11 @@
               },
         "interpolated" : {
                 "type" : "boolean",
-                "description" : "Whether the index is interpolated between fixings."
+                "description" : "Whether the index is interpolated between fixings. Presence-required:\nabsent-vs-false silently changes the observed CPI."
               },
         "revised" : {
                 "type" : "boolean",
-                "description" : "Whether index values can be revised (rare; defaults to false)."
+                "description" : "Whether index values can be revised (rare). Presence-required."
               },
         "kind" : {
                 "$ref" : "#/definitions/quantra_enums_InflationCurveKind"
@@ -2160,7 +2161,8 @@
                 "$ref" : "#/definitions/quantra_enums_Interpolator"
               },
         "bootstrap_accuracy" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Numerical bootstrap tolerance (not a market convention): keeps its default."
               },
         "kind" : {
                 "$ref" : "#/definitions/quantra_enums_InflationCurveKind"

--- a/flatbuffers/json/price_zero_coupon_bond_request.schema.json
+++ b/flatbuffers/json/price_zero_coupon_bond_request.schema.json
@@ -223,7 +223,7 @@
     },
     "quantra_Period" : {
       "type" : "object",
-      "description" : "Canonical period type used across APIs.",
+      "description" : "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
       "properties" : {
         "n" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -368,7 +368,8 @@
                 "$ref" : "#/definitions/quantra_enums_DateGenerationRule"
               },
         "end_of_month" : {
-                "type" : "boolean"
+                "type" : "boolean",
+                "description" : "Presence-required: absent-vs-false silently changes schedule dates for\nmonth-end-anchored (money-market) schedules."
               },
         "first_date" : {
                 "type" : "string",
@@ -409,7 +410,7 @@
               },
         "index_type" : {
                 "$ref" : "#/definitions/quantra_IndexType",
-                "description" : "IBOR or Overnight. Determines QuantLib class used."
+                "description" : "IBOR or Overnight. Determines QuantLib class used. Presence-required: an\nomitted value is a 400, never the silent Ibor default."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -417,23 +418,23 @@
               },
         "fixing_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647,
-                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR)."
+                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR). Presence-required."
               },
         "calendar" : {
                 "$ref" : "#/definitions/quantra_enums_Calendar",
-                "description" : "Calendar for fixing/payment dates."
+                "description" : "Calendar for fixing/payment dates. Presence-required."
               },
         "business_day_convention" : {
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention",
-                "description" : "Business day convention."
+                "description" : "Business day convention. Presence-required."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter",
-                "description" : "Day count convention."
+                "description" : "Day count convention. Presence-required."
               },
         "end_of_month" : {
                 "type" : "boolean",
-                "description" : "End of month rule (IBOR only, ignored for overnight)."
+                "description" : "End of month rule (IBOR only, ignored for overnight). Presence-required:\nabsent-vs-false silently changes money-market schedule dates."
               },
         "currency" : {
                 "type" : "string",
@@ -1616,7 +1617,7 @@
     },
     "quantra_SwapIndexFixedLegSpec" : {
       "type" : "object",
-      "description" : "Fixed leg conventions for swap index.",
+      "description" : "Fixed leg conventions for swap index. Every convention is presence-required.",
       "properties" : {
         "fixed_frequency" : {
                 "$ref" : "#/definitions/quantra_enums_Frequency"
@@ -1644,7 +1645,7 @@
     },
     "quantra_SwapIndexFloatLegSpec" : {
       "type" : "object",
-      "description" : "Floating leg conventions for swap index.",
+      "description" : "Floating leg conventions for swap index. Every convention is\npresence-required.",
       "properties" : {
         "float_tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -1739,7 +1740,7 @@
     },
     "quantra_CdsHelperConventions" : {
       "type" : "object",
-      "description" : "CDS helper conventions for curve building.",
+      "description" : "CDS helper conventions for curve building. Every convention is\npresence-required: an omitted value is a 400 naming the field, never a\nsilent market-default assumption.",
       "properties" : {
         "settlement_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -2015,11 +2016,11 @@
               },
         "interpolated" : {
                 "type" : "boolean",
-                "description" : "Whether the index is interpolated between fixings."
+                "description" : "Whether the index is interpolated between fixings. Presence-required:\nabsent-vs-false silently changes the observed CPI."
               },
         "revised" : {
                 "type" : "boolean",
-                "description" : "Whether index values can be revised (rare; defaults to false)."
+                "description" : "Whether index values can be revised (rare). Presence-required."
               },
         "kind" : {
                 "$ref" : "#/definitions/quantra_enums_InflationCurveKind"
@@ -2160,7 +2161,8 @@
                 "$ref" : "#/definitions/quantra_enums_Interpolator"
               },
         "bootstrap_accuracy" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Numerical bootstrap tolerance (not a market convention): keeps its default."
               },
         "kind" : {
                 "$ref" : "#/definitions/quantra_enums_InflationCurveKind"

--- a/flatbuffers/json/price_zero_coupon_inflation_swap_request.schema.json
+++ b/flatbuffers/json/price_zero_coupon_inflation_swap_request.schema.json
@@ -247,7 +247,8 @@
                 "$ref" : "#/definitions/quantra_enums_DateGenerationRule"
               },
         "end_of_month" : {
-                "type" : "boolean"
+                "type" : "boolean",
+                "description" : "Presence-required: absent-vs-false silently changes schedule dates for\nmonth-end-anchored (money-market) schedules."
               },
         "first_date" : {
                 "type" : "string",
@@ -262,7 +263,7 @@
     },
     "quantra_Period" : {
       "type" : "object",
-      "description" : "Canonical period type used across APIs.",
+      "description" : "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
       "properties" : {
         "n" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -409,7 +410,7 @@
               },
         "index_type" : {
                 "$ref" : "#/definitions/quantra_IndexType",
-                "description" : "IBOR or Overnight. Determines QuantLib class used."
+                "description" : "IBOR or Overnight. Determines QuantLib class used. Presence-required: an\nomitted value is a 400, never the silent Ibor default."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -417,23 +418,23 @@
               },
         "fixing_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647,
-                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR)."
+                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR). Presence-required."
               },
         "calendar" : {
                 "$ref" : "#/definitions/quantra_enums_Calendar",
-                "description" : "Calendar for fixing/payment dates."
+                "description" : "Calendar for fixing/payment dates. Presence-required."
               },
         "business_day_convention" : {
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention",
-                "description" : "Business day convention."
+                "description" : "Business day convention. Presence-required."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter",
-                "description" : "Day count convention."
+                "description" : "Day count convention. Presence-required."
               },
         "end_of_month" : {
                 "type" : "boolean",
-                "description" : "End of month rule (IBOR only, ignored for overnight)."
+                "description" : "End of month rule (IBOR only, ignored for overnight). Presence-required:\nabsent-vs-false silently changes money-market schedule dates."
               },
         "currency" : {
                 "type" : "string",
@@ -1616,7 +1617,7 @@
     },
     "quantra_SwapIndexFixedLegSpec" : {
       "type" : "object",
-      "description" : "Fixed leg conventions for swap index.",
+      "description" : "Fixed leg conventions for swap index. Every convention is presence-required.",
       "properties" : {
         "fixed_frequency" : {
                 "$ref" : "#/definitions/quantra_enums_Frequency"
@@ -1644,7 +1645,7 @@
     },
     "quantra_SwapIndexFloatLegSpec" : {
       "type" : "object",
-      "description" : "Floating leg conventions for swap index.",
+      "description" : "Floating leg conventions for swap index. Every convention is\npresence-required.",
       "properties" : {
         "float_tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -1739,7 +1740,7 @@
     },
     "quantra_CdsHelperConventions" : {
       "type" : "object",
-      "description" : "CDS helper conventions for curve building.",
+      "description" : "CDS helper conventions for curve building. Every convention is\npresence-required: an omitted value is a 400 naming the field, never a\nsilent market-default assumption.",
       "properties" : {
         "settlement_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -2015,11 +2016,11 @@
               },
         "interpolated" : {
                 "type" : "boolean",
-                "description" : "Whether the index is interpolated between fixings."
+                "description" : "Whether the index is interpolated between fixings. Presence-required:\nabsent-vs-false silently changes the observed CPI."
               },
         "revised" : {
                 "type" : "boolean",
-                "description" : "Whether index values can be revised (rare; defaults to false)."
+                "description" : "Whether index values can be revised (rare). Presence-required."
               },
         "kind" : {
                 "$ref" : "#/definitions/quantra_enums_InflationCurveKind"
@@ -2160,7 +2161,8 @@
                 "$ref" : "#/definitions/quantra_enums_Interpolator"
               },
         "bootstrap_accuracy" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Numerical bootstrap tolerance (not a market convention): keeps its default."
               },
         "kind" : {
                 "$ref" : "#/definitions/quantra_enums_InflationCurveKind"

--- a/flatbuffers/json/price_zero_coupon_swap_request.schema.json
+++ b/flatbuffers/json/price_zero_coupon_swap_request.schema.json
@@ -223,7 +223,7 @@
     },
     "quantra_Period" : {
       "type" : "object",
-      "description" : "Canonical period type used across APIs.",
+      "description" : "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
       "properties" : {
         "n" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -368,7 +368,8 @@
                 "$ref" : "#/definitions/quantra_enums_DateGenerationRule"
               },
         "end_of_month" : {
-                "type" : "boolean"
+                "type" : "boolean",
+                "description" : "Presence-required: absent-vs-false silently changes schedule dates for\nmonth-end-anchored (money-market) schedules."
               },
         "first_date" : {
                 "type" : "string",
@@ -409,7 +410,7 @@
               },
         "index_type" : {
                 "$ref" : "#/definitions/quantra_IndexType",
-                "description" : "IBOR or Overnight. Determines QuantLib class used."
+                "description" : "IBOR or Overnight. Determines QuantLib class used. Presence-required: an\nomitted value is a 400, never the silent Ibor default."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -417,23 +418,23 @@
               },
         "fixing_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647,
-                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR)."
+                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR). Presence-required."
               },
         "calendar" : {
                 "$ref" : "#/definitions/quantra_enums_Calendar",
-                "description" : "Calendar for fixing/payment dates."
+                "description" : "Calendar for fixing/payment dates. Presence-required."
               },
         "business_day_convention" : {
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention",
-                "description" : "Business day convention."
+                "description" : "Business day convention. Presence-required."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter",
-                "description" : "Day count convention."
+                "description" : "Day count convention. Presence-required."
               },
         "end_of_month" : {
                 "type" : "boolean",
-                "description" : "End of month rule (IBOR only, ignored for overnight)."
+                "description" : "End of month rule (IBOR only, ignored for overnight). Presence-required:\nabsent-vs-false silently changes money-market schedule dates."
               },
         "currency" : {
                 "type" : "string",
@@ -1616,7 +1617,7 @@
     },
     "quantra_SwapIndexFixedLegSpec" : {
       "type" : "object",
-      "description" : "Fixed leg conventions for swap index.",
+      "description" : "Fixed leg conventions for swap index. Every convention is presence-required.",
       "properties" : {
         "fixed_frequency" : {
                 "$ref" : "#/definitions/quantra_enums_Frequency"
@@ -1644,7 +1645,7 @@
     },
     "quantra_SwapIndexFloatLegSpec" : {
       "type" : "object",
-      "description" : "Floating leg conventions for swap index.",
+      "description" : "Floating leg conventions for swap index. Every convention is\npresence-required.",
       "properties" : {
         "float_tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -1739,7 +1740,7 @@
     },
     "quantra_CdsHelperConventions" : {
       "type" : "object",
-      "description" : "CDS helper conventions for curve building.",
+      "description" : "CDS helper conventions for curve building. Every convention is\npresence-required: an omitted value is a 400 naming the field, never a\nsilent market-default assumption.",
       "properties" : {
         "settlement_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -2015,11 +2016,11 @@
               },
         "interpolated" : {
                 "type" : "boolean",
-                "description" : "Whether the index is interpolated between fixings."
+                "description" : "Whether the index is interpolated between fixings. Presence-required:\nabsent-vs-false silently changes the observed CPI."
               },
         "revised" : {
                 "type" : "boolean",
-                "description" : "Whether index values can be revised (rare; defaults to false)."
+                "description" : "Whether index values can be revised (rare). Presence-required."
               },
         "kind" : {
                 "$ref" : "#/definitions/quantra_enums_InflationCurveKind"
@@ -2160,7 +2161,8 @@
                 "$ref" : "#/definitions/quantra_enums_Interpolator"
               },
         "bootstrap_accuracy" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Numerical bootstrap tolerance (not a market convention): keeps its default."
               },
         "kind" : {
                 "$ref" : "#/definitions/quantra_enums_InflationCurveKind"

--- a/flatbuffers/json/sample_vol_surfaces_request.schema.json
+++ b/flatbuffers/json/sample_vol_surfaces_request.schema.json
@@ -243,7 +243,7 @@
     },
     "quantra_Period" : {
       "type" : "object",
-      "description" : "Canonical period type used across APIs.",
+      "description" : "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
       "properties" : {
         "n" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -388,7 +388,8 @@
                 "$ref" : "#/definitions/quantra_enums_DateGenerationRule"
               },
         "end_of_month" : {
-                "type" : "boolean"
+                "type" : "boolean",
+                "description" : "Presence-required: absent-vs-false silently changes schedule dates for\nmonth-end-anchored (money-market) schedules."
               },
         "first_date" : {
                 "type" : "string",
@@ -429,7 +430,7 @@
               },
         "index_type" : {
                 "$ref" : "#/definitions/quantra_IndexType",
-                "description" : "IBOR or Overnight. Determines QuantLib class used."
+                "description" : "IBOR or Overnight. Determines QuantLib class used. Presence-required: an\nomitted value is a 400, never the silent Ibor default."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -437,23 +438,23 @@
               },
         "fixing_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647,
-                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR)."
+                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR). Presence-required."
               },
         "calendar" : {
                 "$ref" : "#/definitions/quantra_enums_Calendar",
-                "description" : "Calendar for fixing/payment dates."
+                "description" : "Calendar for fixing/payment dates. Presence-required."
               },
         "business_day_convention" : {
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention",
-                "description" : "Business day convention."
+                "description" : "Business day convention. Presence-required."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter",
-                "description" : "Day count convention."
+                "description" : "Day count convention. Presence-required."
               },
         "end_of_month" : {
                 "type" : "boolean",
-                "description" : "End of month rule (IBOR only, ignored for overnight)."
+                "description" : "End of month rule (IBOR only, ignored for overnight). Presence-required:\nabsent-vs-false silently changes money-market schedule dates."
               },
         "currency" : {
                 "type" : "string",
@@ -1636,7 +1637,7 @@
     },
     "quantra_SwapIndexFixedLegSpec" : {
       "type" : "object",
-      "description" : "Fixed leg conventions for swap index.",
+      "description" : "Fixed leg conventions for swap index. Every convention is presence-required.",
       "properties" : {
         "fixed_frequency" : {
                 "$ref" : "#/definitions/quantra_enums_Frequency"
@@ -1664,7 +1665,7 @@
     },
     "quantra_SwapIndexFloatLegSpec" : {
       "type" : "object",
-      "description" : "Floating leg conventions for swap index.",
+      "description" : "Floating leg conventions for swap index. Every convention is\npresence-required.",
       "properties" : {
         "float_tenor" : {
                 "$ref" : "#/definitions/quantra_Period"
@@ -1759,7 +1760,7 @@
     },
     "quantra_CdsHelperConventions" : {
       "type" : "object",
-      "description" : "CDS helper conventions for curve building.",
+      "description" : "CDS helper conventions for curve building. Every convention is\npresence-required: an omitted value is a 400 naming the field, never a\nsilent market-default assumption.",
       "properties" : {
         "settlement_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -2035,11 +2036,11 @@
               },
         "interpolated" : {
                 "type" : "boolean",
-                "description" : "Whether the index is interpolated between fixings."
+                "description" : "Whether the index is interpolated between fixings. Presence-required:\nabsent-vs-false silently changes the observed CPI."
               },
         "revised" : {
                 "type" : "boolean",
-                "description" : "Whether index values can be revised (rare; defaults to false)."
+                "description" : "Whether index values can be revised (rare). Presence-required."
               },
         "kind" : {
                 "$ref" : "#/definitions/quantra_enums_InflationCurveKind"
@@ -2180,7 +2181,8 @@
                 "$ref" : "#/definitions/quantra_enums_Interpolator"
               },
         "bootstrap_accuracy" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Numerical bootstrap tolerance (not a market convention): keeps its default."
               },
         "kind" : {
                 "$ref" : "#/definitions/quantra_enums_InflationCurveKind"

--- a/flatbuffers/json/sample_vol_surfaces_response.schema.json
+++ b/flatbuffers/json/sample_vol_surfaces_response.schema.json
@@ -199,7 +199,7 @@
     },
     "quantra_Period" : {
       "type" : "object",
-      "description" : "Canonical period type used across APIs.",
+      "description" : "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
       "properties" : {
         "n" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647

--- a/flatbuffers/json/swaption.schema.json
+++ b/flatbuffers/json/swaption.schema.json
@@ -211,7 +211,8 @@
                 "$ref" : "#/definitions/quantra_enums_DateGenerationRule"
               },
         "end_of_month" : {
-                "type" : "boolean"
+                "type" : "boolean",
+                "description" : "Presence-required: absent-vs-false silently changes schedule dates for\nmonth-end-anchored (money-market) schedules."
               },
         "first_date" : {
                 "type" : "string",
@@ -226,7 +227,7 @@
     },
     "quantra_Period" : {
       "type" : "object",
-      "description" : "Canonical period type used across APIs.",
+      "description" : "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
       "properties" : {
         "n" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -373,7 +374,7 @@
               },
         "index_type" : {
                 "$ref" : "#/definitions/quantra_IndexType",
-                "description" : "IBOR or Overnight. Determines QuantLib class used."
+                "description" : "IBOR or Overnight. Determines QuantLib class used. Presence-required: an\nomitted value is a 400, never the silent Ibor default."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -381,23 +382,23 @@
               },
         "fixing_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647,
-                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR)."
+                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR). Presence-required."
               },
         "calendar" : {
                 "$ref" : "#/definitions/quantra_enums_Calendar",
-                "description" : "Calendar for fixing/payment dates."
+                "description" : "Calendar for fixing/payment dates. Presence-required."
               },
         "business_day_convention" : {
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention",
-                "description" : "Business day convention."
+                "description" : "Business day convention. Presence-required."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter",
-                "description" : "Day count convention."
+                "description" : "Day count convention. Presence-required."
               },
         "end_of_month" : {
                 "type" : "boolean",
-                "description" : "End of month rule (IBOR only, ignored for overnight)."
+                "description" : "End of month rule (IBOR only, ignored for overnight). Presence-required:\nabsent-vs-false silently changes money-market schedule dates."
               },
         "currency" : {
                 "type" : "string",

--- a/flatbuffers/json/swaption_response.schema.json
+++ b/flatbuffers/json/swaption_response.schema.json
@@ -179,7 +179,7 @@
     },
     "quantra_Period" : {
       "type" : "object",
-      "description" : "Canonical period type used across APIs.",
+      "description" : "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
       "properties" : {
         "n" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647

--- a/flatbuffers/json/term_structure.schema.json
+++ b/flatbuffers/json/term_structure.schema.json
@@ -211,7 +211,8 @@
                 "$ref" : "#/definitions/quantra_enums_DateGenerationRule"
               },
         "end_of_month" : {
-                "type" : "boolean"
+                "type" : "boolean",
+                "description" : "Presence-required: absent-vs-false silently changes schedule dates for\nmonth-end-anchored (money-market) schedules."
               },
         "first_date" : {
                 "type" : "string",
@@ -226,7 +227,7 @@
     },
     "quantra_Period" : {
       "type" : "object",
-      "description" : "Canonical period type used across APIs.",
+      "description" : "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
       "properties" : {
         "n" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -373,7 +374,7 @@
               },
         "index_type" : {
                 "$ref" : "#/definitions/quantra_IndexType",
-                "description" : "IBOR or Overnight. Determines QuantLib class used."
+                "description" : "IBOR or Overnight. Determines QuantLib class used. Presence-required: an\nomitted value is a 400, never the silent Ibor default."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -381,23 +382,23 @@
               },
         "fixing_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647,
-                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR)."
+                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR). Presence-required."
               },
         "calendar" : {
                 "$ref" : "#/definitions/quantra_enums_Calendar",
-                "description" : "Calendar for fixing/payment dates."
+                "description" : "Calendar for fixing/payment dates. Presence-required."
               },
         "business_day_convention" : {
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention",
-                "description" : "Business day convention."
+                "description" : "Business day convention. Presence-required."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter",
-                "description" : "Day count convention."
+                "description" : "Day count convention. Presence-required."
               },
         "end_of_month" : {
                 "type" : "boolean",
-                "description" : "End of month rule (IBOR only, ignored for overnight)."
+                "description" : "End of month rule (IBOR only, ignored for overnight). Presence-required:\nabsent-vs-false silently changes money-market schedule dates."
               },
         "currency" : {
                 "type" : "string",

--- a/flatbuffers/json/vanilla_swap.schema.json
+++ b/flatbuffers/json/vanilla_swap.schema.json
@@ -207,7 +207,8 @@
                 "$ref" : "#/definitions/quantra_enums_DateGenerationRule"
               },
         "end_of_month" : {
-                "type" : "boolean"
+                "type" : "boolean",
+                "description" : "Presence-required: absent-vs-false silently changes schedule dates for\nmonth-end-anchored (money-market) schedules."
               },
         "first_date" : {
                 "type" : "string",
@@ -222,7 +223,7 @@
     },
     "quantra_Period" : {
       "type" : "object",
-      "description" : "Canonical period type used across APIs.",
+      "description" : "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
       "properties" : {
         "n" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -369,7 +370,7 @@
               },
         "index_type" : {
                 "$ref" : "#/definitions/quantra_IndexType",
-                "description" : "IBOR or Overnight. Determines QuantLib class used."
+                "description" : "IBOR or Overnight. Determines QuantLib class used. Presence-required: an\nomitted value is a 400, never the silent Ibor default."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -377,23 +378,23 @@
               },
         "fixing_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647,
-                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR)."
+                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR). Presence-required."
               },
         "calendar" : {
                 "$ref" : "#/definitions/quantra_enums_Calendar",
-                "description" : "Calendar for fixing/payment dates."
+                "description" : "Calendar for fixing/payment dates. Presence-required."
               },
         "business_day_convention" : {
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention",
-                "description" : "Business day convention."
+                "description" : "Business day convention. Presence-required."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter",
-                "description" : "Day count convention."
+                "description" : "Day count convention. Presence-required."
               },
         "end_of_month" : {
                 "type" : "boolean",
-                "description" : "End of month rule (IBOR only, ignored for overnight)."
+                "description" : "End of month rule (IBOR only, ignored for overnight). Presence-required:\nabsent-vs-false silently changes money-market schedule dates."
               },
         "currency" : {
                 "type" : "string",

--- a/flatbuffers/json/vanilla_swap_response.schema.json
+++ b/flatbuffers/json/vanilla_swap_response.schema.json
@@ -179,7 +179,7 @@
     },
     "quantra_Period" : {
       "type" : "object",
-      "description" : "Canonical period type used across APIs.",
+      "description" : "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
       "properties" : {
         "n" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647

--- a/flatbuffers/json/year_on_year_inflation_cap_floor.schema.json
+++ b/flatbuffers/json/year_on_year_inflation_cap_floor.schema.json
@@ -179,7 +179,7 @@
     },
     "quantra_Period" : {
       "type" : "object",
-      "description" : "Canonical period type used across APIs.",
+      "description" : "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
       "properties" : {
         "n" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -324,7 +324,8 @@
                 "$ref" : "#/definitions/quantra_enums_DateGenerationRule"
               },
         "end_of_month" : {
-                "type" : "boolean"
+                "type" : "boolean",
+                "description" : "Presence-required: absent-vs-false silently changes schedule dates for\nmonth-end-anchored (money-market) schedules."
               },
         "first_date" : {
                 "type" : "string",

--- a/flatbuffers/json/year_on_year_inflation_swap.schema.json
+++ b/flatbuffers/json/year_on_year_inflation_swap.schema.json
@@ -187,7 +187,7 @@
     },
     "quantra_Period" : {
       "type" : "object",
-      "description" : "Canonical period type used across APIs.",
+      "description" : "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
       "properties" : {
         "n" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -334,7 +334,7 @@
               },
         "index_type" : {
                 "$ref" : "#/definitions/quantra_IndexType",
-                "description" : "IBOR or Overnight. Determines QuantLib class used."
+                "description" : "IBOR or Overnight. Determines QuantLib class used. Presence-required: an\nomitted value is a 400, never the silent Ibor default."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -342,23 +342,23 @@
               },
         "fixing_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647,
-                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR)."
+                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR). Presence-required."
               },
         "calendar" : {
                 "$ref" : "#/definitions/quantra_enums_Calendar",
-                "description" : "Calendar for fixing/payment dates."
+                "description" : "Calendar for fixing/payment dates. Presence-required."
               },
         "business_day_convention" : {
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention",
-                "description" : "Business day convention."
+                "description" : "Business day convention. Presence-required."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter",
-                "description" : "Day count convention."
+                "description" : "Day count convention. Presence-required."
               },
         "end_of_month" : {
                 "type" : "boolean",
-                "description" : "End of month rule (IBOR only, ignored for overnight)."
+                "description" : "End of month rule (IBOR only, ignored for overnight). Presence-required:\nabsent-vs-false silently changes money-market schedule dates."
               },
         "currency" : {
                 "type" : "string",
@@ -409,7 +409,8 @@
                 "$ref" : "#/definitions/quantra_enums_DateGenerationRule"
               },
         "end_of_month" : {
-                "type" : "boolean"
+                "type" : "boolean",
+                "description" : "Presence-required: absent-vs-false silently changes schedule dates for\nmonth-end-anchored (money-market) schedules."
               },
         "first_date" : {
                 "type" : "string",
@@ -457,11 +458,11 @@
               },
         "interpolated" : {
                 "type" : "boolean",
-                "description" : "Whether the index is interpolated between fixings."
+                "description" : "Whether the index is interpolated between fixings. Presence-required:\nabsent-vs-false silently changes the observed CPI."
               },
         "revised" : {
                 "type" : "boolean",
-                "description" : "Whether index values can be revised (rare; defaults to false)."
+                "description" : "Whether index values can be revised (rare). Presence-required."
               },
         "kind" : {
                 "$ref" : "#/definitions/quantra_enums_InflationCurveKind"
@@ -602,7 +603,8 @@
                 "$ref" : "#/definitions/quantra_enums_Interpolator"
               },
         "bootstrap_accuracy" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Numerical bootstrap tolerance (not a market convention): keeps its default."
               },
         "kind" : {
                 "$ref" : "#/definitions/quantra_enums_InflationCurveKind"

--- a/flatbuffers/json/year_on_year_inflation_swap_response.schema.json
+++ b/flatbuffers/json/year_on_year_inflation_swap_response.schema.json
@@ -179,7 +179,7 @@
     },
     "quantra_Period" : {
       "type" : "object",
-      "description" : "Canonical period type used across APIs.",
+      "description" : "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
       "properties" : {
         "n" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647

--- a/flatbuffers/json/zero_coupon_inflation_swap.schema.json
+++ b/flatbuffers/json/zero_coupon_inflation_swap.schema.json
@@ -187,7 +187,7 @@
     },
     "quantra_Period" : {
       "type" : "object",
-      "description" : "Canonical period type used across APIs.",
+      "description" : "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
       "properties" : {
         "n" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -334,7 +334,7 @@
               },
         "index_type" : {
                 "$ref" : "#/definitions/quantra_IndexType",
-                "description" : "IBOR or Overnight. Determines QuantLib class used."
+                "description" : "IBOR or Overnight. Determines QuantLib class used. Presence-required: an\nomitted value is a 400, never the silent Ibor default."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -342,23 +342,23 @@
               },
         "fixing_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647,
-                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR)."
+                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR). Presence-required."
               },
         "calendar" : {
                 "$ref" : "#/definitions/quantra_enums_Calendar",
-                "description" : "Calendar for fixing/payment dates."
+                "description" : "Calendar for fixing/payment dates. Presence-required."
               },
         "business_day_convention" : {
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention",
-                "description" : "Business day convention."
+                "description" : "Business day convention. Presence-required."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter",
-                "description" : "Day count convention."
+                "description" : "Day count convention. Presence-required."
               },
         "end_of_month" : {
                 "type" : "boolean",
-                "description" : "End of month rule (IBOR only, ignored for overnight)."
+                "description" : "End of month rule (IBOR only, ignored for overnight). Presence-required:\nabsent-vs-false silently changes money-market schedule dates."
               },
         "currency" : {
                 "type" : "string",
@@ -409,7 +409,8 @@
                 "$ref" : "#/definitions/quantra_enums_DateGenerationRule"
               },
         "end_of_month" : {
-                "type" : "boolean"
+                "type" : "boolean",
+                "description" : "Presence-required: absent-vs-false silently changes schedule dates for\nmonth-end-anchored (money-market) schedules."
               },
         "first_date" : {
                 "type" : "string",
@@ -457,11 +458,11 @@
               },
         "interpolated" : {
                 "type" : "boolean",
-                "description" : "Whether the index is interpolated between fixings."
+                "description" : "Whether the index is interpolated between fixings. Presence-required:\nabsent-vs-false silently changes the observed CPI."
               },
         "revised" : {
                 "type" : "boolean",
-                "description" : "Whether index values can be revised (rare; defaults to false)."
+                "description" : "Whether index values can be revised (rare). Presence-required."
               },
         "kind" : {
                 "$ref" : "#/definitions/quantra_enums_InflationCurveKind"
@@ -602,7 +603,8 @@
                 "$ref" : "#/definitions/quantra_enums_Interpolator"
               },
         "bootstrap_accuracy" : {
-                "type" : "number"
+                "type" : "number",
+                "description" : "Numerical bootstrap tolerance (not a market convention): keeps its default."
               },
         "kind" : {
                 "$ref" : "#/definitions/quantra_enums_InflationCurveKind"

--- a/flatbuffers/json/zero_coupon_inflation_swap_response.schema.json
+++ b/flatbuffers/json/zero_coupon_inflation_swap_response.schema.json
@@ -179,7 +179,7 @@
     },
     "quantra_Period" : {
       "type" : "object",
-      "description" : "Canonical period type used across APIs.",
+      "description" : "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
       "properties" : {
         "n" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647

--- a/flatbuffers/json/zero_coupon_swap.schema.json
+++ b/flatbuffers/json/zero_coupon_swap.schema.json
@@ -183,7 +183,7 @@
     },
     "quantra_Period" : {
       "type" : "object",
-      "description" : "Canonical period type used across APIs.",
+      "description" : "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
       "properties" : {
         "n" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
@@ -330,7 +330,7 @@
               },
         "index_type" : {
                 "$ref" : "#/definitions/quantra_IndexType",
-                "description" : "IBOR or Overnight. Determines QuantLib class used."
+                "description" : "IBOR or Overnight. Determines QuantLib class used. Presence-required: an\nomitted value is a 400, never the silent Ibor default."
               },
         "tenor" : {
                 "$ref" : "#/definitions/quantra_Period",
@@ -338,23 +338,23 @@
               },
         "fixing_days" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647,
-                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR)."
+                "description" : "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR). Presence-required."
               },
         "calendar" : {
                 "$ref" : "#/definitions/quantra_enums_Calendar",
-                "description" : "Calendar for fixing/payment dates."
+                "description" : "Calendar for fixing/payment dates. Presence-required."
               },
         "business_day_convention" : {
                 "$ref" : "#/definitions/quantra_enums_BusinessDayConvention",
-                "description" : "Business day convention."
+                "description" : "Business day convention. Presence-required."
               },
         "day_counter" : {
                 "$ref" : "#/definitions/quantra_enums_DayCounter",
-                "description" : "Day count convention."
+                "description" : "Day count convention. Presence-required."
               },
         "end_of_month" : {
                 "type" : "boolean",
-                "description" : "End of month rule (IBOR only, ignored for overnight)."
+                "description" : "End of month rule (IBOR only, ignored for overnight). Presence-required:\nabsent-vs-false silently changes money-market schedule dates."
               },
         "currency" : {
                 "type" : "string",

--- a/flatbuffers/python/quantra/CDS.py
+++ b/flatbuffers/python/quantra/CDS.py
@@ -84,26 +84,28 @@ class CDS(object):
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
         return None
 
+    # ISDA settlement conventions. Presence-required: each is a deliberate
+    # choice (false round-trips) so an omission is a 400, never a silent true.
     # CDS
     def SettlesAccrual(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(18))
         if o != 0:
             return bool(self._tab.Get(flatbuffers.number_types.BoolFlags, o + self._tab.Pos))
-        return True
+        return None
 
     # CDS
     def PaysAtDefaultTime(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(20))
         if o != 0:
             return bool(self._tab.Get(flatbuffers.number_types.BoolFlags, o + self._tab.Pos))
-        return True
+        return None
 
     # CDS
     def RebatesAccrual(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(22))
         if o != 0:
             return bool(self._tab.Get(flatbuffers.number_types.BoolFlags, o + self._tab.Pos))
-        return True
+        return None
 
     # CDS
     def ProtectionStart(self):
@@ -124,7 +126,7 @@ class CDS(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(28))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # CDS
     def TradeDate(self):
@@ -138,7 +140,7 @@ class CDS(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(32))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int32Flags, o + self._tab.Pos)
-        return 3
+        return None
 
 def CDSStart(builder):
     builder.StartObject(15)
@@ -189,19 +191,19 @@ def AddBusinessDayConvention(builder, businessDayConvention):
     CDSAddBusinessDayConvention(builder, businessDayConvention)
 
 def CDSAddSettlesAccrual(builder, settlesAccrual):
-    builder.PrependBoolSlot(7, settlesAccrual, 1)
+    builder.PrependBoolSlot(7, settlesAccrual, None)
 
 def AddSettlesAccrual(builder, settlesAccrual):
     CDSAddSettlesAccrual(builder, settlesAccrual)
 
 def CDSAddPaysAtDefaultTime(builder, paysAtDefaultTime):
-    builder.PrependBoolSlot(8, paysAtDefaultTime, 1)
+    builder.PrependBoolSlot(8, paysAtDefaultTime, None)
 
 def AddPaysAtDefaultTime(builder, paysAtDefaultTime):
     CDSAddPaysAtDefaultTime(builder, paysAtDefaultTime)
 
 def CDSAddRebatesAccrual(builder, rebatesAccrual):
-    builder.PrependBoolSlot(9, rebatesAccrual, 1)
+    builder.PrependBoolSlot(9, rebatesAccrual, None)
 
 def AddRebatesAccrual(builder, rebatesAccrual):
     CDSAddRebatesAccrual(builder, rebatesAccrual)
@@ -219,7 +221,7 @@ def AddUpfrontDate(builder, upfrontDate):
     CDSAddUpfrontDate(builder, upfrontDate)
 
 def CDSAddLastPeriodDayCounter(builder, lastPeriodDayCounter):
-    builder.PrependInt8Slot(12, lastPeriodDayCounter, 0)
+    builder.PrependInt8Slot(12, lastPeriodDayCounter, None)
 
 def AddLastPeriodDayCounter(builder, lastPeriodDayCounter):
     CDSAddLastPeriodDayCounter(builder, lastPeriodDayCounter)
@@ -231,7 +233,7 @@ def AddTradeDate(builder, tradeDate):
     CDSAddTradeDate(builder, tradeDate)
 
 def CDSAddCashSettlementDays(builder, cashSettlementDays):
-    builder.PrependInt32Slot(14, cashSettlementDays, 3)
+    builder.PrependInt32Slot(14, cashSettlementDays, None)
 
 def AddCashSettlementDays(builder, cashSettlementDays):
     CDSAddCashSettlementDays(builder, cashSettlementDays)
@@ -258,14 +260,14 @@ class CDST(object):
         self.upfront = None  # type: Optional[float]
         self.dayCounter = None  # type: Optional[int]
         self.businessDayConvention = None  # type: Optional[int]
-        self.settlesAccrual = True  # type: bool
-        self.paysAtDefaultTime = True  # type: bool
-        self.rebatesAccrual = True  # type: bool
+        self.settlesAccrual = None  # type: Optional[bool]
+        self.paysAtDefaultTime = None  # type: Optional[bool]
+        self.rebatesAccrual = None  # type: Optional[bool]
         self.protectionStart = None  # type: str
         self.upfrontDate = None  # type: str
-        self.lastPeriodDayCounter = 0  # type: int
+        self.lastPeriodDayCounter = None  # type: Optional[int]
         self.tradeDate = None  # type: str
-        self.cashSettlementDays = 3  # type: int
+        self.cashSettlementDays = None  # type: Optional[int]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):

--- a/flatbuffers/python/quantra/CdsHelperConventions.py
+++ b/flatbuffers/python/quantra/CdsHelperConventions.py
@@ -6,7 +6,9 @@ import flatbuffers
 from flatbuffers.compat import import_numpy
 np = import_numpy()
 
-# CDS helper conventions for curve building.
+# CDS helper conventions for curve building. Every convention is
+# presence-required: an omitted value is a 400 naming the field, never a
+# silent market-default assumption.
 class CdsHelperConventions(object):
     __slots__ = ['_tab']
 
@@ -30,63 +32,63 @@ class CdsHelperConventions(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int32Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # CdsHelperConventions
     def Frequency(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 10
+        return None
 
     # CdsHelperConventions
     def BusinessDayConvention(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(8))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # CdsHelperConventions
     def DateGenerationRule(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(10))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 6
+        return None
 
     # CdsHelperConventions
     def LastPeriodDayCounter(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(12))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 1
+        return None
 
     # CdsHelperConventions
     def SettlesAccrual(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(14))
         if o != 0:
             return bool(self._tab.Get(flatbuffers.number_types.BoolFlags, o + self._tab.Pos))
-        return True
+        return None
 
     # CdsHelperConventions
     def PaysAtDefaultTime(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(16))
         if o != 0:
             return bool(self._tab.Get(flatbuffers.number_types.BoolFlags, o + self._tab.Pos))
-        return True
+        return None
 
     # CdsHelperConventions
     def RebatesAccrual(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(18))
         if o != 0:
             return bool(self._tab.Get(flatbuffers.number_types.BoolFlags, o + self._tab.Pos))
-        return True
+        return None
 
     # CdsHelperConventions
     def HelperModel(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(20))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
 def CdsHelperConventionsStart(builder):
     builder.StartObject(9)
@@ -95,55 +97,55 @@ def Start(builder):
     CdsHelperConventionsStart(builder)
 
 def CdsHelperConventionsAddSettlementDays(builder, settlementDays):
-    builder.PrependInt32Slot(0, settlementDays, 0)
+    builder.PrependInt32Slot(0, settlementDays, None)
 
 def AddSettlementDays(builder, settlementDays):
     CdsHelperConventionsAddSettlementDays(builder, settlementDays)
 
 def CdsHelperConventionsAddFrequency(builder, frequency):
-    builder.PrependInt8Slot(1, frequency, 10)
+    builder.PrependInt8Slot(1, frequency, None)
 
 def AddFrequency(builder, frequency):
     CdsHelperConventionsAddFrequency(builder, frequency)
 
 def CdsHelperConventionsAddBusinessDayConvention(builder, businessDayConvention):
-    builder.PrependInt8Slot(2, businessDayConvention, 0)
+    builder.PrependInt8Slot(2, businessDayConvention, None)
 
 def AddBusinessDayConvention(builder, businessDayConvention):
     CdsHelperConventionsAddBusinessDayConvention(builder, businessDayConvention)
 
 def CdsHelperConventionsAddDateGenerationRule(builder, dateGenerationRule):
-    builder.PrependInt8Slot(3, dateGenerationRule, 6)
+    builder.PrependInt8Slot(3, dateGenerationRule, None)
 
 def AddDateGenerationRule(builder, dateGenerationRule):
     CdsHelperConventionsAddDateGenerationRule(builder, dateGenerationRule)
 
 def CdsHelperConventionsAddLastPeriodDayCounter(builder, lastPeriodDayCounter):
-    builder.PrependInt8Slot(4, lastPeriodDayCounter, 1)
+    builder.PrependInt8Slot(4, lastPeriodDayCounter, None)
 
 def AddLastPeriodDayCounter(builder, lastPeriodDayCounter):
     CdsHelperConventionsAddLastPeriodDayCounter(builder, lastPeriodDayCounter)
 
 def CdsHelperConventionsAddSettlesAccrual(builder, settlesAccrual):
-    builder.PrependBoolSlot(5, settlesAccrual, 1)
+    builder.PrependBoolSlot(5, settlesAccrual, None)
 
 def AddSettlesAccrual(builder, settlesAccrual):
     CdsHelperConventionsAddSettlesAccrual(builder, settlesAccrual)
 
 def CdsHelperConventionsAddPaysAtDefaultTime(builder, paysAtDefaultTime):
-    builder.PrependBoolSlot(6, paysAtDefaultTime, 1)
+    builder.PrependBoolSlot(6, paysAtDefaultTime, None)
 
 def AddPaysAtDefaultTime(builder, paysAtDefaultTime):
     CdsHelperConventionsAddPaysAtDefaultTime(builder, paysAtDefaultTime)
 
 def CdsHelperConventionsAddRebatesAccrual(builder, rebatesAccrual):
-    builder.PrependBoolSlot(7, rebatesAccrual, 1)
+    builder.PrependBoolSlot(7, rebatesAccrual, None)
 
 def AddRebatesAccrual(builder, rebatesAccrual):
     CdsHelperConventionsAddRebatesAccrual(builder, rebatesAccrual)
 
 def CdsHelperConventionsAddHelperModel(builder, helperModel):
-    builder.PrependInt8Slot(8, helperModel, 0)
+    builder.PrependInt8Slot(8, helperModel, None)
 
 def AddHelperModel(builder, helperModel):
     CdsHelperConventionsAddHelperModel(builder, helperModel)
@@ -159,15 +161,15 @@ class CdsHelperConventionsT(object):
 
     # CdsHelperConventionsT
     def __init__(self):
-        self.settlementDays = 0  # type: int
-        self.frequency = 10  # type: int
-        self.businessDayConvention = 0  # type: int
-        self.dateGenerationRule = 6  # type: int
-        self.lastPeriodDayCounter = 1  # type: int
-        self.settlesAccrual = True  # type: bool
-        self.paysAtDefaultTime = True  # type: bool
-        self.rebatesAccrual = True  # type: bool
-        self.helperModel = 0  # type: int
+        self.settlementDays = None  # type: Optional[int]
+        self.frequency = None  # type: Optional[int]
+        self.businessDayConvention = None  # type: Optional[int]
+        self.dateGenerationRule = None  # type: Optional[int]
+        self.lastPeriodDayCounter = None  # type: Optional[int]
+        self.settlesAccrual = None  # type: Optional[bool]
+        self.paysAtDefaultTime = None  # type: Optional[bool]
+        self.rebatesAccrual = None  # type: Optional[bool]
+        self.helperModel = None  # type: Optional[int]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):

--- a/flatbuffers/python/quantra/CreditCurveSpec.py
+++ b/flatbuffers/python/quantra/CreditCurveSpec.py
@@ -44,28 +44,28 @@ class CreditCurveSpec(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(8))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 21
+        return None
 
     # CreditCurveSpec
     def DayCounter(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(10))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 1
+        return None
 
     # CreditCurveSpec
     def RecoveryRate(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(12))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return 0.4
+        return None
 
     # CreditCurveSpec
     def CurveInterpolator(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(14))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 4
+        return None
 
     # CreditCurveSpec
     def HelperConventions(self):
@@ -133,25 +133,25 @@ def AddReferenceDate(builder, referenceDate):
     CreditCurveSpecAddReferenceDate(builder, referenceDate)
 
 def CreditCurveSpecAddCalendar(builder, calendar):
-    builder.PrependInt8Slot(2, calendar, 21)
+    builder.PrependInt8Slot(2, calendar, None)
 
 def AddCalendar(builder, calendar):
     CreditCurveSpecAddCalendar(builder, calendar)
 
 def CreditCurveSpecAddDayCounter(builder, dayCounter):
-    builder.PrependInt8Slot(3, dayCounter, 1)
+    builder.PrependInt8Slot(3, dayCounter, None)
 
 def AddDayCounter(builder, dayCounter):
     CreditCurveSpecAddDayCounter(builder, dayCounter)
 
 def CreditCurveSpecAddRecoveryRate(builder, recoveryRate):
-    builder.PrependFloat64Slot(4, recoveryRate, 0.4)
+    builder.PrependFloat64Slot(4, recoveryRate, None)
 
 def AddRecoveryRate(builder, recoveryRate):
     CreditCurveSpecAddRecoveryRate(builder, recoveryRate)
 
 def CreditCurveSpecAddCurveInterpolator(builder, curveInterpolator):
-    builder.PrependInt8Slot(5, curveInterpolator, 4)
+    builder.PrependInt8Slot(5, curveInterpolator, None)
 
 def AddCurveInterpolator(builder, curveInterpolator):
     CreditCurveSpecAddCurveInterpolator(builder, curveInterpolator)
@@ -197,10 +197,10 @@ class CreditCurveSpecT(object):
     def __init__(self):
         self.id = None  # type: str
         self.referenceDate = None  # type: str
-        self.calendar = 21  # type: int
-        self.dayCounter = 1  # type: int
-        self.recoveryRate = 0.4  # type: float
-        self.curveInterpolator = 4  # type: int
+        self.calendar = None  # type: Optional[int]
+        self.dayCounter = None  # type: Optional[int]
+        self.recoveryRate = None  # type: Optional[float]
+        self.curveInterpolator = None  # type: Optional[int]
         self.helperConventions = None  # type: Optional[CdsHelperConventionsT]
         self.quotes = None  # type: List[CdsQuoteT]
         self.flatHazardRate = None  # type: Optional[float]

--- a/flatbuffers/python/quantra/DatedOISHelper.py
+++ b/flatbuffers/python/quantra/DatedOISHelper.py
@@ -64,28 +64,28 @@ class DatedOISHelper(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(12))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int32Flags, o + self._tab.Pos)
-        return 2
+        return None
 
     # DatedOISHelper
     def Calendar(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(14))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 32
+        return None
 
     # DatedOISHelper
     def FixedLegConvention(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(16))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 2
+        return None
 
     # DatedOISHelper
     def FixedLegDayCounter(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(18))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # Exogenous discount curve for dual-curve OIS bootstrapping.
     # DatedOISHelper
@@ -137,25 +137,25 @@ def AddOvernightIndex(builder, overnightIndex):
     DatedOISHelperAddOvernightIndex(builder, overnightIndex)
 
 def DatedOISHelperAddSettlementDays(builder, settlementDays):
-    builder.PrependInt32Slot(4, settlementDays, 2)
+    builder.PrependInt32Slot(4, settlementDays, None)
 
 def AddSettlementDays(builder, settlementDays):
     DatedOISHelperAddSettlementDays(builder, settlementDays)
 
 def DatedOISHelperAddCalendar(builder, calendar):
-    builder.PrependInt8Slot(5, calendar, 32)
+    builder.PrependInt8Slot(5, calendar, None)
 
 def AddCalendar(builder, calendar):
     DatedOISHelperAddCalendar(builder, calendar)
 
 def DatedOISHelperAddFixedLegConvention(builder, fixedLegConvention):
-    builder.PrependInt8Slot(6, fixedLegConvention, 2)
+    builder.PrependInt8Slot(6, fixedLegConvention, None)
 
 def AddFixedLegConvention(builder, fixedLegConvention):
     DatedOISHelperAddFixedLegConvention(builder, fixedLegConvention)
 
 def DatedOISHelperAddFixedLegDayCounter(builder, fixedLegDayCounter):
-    builder.PrependInt8Slot(7, fixedLegDayCounter, 0)
+    builder.PrependInt8Slot(7, fixedLegDayCounter, None)
 
 def AddFixedLegDayCounter(builder, fixedLegDayCounter):
     DatedOISHelperAddFixedLegDayCounter(builder, fixedLegDayCounter)
@@ -191,10 +191,10 @@ class DatedOISHelperT(object):
         self.startDate = None  # type: str
         self.endDate = None  # type: str
         self.overnightIndex = None  # type: Optional[IndexRefT]
-        self.settlementDays = 2  # type: int
-        self.calendar = 32  # type: int
-        self.fixedLegConvention = 2  # type: int
-        self.fixedLegDayCounter = 0  # type: int
+        self.settlementDays = None  # type: Optional[int]
+        self.calendar = None  # type: Optional[int]
+        self.fixedLegConvention = None  # type: Optional[int]
+        self.fixedLegDayCounter = None  # type: Optional[int]
         self.deps = None  # type: Optional[HelperDependenciesT]
         self.quoteId = None  # type: str
 

--- a/flatbuffers/python/quantra/DiscountFactorPoint.py
+++ b/flatbuffers/python/quantra/DiscountFactorPoint.py
@@ -52,14 +52,14 @@ class DiscountFactorPoint(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(8))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 32
+        return None
 
     # DiscountFactorPoint
     def BusinessDayConvention(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(10))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 2
+        return None
 
     # Discount factor to this maturity. Required; must be in (0, 1]. The first
     # point (reference date) must carry a discount factor of exactly 1.0.
@@ -89,13 +89,13 @@ def AddTenor(builder, tenor):
     DiscountFactorPointAddTenor(builder, tenor)
 
 def DiscountFactorPointAddCalendar(builder, calendar):
-    builder.PrependInt8Slot(2, calendar, 32)
+    builder.PrependInt8Slot(2, calendar, None)
 
 def AddCalendar(builder, calendar):
     DiscountFactorPointAddCalendar(builder, calendar)
 
 def DiscountFactorPointAddBusinessDayConvention(builder, businessDayConvention):
-    builder.PrependInt8Slot(3, businessDayConvention, 2)
+    builder.PrependInt8Slot(3, businessDayConvention, None)
 
 def AddBusinessDayConvention(builder, businessDayConvention):
     DiscountFactorPointAddBusinessDayConvention(builder, businessDayConvention)
@@ -123,8 +123,8 @@ class DiscountFactorPointT(object):
     def __init__(self):
         self.date = None  # type: str
         self.tenor = None  # type: Optional[PeriodT]
-        self.calendar = 32  # type: int
-        self.businessDayConvention = 2  # type: int
+        self.calendar = None  # type: Optional[int]
+        self.businessDayConvention = None  # type: Optional[int]
         self.discountFactor = None  # type: Optional[float]
 
     @classmethod

--- a/flatbuffers/python/quantra/ForwardRatePoint.py
+++ b/flatbuffers/python/quantra/ForwardRatePoint.py
@@ -56,14 +56,14 @@ class ForwardRatePoint(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(8))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 32
+        return None
 
     # ForwardRatePoint
     def BusinessDayConvention(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(10))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 2
+        return None
 
     # Instantaneous, continuously-compounded forward rate at this node.
     # Required. May be negative in some markets; only non-finite is rejected.
@@ -93,13 +93,13 @@ def AddTenor(builder, tenor):
     ForwardRatePointAddTenor(builder, tenor)
 
 def ForwardRatePointAddCalendar(builder, calendar):
-    builder.PrependInt8Slot(2, calendar, 32)
+    builder.PrependInt8Slot(2, calendar, None)
 
 def AddCalendar(builder, calendar):
     ForwardRatePointAddCalendar(builder, calendar)
 
 def ForwardRatePointAddBusinessDayConvention(builder, businessDayConvention):
-    builder.PrependInt8Slot(3, businessDayConvention, 2)
+    builder.PrependInt8Slot(3, businessDayConvention, None)
 
 def AddBusinessDayConvention(builder, businessDayConvention):
     ForwardRatePointAddBusinessDayConvention(builder, businessDayConvention)
@@ -127,8 +127,8 @@ class ForwardRatePointT(object):
     def __init__(self):
         self.date = None  # type: str
         self.tenor = None  # type: Optional[PeriodT]
-        self.calendar = 32  # type: int
-        self.businessDayConvention = 2  # type: int
+        self.calendar = None  # type: Optional[int]
+        self.businessDayConvention = None  # type: Optional[int]
         self.forwardRate = None  # type: Optional[float]
 
     @classmethod

--- a/flatbuffers/python/quantra/FxSwapHelper.py
+++ b/flatbuffers/python/quantra/FxSwapHelper.py
@@ -49,21 +49,21 @@ class FxSwapHelper(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(8))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int32Flags, o + self._tab.Pos)
-        return 2
+        return None
 
     # FxSwapHelper
     def CalendarDomestic(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(10))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 32
+        return None
 
     # FxSwapHelper
     def CalendarForeign(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(12))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 32
+        return None
 
     # FxSwapHelper
     def Deps(self):
@@ -102,19 +102,19 @@ def AddTenor(builder, tenor):
     FxSwapHelperAddTenor(builder, tenor)
 
 def FxSwapHelperAddSpotDays(builder, spotDays):
-    builder.PrependInt32Slot(2, spotDays, 2)
+    builder.PrependInt32Slot(2, spotDays, None)
 
 def AddSpotDays(builder, spotDays):
     FxSwapHelperAddSpotDays(builder, spotDays)
 
 def FxSwapHelperAddCalendarDomestic(builder, calendarDomestic):
-    builder.PrependInt8Slot(3, calendarDomestic, 32)
+    builder.PrependInt8Slot(3, calendarDomestic, None)
 
 def AddCalendarDomestic(builder, calendarDomestic):
     FxSwapHelperAddCalendarDomestic(builder, calendarDomestic)
 
 def FxSwapHelperAddCalendarForeign(builder, calendarForeign):
-    builder.PrependInt8Slot(4, calendarForeign, 32)
+    builder.PrependInt8Slot(4, calendarForeign, None)
 
 def AddCalendarForeign(builder, calendarForeign):
     FxSwapHelperAddCalendarForeign(builder, calendarForeign)
@@ -148,9 +148,9 @@ class FxSwapHelperT(object):
     def __init__(self):
         self.fxPoints = None  # type: Optional[float]
         self.tenor = None  # type: Optional[PeriodT]
-        self.spotDays = 2  # type: int
-        self.calendarDomestic = 32  # type: int
-        self.calendarForeign = 32  # type: int
+        self.spotDays = None  # type: Optional[int]
+        self.calendarDomestic = None  # type: Optional[int]
+        self.calendarForeign = None  # type: Optional[int]
         self.deps = None  # type: Optional[HelperDependenciesT]
         self.quoteId = None  # type: str
 

--- a/flatbuffers/python/quantra/IndexDef.py
+++ b/flatbuffers/python/quantra/IndexDef.py
@@ -41,13 +41,14 @@ class IndexDef(object):
             return self._tab.String(o + self._tab.Pos)
         return None
 
-    # IBOR or Overnight. Determines QuantLib class used.
+    # IBOR or Overnight. Determines QuantLib class used. Presence-required: an
+    # omitted value is a 400, never the silent Ibor default.
     # IndexDef
     def IndexType(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(8))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # Tenor period (e.g., 6 Months for Euribor 6M, 0 Days for overnight).
     # IndexDef
@@ -61,45 +62,46 @@ class IndexDef(object):
             return obj
         return None
 
-    # Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR).
+    # Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR). Presence-required.
     # IndexDef
     def FixingDays(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(12))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int32Flags, o + self._tab.Pos)
-        return 2
+        return None
 
-    # Calendar for fixing/payment dates.
+    # Calendar for fixing/payment dates. Presence-required.
     # IndexDef
     def Calendar(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(14))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 32
+        return None
 
-    # Business day convention.
+    # Business day convention. Presence-required.
     # IndexDef
     def BusinessDayConvention(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(16))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 2
+        return None
 
-    # Day count convention.
+    # Day count convention. Presence-required.
     # IndexDef
     def DayCounter(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(18))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
-    # End of month rule (IBOR only, ignored for overnight).
+    # End of month rule (IBOR only, ignored for overnight). Presence-required:
+    # absent-vs-false silently changes money-market schedule dates.
     # IndexDef
     def EndOfMonth(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(20))
         if o != 0:
             return bool(self._tab.Get(flatbuffers.number_types.BoolFlags, o + self._tab.Pos))
-        return True
+        return None
 
     # ISO currency code (e.g., "EUR", "USD", "GBP", "JPY").
     # IndexDef
@@ -154,7 +156,7 @@ def AddName(builder, name):
     IndexDefAddName(builder, name)
 
 def IndexDefAddIndexType(builder, indexType):
-    builder.PrependInt8Slot(2, indexType, 0)
+    builder.PrependInt8Slot(2, indexType, None)
 
 def AddIndexType(builder, indexType):
     IndexDefAddIndexType(builder, indexType)
@@ -166,31 +168,31 @@ def AddTenor(builder, tenor):
     IndexDefAddTenor(builder, tenor)
 
 def IndexDefAddFixingDays(builder, fixingDays):
-    builder.PrependInt32Slot(4, fixingDays, 2)
+    builder.PrependInt32Slot(4, fixingDays, None)
 
 def AddFixingDays(builder, fixingDays):
     IndexDefAddFixingDays(builder, fixingDays)
 
 def IndexDefAddCalendar(builder, calendar):
-    builder.PrependInt8Slot(5, calendar, 32)
+    builder.PrependInt8Slot(5, calendar, None)
 
 def AddCalendar(builder, calendar):
     IndexDefAddCalendar(builder, calendar)
 
 def IndexDefAddBusinessDayConvention(builder, businessDayConvention):
-    builder.PrependInt8Slot(6, businessDayConvention, 2)
+    builder.PrependInt8Slot(6, businessDayConvention, None)
 
 def AddBusinessDayConvention(builder, businessDayConvention):
     IndexDefAddBusinessDayConvention(builder, businessDayConvention)
 
 def IndexDefAddDayCounter(builder, dayCounter):
-    builder.PrependInt8Slot(7, dayCounter, 0)
+    builder.PrependInt8Slot(7, dayCounter, None)
 
 def AddDayCounter(builder, dayCounter):
     IndexDefAddDayCounter(builder, dayCounter)
 
 def IndexDefAddEndOfMonth(builder, endOfMonth):
-    builder.PrependBoolSlot(8, endOfMonth, 1)
+    builder.PrependBoolSlot(8, endOfMonth, None)
 
 def AddEndOfMonth(builder, endOfMonth):
     IndexDefAddEndOfMonth(builder, endOfMonth)
@@ -230,13 +232,13 @@ class IndexDefT(object):
     def __init__(self):
         self.id = None  # type: str
         self.name = None  # type: str
-        self.indexType = 0  # type: int
+        self.indexType = None  # type: Optional[int]
         self.tenor = None  # type: Optional[PeriodT]
-        self.fixingDays = 2  # type: int
-        self.calendar = 32  # type: int
-        self.businessDayConvention = 2  # type: int
-        self.dayCounter = 0  # type: int
-        self.endOfMonth = True  # type: bool
+        self.fixingDays = None  # type: Optional[int]
+        self.calendar = None  # type: Optional[int]
+        self.businessDayConvention = None  # type: Optional[int]
+        self.dayCounter = None  # type: Optional[int]
+        self.endOfMonth = None  # type: Optional[bool]
         self.currency = None  # type: str
         self.fixings = None  # type: List[FixingT]
 

--- a/flatbuffers/python/quantra/InflationCurveSpec.py
+++ b/flatbuffers/python/quantra/InflationCurveSpec.py
@@ -44,29 +44,30 @@ class InflationCurveSpec(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(8))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 32
+        return None
 
     # InflationCurveSpec
     def BusinessDayConvention(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(10))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 2
+        return None
 
     # InflationCurveSpec
     def DayCounter(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(12))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 1
+        return None
 
     # InflationCurveSpec
     def Interpolator(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(14))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 2
+        return None
 
+    # Numerical bootstrap tolerance (not a market convention): keeps its default.
     # InflationCurveSpec
     def BootstrapAccuracy(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(16))
@@ -79,7 +80,7 @@ class InflationCurveSpec(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(18))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # Link to InflationIndexSpec.id.
     # InflationCurveSpec
@@ -148,25 +149,25 @@ def AddReferenceDate(builder, referenceDate):
     InflationCurveSpecAddReferenceDate(builder, referenceDate)
 
 def InflationCurveSpecAddCalendar(builder, calendar):
-    builder.PrependInt8Slot(2, calendar, 32)
+    builder.PrependInt8Slot(2, calendar, None)
 
 def AddCalendar(builder, calendar):
     InflationCurveSpecAddCalendar(builder, calendar)
 
 def InflationCurveSpecAddBusinessDayConvention(builder, businessDayConvention):
-    builder.PrependInt8Slot(3, businessDayConvention, 2)
+    builder.PrependInt8Slot(3, businessDayConvention, None)
 
 def AddBusinessDayConvention(builder, businessDayConvention):
     InflationCurveSpecAddBusinessDayConvention(builder, businessDayConvention)
 
 def InflationCurveSpecAddDayCounter(builder, dayCounter):
-    builder.PrependInt8Slot(4, dayCounter, 1)
+    builder.PrependInt8Slot(4, dayCounter, None)
 
 def AddDayCounter(builder, dayCounter):
     InflationCurveSpecAddDayCounter(builder, dayCounter)
 
 def InflationCurveSpecAddInterpolator(builder, interpolator):
-    builder.PrependInt8Slot(5, interpolator, 2)
+    builder.PrependInt8Slot(5, interpolator, None)
 
 def AddInterpolator(builder, interpolator):
     InflationCurveSpecAddInterpolator(builder, interpolator)
@@ -178,7 +179,7 @@ def AddBootstrapAccuracy(builder, bootstrapAccuracy):
     InflationCurveSpecAddBootstrapAccuracy(builder, bootstrapAccuracy)
 
 def InflationCurveSpecAddKind(builder, kind):
-    builder.PrependInt8Slot(7, kind, 0)
+    builder.PrependInt8Slot(7, kind, None)
 
 def AddKind(builder, kind):
     InflationCurveSpecAddKind(builder, kind)
@@ -230,12 +231,12 @@ class InflationCurveSpecT(object):
     def __init__(self):
         self.id = None  # type: str
         self.referenceDate = None  # type: str
-        self.calendar = 32  # type: int
-        self.businessDayConvention = 2  # type: int
-        self.dayCounter = 1  # type: int
-        self.interpolator = 2  # type: int
+        self.calendar = None  # type: Optional[int]
+        self.businessDayConvention = None  # type: Optional[int]
+        self.dayCounter = None  # type: Optional[int]
+        self.interpolator = None  # type: Optional[int]
         self.bootstrapAccuracy = 1.0e-12  # type: float
-        self.kind = 0  # type: int
+        self.kind = None  # type: Optional[int]
         self.indexId = None  # type: str
         self.discountCurveId = None  # type: str
         self.allowExtrapolation = True  # type: bool

--- a/flatbuffers/python/quantra/InflationIndexSpec.py
+++ b/flatbuffers/python/quantra/InflationIndexSpec.py
@@ -54,21 +54,21 @@ class InflationIndexSpec(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(10))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 32
+        return None
 
     # InflationIndexSpec
     def DayCounter(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(12))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 1
+        return None
 
     # InflationIndexSpec
     def Frequency(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(14))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 6
+        return None
 
     # Publication availability lag (e.g., 2 Months).
     # InflationIndexSpec
@@ -93,28 +93,29 @@ class InflationIndexSpec(object):
             return obj
         return None
 
-    # Whether the index is interpolated between fixings.
+    # Whether the index is interpolated between fixings. Presence-required:
+    # absent-vs-false silently changes the observed CPI.
     # InflationIndexSpec
     def Interpolated(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(20))
         if o != 0:
             return bool(self._tab.Get(flatbuffers.number_types.BoolFlags, o + self._tab.Pos))
-        return True
+        return None
 
-    # Whether index values can be revised (rare; defaults to false).
+    # Whether index values can be revised (rare). Presence-required.
     # InflationIndexSpec
     def Revised(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(22))
         if o != 0:
             return bool(self._tab.Get(flatbuffers.number_types.BoolFlags, o + self._tab.Pos))
-        return False
+        return None
 
     # InflationIndexSpec
     def Kind(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(24))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # For ratio-based YoY indices, link to the underlying zero inflation index id.
     # InflationIndexSpec
@@ -175,19 +176,19 @@ def AddCurrency(builder, currency):
     InflationIndexSpecAddCurrency(builder, currency)
 
 def InflationIndexSpecAddCalendar(builder, calendar):
-    builder.PrependInt8Slot(3, calendar, 32)
+    builder.PrependInt8Slot(3, calendar, None)
 
 def AddCalendar(builder, calendar):
     InflationIndexSpecAddCalendar(builder, calendar)
 
 def InflationIndexSpecAddDayCounter(builder, dayCounter):
-    builder.PrependInt8Slot(4, dayCounter, 1)
+    builder.PrependInt8Slot(4, dayCounter, None)
 
 def AddDayCounter(builder, dayCounter):
     InflationIndexSpecAddDayCounter(builder, dayCounter)
 
 def InflationIndexSpecAddFrequency(builder, frequency):
-    builder.PrependInt8Slot(5, frequency, 6)
+    builder.PrependInt8Slot(5, frequency, None)
 
 def AddFrequency(builder, frequency):
     InflationIndexSpecAddFrequency(builder, frequency)
@@ -205,19 +206,19 @@ def AddObservationLag(builder, observationLag):
     InflationIndexSpecAddObservationLag(builder, observationLag)
 
 def InflationIndexSpecAddInterpolated(builder, interpolated):
-    builder.PrependBoolSlot(8, interpolated, 1)
+    builder.PrependBoolSlot(8, interpolated, None)
 
 def AddInterpolated(builder, interpolated):
     InflationIndexSpecAddInterpolated(builder, interpolated)
 
 def InflationIndexSpecAddRevised(builder, revised):
-    builder.PrependBoolSlot(9, revised, 0)
+    builder.PrependBoolSlot(9, revised, None)
 
 def AddRevised(builder, revised):
     InflationIndexSpecAddRevised(builder, revised)
 
 def InflationIndexSpecAddKind(builder, kind):
-    builder.PrependInt8Slot(10, kind, 0)
+    builder.PrependInt8Slot(10, kind, None)
 
 def AddKind(builder, kind):
     InflationIndexSpecAddKind(builder, kind)
@@ -258,14 +259,14 @@ class InflationIndexSpecT(object):
         self.id = None  # type: str
         self.familyName = None  # type: str
         self.currency = None  # type: str
-        self.calendar = 32  # type: int
-        self.dayCounter = 1  # type: int
-        self.frequency = 6  # type: int
+        self.calendar = None  # type: Optional[int]
+        self.dayCounter = None  # type: Optional[int]
+        self.frequency = None  # type: Optional[int]
         self.availabilityLag = None  # type: Optional[PeriodT]
         self.observationLag = None  # type: Optional[PeriodT]
-        self.interpolated = True  # type: bool
-        self.revised = False  # type: bool
-        self.kind = 0  # type: int
+        self.interpolated = None  # type: Optional[bool]
+        self.revised = None  # type: Optional[bool]
+        self.kind = None  # type: Optional[int]
         self.underlyingZeroIndexId = None  # type: str
         self.fixings = None  # type: List[FixingT]
 

--- a/flatbuffers/python/quantra/OISHelper.py
+++ b/flatbuffers/python/quantra/OISHelper.py
@@ -61,35 +61,35 @@ class OISHelper(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(10))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int32Flags, o + self._tab.Pos)
-        return 2
+        return None
 
     # OISHelper
     def Calendar(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(12))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 32
+        return None
 
     # OISHelper
     def FixedLegFrequency(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(14))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # OISHelper
     def FixedLegConvention(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(16))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 2
+        return None
 
     # OISHelper
     def FixedLegDayCounter(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(18))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # Exogenous discount curve for dual-curve OIS bootstrapping.
     # OISHelper
@@ -135,31 +135,31 @@ def AddOvernightIndex(builder, overnightIndex):
     OISHelperAddOvernightIndex(builder, overnightIndex)
 
 def OISHelperAddSettlementDays(builder, settlementDays):
-    builder.PrependInt32Slot(3, settlementDays, 2)
+    builder.PrependInt32Slot(3, settlementDays, None)
 
 def AddSettlementDays(builder, settlementDays):
     OISHelperAddSettlementDays(builder, settlementDays)
 
 def OISHelperAddCalendar(builder, calendar):
-    builder.PrependInt8Slot(4, calendar, 32)
+    builder.PrependInt8Slot(4, calendar, None)
 
 def AddCalendar(builder, calendar):
     OISHelperAddCalendar(builder, calendar)
 
 def OISHelperAddFixedLegFrequency(builder, fixedLegFrequency):
-    builder.PrependInt8Slot(5, fixedLegFrequency, 0)
+    builder.PrependInt8Slot(5, fixedLegFrequency, None)
 
 def AddFixedLegFrequency(builder, fixedLegFrequency):
     OISHelperAddFixedLegFrequency(builder, fixedLegFrequency)
 
 def OISHelperAddFixedLegConvention(builder, fixedLegConvention):
-    builder.PrependInt8Slot(6, fixedLegConvention, 2)
+    builder.PrependInt8Slot(6, fixedLegConvention, None)
 
 def AddFixedLegConvention(builder, fixedLegConvention):
     OISHelperAddFixedLegConvention(builder, fixedLegConvention)
 
 def OISHelperAddFixedLegDayCounter(builder, fixedLegDayCounter):
-    builder.PrependInt8Slot(7, fixedLegDayCounter, 0)
+    builder.PrependInt8Slot(7, fixedLegDayCounter, None)
 
 def AddFixedLegDayCounter(builder, fixedLegDayCounter):
     OISHelperAddFixedLegDayCounter(builder, fixedLegDayCounter)
@@ -194,11 +194,11 @@ class OISHelperT(object):
         self.rate = None  # type: Optional[float]
         self.tenor = None  # type: Optional[PeriodT]
         self.overnightIndex = None  # type: Optional[IndexRefT]
-        self.settlementDays = 2  # type: int
-        self.calendar = 32  # type: int
-        self.fixedLegFrequency = 0  # type: int
-        self.fixedLegConvention = 2  # type: int
-        self.fixedLegDayCounter = 0  # type: int
+        self.settlementDays = None  # type: Optional[int]
+        self.calendar = None  # type: Optional[int]
+        self.fixedLegFrequency = None  # type: Optional[int]
+        self.fixedLegConvention = None  # type: Optional[int]
+        self.fixedLegDayCounter = None  # type: Optional[int]
         self.deps = None  # type: Optional[HelperDependenciesT]
         self.quoteId = None  # type: str
 

--- a/flatbuffers/python/quantra/Period.py
+++ b/flatbuffers/python/quantra/Period.py
@@ -6,7 +6,10 @@ import flatbuffers
 from flatbuffers.compat import import_numpy
 np = import_numpy()
 
-# Canonical period type used across APIs.
+# Canonical period type used across APIs. Both fields are presence-required:
+# a bare `n` would silently default to 0 and an omitted `unit` would silently
+# mean Months, so a forgotten value is a 400 naming the field rather than a
+# silent (0 Months) tenor.
 class Period(object):
     __slots__ = ['_tab']
 
@@ -30,14 +33,14 @@ class Period(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int32Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # Period
     def Unit(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 5
+        return None
 
 def PeriodStart(builder):
     builder.StartObject(2)
@@ -46,13 +49,13 @@ def Start(builder):
     PeriodStart(builder)
 
 def PeriodAddN(builder, n):
-    builder.PrependInt32Slot(0, n, 0)
+    builder.PrependInt32Slot(0, n, None)
 
 def AddN(builder, n):
     PeriodAddN(builder, n)
 
 def PeriodAddUnit(builder, unit):
-    builder.PrependInt8Slot(1, unit, 5)
+    builder.PrependInt8Slot(1, unit, None)
 
 def AddUnit(builder, unit):
     PeriodAddUnit(builder, unit)
@@ -68,8 +71,8 @@ class PeriodT(object):
 
     # PeriodT
     def __init__(self):
-        self.n = 0  # type: int
-        self.unit = 5  # type: int
+        self.n = None  # type: Optional[int]
+        self.unit = None  # type: Optional[int]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):

--- a/flatbuffers/python/quantra/Schedule.py
+++ b/flatbuffers/python/quantra/Schedule.py
@@ -74,12 +74,14 @@ class Schedule(object):
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
         return None
 
+    # Presence-required: absent-vs-false silently changes schedule dates for
+    # month-end-anchored (money-market) schedules.
     # Schedule
     def EndOfMonth(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(18))
         if o != 0:
             return bool(self._tab.Get(flatbuffers.number_types.BoolFlags, o + self._tab.Pos))
-        return False
+        return None
 
     # Optional. ISO-8601 (YYYY-MM-DD). When present, passed as QuantLib's
     # firstDate, which controls the FIRST stub coupon: with Backward date
@@ -155,7 +157,7 @@ def AddDateGenerationRule(builder, dateGenerationRule):
     ScheduleAddDateGenerationRule(builder, dateGenerationRule)
 
 def ScheduleAddEndOfMonth(builder, endOfMonth):
-    builder.PrependBoolSlot(7, endOfMonth, 0)
+    builder.PrependBoolSlot(7, endOfMonth, None)
 
 def AddEndOfMonth(builder, endOfMonth):
     ScheduleAddEndOfMonth(builder, endOfMonth)
@@ -190,7 +192,7 @@ class ScheduleT(object):
         self.convention = None  # type: Optional[int]
         self.terminationDateConvention = None  # type: Optional[int]
         self.dateGenerationRule = None  # type: Optional[int]
-        self.endOfMonth = False  # type: bool
+        self.endOfMonth = None  # type: Optional[bool]
         self.firstDate = None  # type: str
         self.nextToLastDate = None  # type: str
 

--- a/flatbuffers/python/quantra/SwapIndexDef.py
+++ b/flatbuffers/python/quantra/SwapIndexDef.py
@@ -37,7 +37,7 @@ class SwapIndexDef(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # Spot/effective-date lag used for exercise-to-swap-start advancement.
     # SwapIndexDef
@@ -45,7 +45,7 @@ class SwapIndexDef(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(8))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int32Flags, o + self._tab.Pos)
-        return 2
+        return None
 
     # Metadata only; pricing uses fixed_leg/float_leg conventions.
     # SwapIndexDef
@@ -53,7 +53,7 @@ class SwapIndexDef(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(10))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 32
+        return None
 
     # Metadata only; pricing uses fixed_leg/float_leg conventions.
     # SwapIndexDef
@@ -61,7 +61,7 @@ class SwapIndexDef(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(12))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 2
+        return None
 
     # Metadata only; pricing uses fixed_leg/float_leg conventions.
     # SwapIndexDef
@@ -69,7 +69,7 @@ class SwapIndexDef(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(14))
         if o != 0:
             return bool(self._tab.Get(flatbuffers.number_types.BoolFlags, o + self._tab.Pos))
-        return False
+        return None
 
     # SwapIndexDef
     def FixedLeg(self):
@@ -114,31 +114,31 @@ def AddId(builder, id):
     SwapIndexDefAddId(builder, id)
 
 def SwapIndexDefAddKind(builder, kind):
-    builder.PrependInt8Slot(1, kind, 0)
+    builder.PrependInt8Slot(1, kind, None)
 
 def AddKind(builder, kind):
     SwapIndexDefAddKind(builder, kind)
 
 def SwapIndexDefAddSpotDays(builder, spotDays):
-    builder.PrependInt32Slot(2, spotDays, 2)
+    builder.PrependInt32Slot(2, spotDays, None)
 
 def AddSpotDays(builder, spotDays):
     SwapIndexDefAddSpotDays(builder, spotDays)
 
 def SwapIndexDefAddCalendar(builder, calendar):
-    builder.PrependInt8Slot(3, calendar, 32)
+    builder.PrependInt8Slot(3, calendar, None)
 
 def AddCalendar(builder, calendar):
     SwapIndexDefAddCalendar(builder, calendar)
 
 def SwapIndexDefAddBusinessDayConvention(builder, businessDayConvention):
-    builder.PrependInt8Slot(4, businessDayConvention, 2)
+    builder.PrependInt8Slot(4, businessDayConvention, None)
 
 def AddBusinessDayConvention(builder, businessDayConvention):
     SwapIndexDefAddBusinessDayConvention(builder, businessDayConvention)
 
 def SwapIndexDefAddEndOfMonth(builder, endOfMonth):
-    builder.PrependBoolSlot(5, endOfMonth, 0)
+    builder.PrependBoolSlot(5, endOfMonth, None)
 
 def AddEndOfMonth(builder, endOfMonth):
     SwapIndexDefAddEndOfMonth(builder, endOfMonth)
@@ -177,11 +177,11 @@ class SwapIndexDefT(object):
     # SwapIndexDefT
     def __init__(self):
         self.id = None  # type: str
-        self.kind = 0  # type: int
-        self.spotDays = 2  # type: int
-        self.calendar = 32  # type: int
-        self.businessDayConvention = 2  # type: int
-        self.endOfMonth = False  # type: bool
+        self.kind = None  # type: Optional[int]
+        self.spotDays = None  # type: Optional[int]
+        self.calendar = None  # type: Optional[int]
+        self.businessDayConvention = None  # type: Optional[int]
+        self.endOfMonth = None  # type: Optional[bool]
         self.fixedLeg = None  # type: Optional[SwapIndexFixedLegSpecT]
         self.floatIndexId = None  # type: str
         self.floatLeg = None  # type: Optional[SwapIndexFloatLegSpecT]

--- a/flatbuffers/python/quantra/SwapIndexFixedLegSpec.py
+++ b/flatbuffers/python/quantra/SwapIndexFixedLegSpec.py
@@ -6,7 +6,7 @@ import flatbuffers
 from flatbuffers.compat import import_numpy
 np = import_numpy()
 
-# Fixed leg conventions for swap index.
+# Fixed leg conventions for swap index. Every convention is presence-required.
 class SwapIndexFixedLegSpec(object):
     __slots__ = ['_tab']
 
@@ -30,49 +30,49 @@ class SwapIndexFixedLegSpec(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # SwapIndexFixedLegSpec
     def FixedDayCounter(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 14
+        return None
 
     # SwapIndexFixedLegSpec
     def FixedCalendar(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(8))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 32
+        return None
 
     # SwapIndexFixedLegSpec
     def FixedBdc(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(10))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 2
+        return None
 
     # SwapIndexFixedLegSpec
     def FixedTermBdc(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(12))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 2
+        return None
 
     # SwapIndexFixedLegSpec
     def FixedDateRule(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(14))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 2
+        return None
 
     # SwapIndexFixedLegSpec
     def FixedEom(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(16))
         if o != 0:
             return bool(self._tab.Get(flatbuffers.number_types.BoolFlags, o + self._tab.Pos))
-        return False
+        return None
 
 def SwapIndexFixedLegSpecStart(builder):
     builder.StartObject(7)
@@ -81,43 +81,43 @@ def Start(builder):
     SwapIndexFixedLegSpecStart(builder)
 
 def SwapIndexFixedLegSpecAddFixedFrequency(builder, fixedFrequency):
-    builder.PrependInt8Slot(0, fixedFrequency, 0)
+    builder.PrependInt8Slot(0, fixedFrequency, None)
 
 def AddFixedFrequency(builder, fixedFrequency):
     SwapIndexFixedLegSpecAddFixedFrequency(builder, fixedFrequency)
 
 def SwapIndexFixedLegSpecAddFixedDayCounter(builder, fixedDayCounter):
-    builder.PrependInt8Slot(1, fixedDayCounter, 14)
+    builder.PrependInt8Slot(1, fixedDayCounter, None)
 
 def AddFixedDayCounter(builder, fixedDayCounter):
     SwapIndexFixedLegSpecAddFixedDayCounter(builder, fixedDayCounter)
 
 def SwapIndexFixedLegSpecAddFixedCalendar(builder, fixedCalendar):
-    builder.PrependInt8Slot(2, fixedCalendar, 32)
+    builder.PrependInt8Slot(2, fixedCalendar, None)
 
 def AddFixedCalendar(builder, fixedCalendar):
     SwapIndexFixedLegSpecAddFixedCalendar(builder, fixedCalendar)
 
 def SwapIndexFixedLegSpecAddFixedBdc(builder, fixedBdc):
-    builder.PrependInt8Slot(3, fixedBdc, 2)
+    builder.PrependInt8Slot(3, fixedBdc, None)
 
 def AddFixedBdc(builder, fixedBdc):
     SwapIndexFixedLegSpecAddFixedBdc(builder, fixedBdc)
 
 def SwapIndexFixedLegSpecAddFixedTermBdc(builder, fixedTermBdc):
-    builder.PrependInt8Slot(4, fixedTermBdc, 2)
+    builder.PrependInt8Slot(4, fixedTermBdc, None)
 
 def AddFixedTermBdc(builder, fixedTermBdc):
     SwapIndexFixedLegSpecAddFixedTermBdc(builder, fixedTermBdc)
 
 def SwapIndexFixedLegSpecAddFixedDateRule(builder, fixedDateRule):
-    builder.PrependInt8Slot(5, fixedDateRule, 2)
+    builder.PrependInt8Slot(5, fixedDateRule, None)
 
 def AddFixedDateRule(builder, fixedDateRule):
     SwapIndexFixedLegSpecAddFixedDateRule(builder, fixedDateRule)
 
 def SwapIndexFixedLegSpecAddFixedEom(builder, fixedEom):
-    builder.PrependBoolSlot(6, fixedEom, 0)
+    builder.PrependBoolSlot(6, fixedEom, None)
 
 def AddFixedEom(builder, fixedEom):
     SwapIndexFixedLegSpecAddFixedEom(builder, fixedEom)
@@ -133,13 +133,13 @@ class SwapIndexFixedLegSpecT(object):
 
     # SwapIndexFixedLegSpecT
     def __init__(self):
-        self.fixedFrequency = 0  # type: int
-        self.fixedDayCounter = 14  # type: int
-        self.fixedCalendar = 32  # type: int
-        self.fixedBdc = 2  # type: int
-        self.fixedTermBdc = 2  # type: int
-        self.fixedDateRule = 2  # type: int
-        self.fixedEom = False  # type: bool
+        self.fixedFrequency = None  # type: Optional[int]
+        self.fixedDayCounter = None  # type: Optional[int]
+        self.fixedCalendar = None  # type: Optional[int]
+        self.fixedBdc = None  # type: Optional[int]
+        self.fixedTermBdc = None  # type: Optional[int]
+        self.fixedDateRule = None  # type: Optional[int]
+        self.fixedEom = None  # type: Optional[bool]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):

--- a/flatbuffers/python/quantra/SwapIndexFloatLegSpec.py
+++ b/flatbuffers/python/quantra/SwapIndexFloatLegSpec.py
@@ -6,7 +6,8 @@ import flatbuffers
 from flatbuffers.compat import import_numpy
 np = import_numpy()
 
-# Floating leg conventions for swap index.
+# Floating leg conventions for swap index. Every convention is
+# presence-required.
 class SwapIndexFloatLegSpec(object):
     __slots__ = ['_tab']
 
@@ -41,35 +42,35 @@ class SwapIndexFloatLegSpec(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 32
+        return None
 
     # SwapIndexFloatLegSpec
     def FloatBdc(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(8))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 2
+        return None
 
     # SwapIndexFloatLegSpec
     def FloatTermBdc(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(10))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 2
+        return None
 
     # SwapIndexFloatLegSpec
     def FloatDateRule(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(12))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 2
+        return None
 
     # SwapIndexFloatLegSpec
     def FloatEom(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(14))
         if o != 0:
             return bool(self._tab.Get(flatbuffers.number_types.BoolFlags, o + self._tab.Pos))
-        return False
+        return None
 
 def SwapIndexFloatLegSpecStart(builder):
     builder.StartObject(6)
@@ -84,31 +85,31 @@ def AddFloatTenor(builder, floatTenor):
     SwapIndexFloatLegSpecAddFloatTenor(builder, floatTenor)
 
 def SwapIndexFloatLegSpecAddFloatCalendar(builder, floatCalendar):
-    builder.PrependInt8Slot(1, floatCalendar, 32)
+    builder.PrependInt8Slot(1, floatCalendar, None)
 
 def AddFloatCalendar(builder, floatCalendar):
     SwapIndexFloatLegSpecAddFloatCalendar(builder, floatCalendar)
 
 def SwapIndexFloatLegSpecAddFloatBdc(builder, floatBdc):
-    builder.PrependInt8Slot(2, floatBdc, 2)
+    builder.PrependInt8Slot(2, floatBdc, None)
 
 def AddFloatBdc(builder, floatBdc):
     SwapIndexFloatLegSpecAddFloatBdc(builder, floatBdc)
 
 def SwapIndexFloatLegSpecAddFloatTermBdc(builder, floatTermBdc):
-    builder.PrependInt8Slot(3, floatTermBdc, 2)
+    builder.PrependInt8Slot(3, floatTermBdc, None)
 
 def AddFloatTermBdc(builder, floatTermBdc):
     SwapIndexFloatLegSpecAddFloatTermBdc(builder, floatTermBdc)
 
 def SwapIndexFloatLegSpecAddFloatDateRule(builder, floatDateRule):
-    builder.PrependInt8Slot(4, floatDateRule, 2)
+    builder.PrependInt8Slot(4, floatDateRule, None)
 
 def AddFloatDateRule(builder, floatDateRule):
     SwapIndexFloatLegSpecAddFloatDateRule(builder, floatDateRule)
 
 def SwapIndexFloatLegSpecAddFloatEom(builder, floatEom):
-    builder.PrependBoolSlot(5, floatEom, 0)
+    builder.PrependBoolSlot(5, floatEom, None)
 
 def AddFloatEom(builder, floatEom):
     SwapIndexFloatLegSpecAddFloatEom(builder, floatEom)
@@ -129,11 +130,11 @@ class SwapIndexFloatLegSpecT(object):
     # SwapIndexFloatLegSpecT
     def __init__(self):
         self.floatTenor = None  # type: Optional[PeriodT]
-        self.floatCalendar = 32  # type: int
-        self.floatBdc = 2  # type: int
-        self.floatTermBdc = 2  # type: int
-        self.floatDateRule = 2  # type: int
-        self.floatEom = False  # type: bool
+        self.floatCalendar = None  # type: Optional[int]
+        self.floatBdc = None  # type: Optional[int]
+        self.floatTermBdc = None  # type: Optional[int]
+        self.floatDateRule = None  # type: Optional[int]
+        self.floatEom = None  # type: Optional[bool]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):

--- a/flatbuffers/python/quantra/YearOnYearInflationSwapHelper.py
+++ b/flatbuffers/python/quantra/YearOnYearInflationSwapHelper.py
@@ -83,28 +83,28 @@ class YearOnYearInflationSwapHelper(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(16))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 32
+        return None
 
     # YearOnYearInflationSwapHelper
     def PaymentConvention(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(18))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 2
+        return None
 
     # YearOnYearInflationSwapHelper
     def DayCounter(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(20))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 1
+        return None
 
     # YearOnYearInflationSwapHelper
     def ObservationInterpolation(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(22))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
     # QuantLib YoY helper requires a nominal term structure id.
     # YearOnYearInflationSwapHelper
@@ -157,25 +157,25 @@ def AddEndDate(builder, endDate):
     YearOnYearInflationSwapHelperAddEndDate(builder, endDate)
 
 def YearOnYearInflationSwapHelperAddCalendar(builder, calendar):
-    builder.PrependInt8Slot(6, calendar, 32)
+    builder.PrependInt8Slot(6, calendar, None)
 
 def AddCalendar(builder, calendar):
     YearOnYearInflationSwapHelperAddCalendar(builder, calendar)
 
 def YearOnYearInflationSwapHelperAddPaymentConvention(builder, paymentConvention):
-    builder.PrependInt8Slot(7, paymentConvention, 2)
+    builder.PrependInt8Slot(7, paymentConvention, None)
 
 def AddPaymentConvention(builder, paymentConvention):
     YearOnYearInflationSwapHelperAddPaymentConvention(builder, paymentConvention)
 
 def YearOnYearInflationSwapHelperAddDayCounter(builder, dayCounter):
-    builder.PrependInt8Slot(8, dayCounter, 1)
+    builder.PrependInt8Slot(8, dayCounter, None)
 
 def AddDayCounter(builder, dayCounter):
     YearOnYearInflationSwapHelperAddDayCounter(builder, dayCounter)
 
 def YearOnYearInflationSwapHelperAddObservationInterpolation(builder, observationInterpolation):
-    builder.PrependInt8Slot(9, observationInterpolation, 0)
+    builder.PrependInt8Slot(9, observationInterpolation, None)
 
 def AddObservationInterpolation(builder, observationInterpolation):
     YearOnYearInflationSwapHelperAddObservationInterpolation(builder, observationInterpolation)
@@ -207,10 +207,10 @@ class YearOnYearInflationSwapHelperT(object):
         self.tenor = None  # type: Optional[PeriodT]
         self.startDate = None  # type: str
         self.endDate = None  # type: str
-        self.calendar = 32  # type: int
-        self.paymentConvention = 2  # type: int
-        self.dayCounter = 1  # type: int
-        self.observationInterpolation = 0  # type: int
+        self.calendar = None  # type: Optional[int]
+        self.paymentConvention = None  # type: Optional[int]
+        self.dayCounter = None  # type: Optional[int]
+        self.observationInterpolation = None  # type: Optional[int]
         self.nominalCurveId = None  # type: str
 
     @classmethod

--- a/flatbuffers/python/quantra/ZeroCouponInflationSwapHelper.py
+++ b/flatbuffers/python/quantra/ZeroCouponInflationSwapHelper.py
@@ -87,28 +87,28 @@ class ZeroCouponInflationSwapHelper(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(16))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 32
+        return None
 
     # ZeroCouponInflationSwapHelper
     def PaymentConvention(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(18))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 2
+        return None
 
     # ZeroCouponInflationSwapHelper
     def DayCounter(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(20))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 1
+        return None
 
     # ZeroCouponInflationSwapHelper
     def ObservationInterpolation(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(22))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
 def ZeroCouponInflationSwapHelperStart(builder):
     builder.StartObject(10)
@@ -153,25 +153,25 @@ def AddEndDate(builder, endDate):
     ZeroCouponInflationSwapHelperAddEndDate(builder, endDate)
 
 def ZeroCouponInflationSwapHelperAddCalendar(builder, calendar):
-    builder.PrependInt8Slot(6, calendar, 32)
+    builder.PrependInt8Slot(6, calendar, None)
 
 def AddCalendar(builder, calendar):
     ZeroCouponInflationSwapHelperAddCalendar(builder, calendar)
 
 def ZeroCouponInflationSwapHelperAddPaymentConvention(builder, paymentConvention):
-    builder.PrependInt8Slot(7, paymentConvention, 2)
+    builder.PrependInt8Slot(7, paymentConvention, None)
 
 def AddPaymentConvention(builder, paymentConvention):
     ZeroCouponInflationSwapHelperAddPaymentConvention(builder, paymentConvention)
 
 def ZeroCouponInflationSwapHelperAddDayCounter(builder, dayCounter):
-    builder.PrependInt8Slot(8, dayCounter, 1)
+    builder.PrependInt8Slot(8, dayCounter, None)
 
 def AddDayCounter(builder, dayCounter):
     ZeroCouponInflationSwapHelperAddDayCounter(builder, dayCounter)
 
 def ZeroCouponInflationSwapHelperAddObservationInterpolation(builder, observationInterpolation):
-    builder.PrependInt8Slot(9, observationInterpolation, 0)
+    builder.PrependInt8Slot(9, observationInterpolation, None)
 
 def AddObservationInterpolation(builder, observationInterpolation):
     ZeroCouponInflationSwapHelperAddObservationInterpolation(builder, observationInterpolation)
@@ -197,10 +197,10 @@ class ZeroCouponInflationSwapHelperT(object):
         self.tenor = None  # type: Optional[PeriodT]
         self.startDate = None  # type: str
         self.endDate = None  # type: str
-        self.calendar = 32  # type: int
-        self.paymentConvention = 2  # type: int
-        self.dayCounter = 1  # type: int
-        self.observationInterpolation = 0  # type: int
+        self.calendar = None  # type: Optional[int]
+        self.paymentConvention = None  # type: Optional[int]
+        self.dayCounter = None  # type: Optional[int]
+        self.observationInterpolation = None  # type: Optional[int]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):

--- a/flatbuffers/python/quantra/ZeroRatePoint.py
+++ b/flatbuffers/python/quantra/ZeroRatePoint.py
@@ -50,14 +50,14 @@ class ZeroRatePoint(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(8))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 32
+        return None
 
     # ZeroRatePoint
     def BusinessDayConvention(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(10))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 2
+        return None
 
     # Zero rate for this maturity. Required.
     # ZeroRatePoint
@@ -73,7 +73,7 @@ class ZeroRatePoint(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(14))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 1
+        return None
 
     # Frequency (used when compounding != Continuous).
     # ZeroRatePoint
@@ -81,7 +81,7 @@ class ZeroRatePoint(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(16))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
-        return 0
+        return None
 
 def ZeroRatePointStart(builder):
     builder.StartObject(7)
@@ -102,13 +102,13 @@ def AddTenor(builder, tenor):
     ZeroRatePointAddTenor(builder, tenor)
 
 def ZeroRatePointAddCalendar(builder, calendar):
-    builder.PrependInt8Slot(2, calendar, 32)
+    builder.PrependInt8Slot(2, calendar, None)
 
 def AddCalendar(builder, calendar):
     ZeroRatePointAddCalendar(builder, calendar)
 
 def ZeroRatePointAddBusinessDayConvention(builder, businessDayConvention):
-    builder.PrependInt8Slot(3, businessDayConvention, 2)
+    builder.PrependInt8Slot(3, businessDayConvention, None)
 
 def AddBusinessDayConvention(builder, businessDayConvention):
     ZeroRatePointAddBusinessDayConvention(builder, businessDayConvention)
@@ -120,13 +120,13 @@ def AddZeroRate(builder, zeroRate):
     ZeroRatePointAddZeroRate(builder, zeroRate)
 
 def ZeroRatePointAddCompounding(builder, compounding):
-    builder.PrependInt8Slot(5, compounding, 1)
+    builder.PrependInt8Slot(5, compounding, None)
 
 def AddCompounding(builder, compounding):
     ZeroRatePointAddCompounding(builder, compounding)
 
 def ZeroRatePointAddFrequency(builder, frequency):
-    builder.PrependInt8Slot(6, frequency, 0)
+    builder.PrependInt8Slot(6, frequency, None)
 
 def AddFrequency(builder, frequency):
     ZeroRatePointAddFrequency(builder, frequency)
@@ -148,11 +148,11 @@ class ZeroRatePointT(object):
     def __init__(self):
         self.date = None  # type: str
         self.tenor = None  # type: Optional[PeriodT]
-        self.calendar = 32  # type: int
-        self.businessDayConvention = 2  # type: int
+        self.calendar = None  # type: Optional[int]
+        self.businessDayConvention = None  # type: Optional[int]
         self.zeroRate = None  # type: Optional[float]
-        self.compounding = 1  # type: int
-        self.frequency = 0  # type: int
+        self.compounding = None  # type: Optional[int]
+        self.frequency = None  # type: Optional[int]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):

--- a/jsonserver/openapi/openapi3.json
+++ b/jsonserver/openapi/openapi3.json
@@ -2096,7 +2096,8 @@
             "$ref": "#/components/schemas/quantra_enums_DateGenerationRule"
           },
           "end_of_month": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Presence-required: absent-vs-false silently changes schedule dates for\nmonth-end-anchored (money-market) schedules."
           },
           "first_date": {
             "type": "string",
@@ -2111,7 +2112,7 @@
       },
       "quantra_Period": {
         "type": "object",
-        "description": "Canonical period type used across APIs.",
+        "description": "Canonical period type used across APIs. Both fields are presence-required:\na bare `n` would silently default to 0 and an omitted `unit` would silently\nmean Months, so a forgotten value is a 400 naming the field rather than a\nsilent (0 Months) tenor.",
         "properties": {
           "n": {
             "type": "integer",
@@ -2278,7 +2279,7 @@
           },
           "fixing_days": {
             "type": "integer",
-            "description": "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR).",
+            "description": "Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR). Presence-required.",
             "minimum": -2147483648,
             "maximum": 2147483647
           },
@@ -2293,7 +2294,7 @@
           },
           "end_of_month": {
             "type": "boolean",
-            "description": "End of month rule (IBOR only, ignored for overnight)."
+            "description": "End of month rule (IBOR only, ignored for overnight). Presence-required:\nabsent-vs-false silently changes money-market schedule dates."
           },
           "currency": {
             "type": "string",
@@ -4203,7 +4204,7 @@
       },
       "quantra_SwapIndexFixedLegSpec": {
         "type": "object",
-        "description": "Fixed leg conventions for swap index.",
+        "description": "Fixed leg conventions for swap index. Every convention is presence-required.",
         "properties": {
           "fixed_frequency": {
             "$ref": "#/components/schemas/quantra_enums_Frequency"
@@ -4231,7 +4232,7 @@
       },
       "quantra_SwapIndexFloatLegSpec": {
         "type": "object",
-        "description": "Floating leg conventions for swap index.",
+        "description": "Floating leg conventions for swap index. Every convention is\npresence-required.",
         "properties": {
           "float_tenor": {
             "$ref": "#/components/schemas/quantra_Period"
@@ -4328,7 +4329,7 @@
       },
       "quantra_CdsHelperConventions": {
         "type": "object",
-        "description": "CDS helper conventions for curve building.",
+        "description": "CDS helper conventions for curve building. Every convention is\npresence-required: an omitted value is a 400 naming the field, never a\nsilent market-default assumption.",
         "properties": {
           "settlement_days": {
             "type": "integer",
@@ -4646,11 +4647,11 @@
           },
           "interpolated": {
             "type": "boolean",
-            "description": "Whether the index is interpolated between fixings."
+            "description": "Whether the index is interpolated between fixings. Presence-required:\nabsent-vs-false silently changes the observed CPI."
           },
           "revised": {
             "type": "boolean",
-            "description": "Whether index values can be revised (rare; defaults to false)."
+            "description": "Whether index values can be revised (rare). Presence-required."
           },
           "kind": {
             "$ref": "#/components/schemas/quantra_enums_InflationCurveKind"
@@ -4806,7 +4807,8 @@
             "$ref": "#/components/schemas/quantra_enums_Interpolator"
           },
           "bootstrap_accuracy": {
-            "type": "number"
+            "type": "number",
+            "description": "Numerical bootstrap tolerance (not a market convention): keeps its default."
           },
           "kind": {
             "$ref": "#/components/schemas/quantra_enums_InflationCurveKind"
@@ -6061,7 +6063,8 @@
             "$ref": "#/components/schemas/quantra_enums_BusinessDayConvention"
           },
           "settles_accrual": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "ISDA settlement conventions. Presence-required: each is a deliberate\nchoice (false round-trips) so an omission is a 400, never a silent true."
           },
           "pays_at_default_time": {
             "type": "boolean"

--- a/jsonserver/openapi/openapi3.yaml
+++ b/jsonserver/openapi/openapi3.yaml
@@ -1440,6 +1440,10 @@ components:
           $ref: '#/components/schemas/quantra_enums_DateGenerationRule'
         end_of_month:
           type: boolean
+          description: 'Presence-required: absent-vs-false silently changes schedule
+            dates for
+
+            month-end-anchored (money-market) schedules.'
         first_date:
           type: string
           description: 'Optional. ISO-8601 (YYYY-MM-DD). When present, passed as QuantLib''s
@@ -1467,7 +1471,13 @@ components:
       additionalProperties: false
     quantra_Period:
       type: object
-      description: Canonical period type used across APIs.
+      description: 'Canonical period type used across APIs. Both fields are presence-required:
+
+        a bare `n` would silently default to 0 and an omitted `unit` would silently
+
+        mean Months, so a forgotten value is a 400 naming the field rather than a
+
+        silent (0 Months) tenor.'
       properties:
         n:
           type: integer
@@ -1581,7 +1591,7 @@ components:
           $ref: '#/components/schemas/quantra_Period'
         fixing_days:
           type: integer
-          description: Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR).
+          description: Fixing days (e.g., 2 for Euribor, 0 for SOFR/ESTR). Presence-required.
           minimum: -2147483648
           maximum: 2147483647
         calendar:
@@ -1592,7 +1602,9 @@ components:
           $ref: '#/components/schemas/quantra_enums_DayCounter'
         end_of_month:
           type: boolean
-          description: End of month rule (IBOR only, ignored for overnight).
+          description: 'End of month rule (IBOR only, ignored for overnight). Presence-required:
+
+            absent-vs-false silently changes money-market schedule dates.'
         currency:
           type: string
           description: ISO currency code (e.g., "EUR", "USD", "GBP", "JPY").
@@ -3077,7 +3089,7 @@ components:
       additionalProperties: false
     quantra_SwapIndexFixedLegSpec:
       type: object
-      description: Fixed leg conventions for swap index.
+      description: Fixed leg conventions for swap index. Every convention is presence-required.
       properties:
         fixed_frequency:
           $ref: '#/components/schemas/quantra_enums_Frequency'
@@ -3096,7 +3108,9 @@ components:
       additionalProperties: false
     quantra_SwapIndexFloatLegSpec:
       type: object
-      description: Floating leg conventions for swap index.
+      description: 'Floating leg conventions for swap index. Every convention is
+
+        presence-required.'
       properties:
         float_tenor:
           $ref: '#/components/schemas/quantra_Period'
@@ -3169,7 +3183,11 @@ components:
       additionalProperties: false
     quantra_CdsHelperConventions:
       type: object
-      description: CDS helper conventions for curve building.
+      description: 'CDS helper conventions for curve building. Every convention is
+
+        presence-required: an omitted value is a 400 naming the field, never a
+
+        silent market-default assumption.'
       properties:
         settlement_days:
           type: integer
@@ -3391,10 +3409,12 @@ components:
           $ref: '#/components/schemas/quantra_Period'
         interpolated:
           type: boolean
-          description: Whether the index is interpolated between fixings.
+          description: 'Whether the index is interpolated between fixings. Presence-required:
+
+            absent-vs-false silently changes the observed CPI.'
         revised:
           type: boolean
-          description: Whether index values can be revised (rare; defaults to false).
+          description: Whether index values can be revised (rare). Presence-required.
         kind:
           $ref: '#/components/schemas/quantra_enums_InflationCurveKind'
         underlying_zero_index_id:
@@ -3515,6 +3535,8 @@ components:
           $ref: '#/components/schemas/quantra_enums_Interpolator'
         bootstrap_accuracy:
           type: number
+          description: 'Numerical bootstrap tolerance (not a market convention): keeps
+            its default.'
         kind:
           $ref: '#/components/schemas/quantra_enums_InflationCurveKind'
         index_id:
@@ -4526,6 +4548,10 @@ components:
           $ref: '#/components/schemas/quantra_enums_BusinessDayConvention'
         settles_accrual:
           type: boolean
+          description: 'ISDA settlement conventions. Presence-required: each is a
+            deliberate
+
+            choice (false round-trips) so an omission is a 400, never a silent true.'
         pays_at_default_time:
           type: boolean
         rebates_accrual:

--- a/src/common/require_period.h
+++ b/src/common/require_period.h
@@ -1,0 +1,39 @@
+#ifndef QUANTRA_REQUIRE_PERIOD_H
+#define QUANTRA_REQUIRE_PERIOD_H
+
+/**
+ * Presence validation for the shared `Period` table (common.fbs). Both `n` and
+ * `unit` are declared optional on the wire (`= null`); a bare `n` would default
+ * to a silent 0 and an omitted `unit` would silently mean Months, so a forgotten
+ * value turns into a named 400 (QuantraInvalidArgument) here instead of pricing
+ * a bogus (0 Months) tenor. Only ever included from the parsers/mappers layer.
+ */
+
+#include <string>
+
+#include <ql/time/period.hpp>
+
+#include "common_generated.h"
+#include "enum_convert.h"
+#include "error.h"
+
+namespace quantra {
+
+/// Require a present Period table and both of its fields, returning a QL Period.
+inline QuantLib::Period requirePeriod(const quantra::Period* p,
+                                      const std::string& name) {
+    if (p == nullptr) {
+        QUANTRA_INVALID_ARGUMENT(name + " is required");
+    }
+    if (!p->n().has_value()) {
+        QUANTRA_INVALID_ARGUMENT(name + ".n is required");
+    }
+    if (!p->unit().has_value()) {
+        QUANTRA_INVALID_ARGUMENT(name + ".unit is required");
+    }
+    return QuantLib::Period(p->n().value(), TimeUnitToQL(p->unit().value()));
+}
+
+} // namespace quantra
+
+#endif // QUANTRA_REQUIRE_PERIOD_H

--- a/src/common/require_scalar.h
+++ b/src/common/require_scalar.h
@@ -57,6 +57,44 @@ inline double requirePositive(flatbuffers::Optional<double> v, const std::string
     return v.value();
 }
 
+/**
+ * Require a presence-optional enum to be provided. Convention enums
+ * (calendar / day_counter / business_day_convention / frequency / etc.) are
+ * declared `field:enums.Foo = null` on the wire so an omission is a named 400
+ * rather than the silent alphabetical-0 enum value.
+ */
+template <typename T>
+inline T requireEnum(flatbuffers::Optional<T> v, const std::string& name) {
+    if (!v.has_value()) {
+        QUANTRA_INVALID_ARGUMENT(name + " is required");
+    }
+    return v.value();
+}
+
+/**
+ * Require a presence-optional integer convention (fixing_days / settlement_days
+ * / spot_days / cash_settlement_days) to be provided. A bare int would silently
+ * default to 0, so an omission is a named 400 instead.
+ */
+inline int requireInt(flatbuffers::Optional<int> v, const std::string& name) {
+    if (!v.has_value()) {
+        QUANTRA_INVALID_ARGUMENT(name + " is required");
+    }
+    return v.value();
+}
+
+/**
+ * Require a presence-optional bool convention (end_of_month, CDS ISDA flags,
+ * inflation interpolated/revised) to be provided. A bare bool would silently
+ * default to false (or a hard-coded true), so an omission is a named 400.
+ */
+inline bool requireBool(flatbuffers::Optional<bool> v, const std::string& name) {
+    if (!v.has_value()) {
+        QUANTRA_INVALID_ARGUMENT(name + " is required");
+    }
+    return v.value();
+}
+
 } // namespace quantra
 
 #endif // QUANTRA_REQUIRE_SCALAR_H

--- a/src/mappers/bootstrap_curves_mapper.cpp
+++ b/src/mappers/bootstrap_curves_mapper.cpp
@@ -9,6 +9,8 @@
 #include "enum_convert.h"
 #include "error.h"
 #include "grid_utils.h"
+#include "require_period.h"
+#include "require_scalar.h"
 
 namespace quantra {
 
@@ -50,7 +52,8 @@ QuantLib::Calendar calendarFromTermStructure(const quantra::TermStructure* ts) {
                 QUANTRA_INVALID_ARGUMENT("FutureHelper.calendar is required");
             return CalendarToQL(h->calendar().value());
         }
-        if (auto h = first->point_as_OISHelper())     return CalendarToQL(h->calendar());
+        if (auto h = first->point_as_OISHelper())
+            return CalendarToQL(requireEnum(h->calendar(), "OISHelper.calendar"));
     }
     return QuantLib::TARGET();
 }
@@ -79,21 +82,15 @@ std::vector<QuantLib::Date> extractPillarDates(
         const auto* point = points->Get(i);
         QuantLib::Date maturityDate;
         if (auto deposit = point->point_as_DepositHelper()) {
-            if (!deposit->tenor()) {
-                QUANTRA_INVALID_ARGUMENT("DepositHelper.tenor is required");
-            }
-            QuantLib::Period tenor(
-                deposit->tenor()->n(), TimeUnitToQL(deposit->tenor()->unit()));
+            QuantLib::Period tenor =
+                requirePeriod(deposit->tenor(), "DepositHelper.tenor");
             if (!deposit->business_day_convention().has_value())
                 QUANTRA_INVALID_ARGUMENT("DepositHelper.business_day_convention is required");
             maturityDate = calendar.advance(
                 referenceDate, tenor, ConventionToQL(deposit->business_day_convention().value()));
         } else if (auto swap = point->point_as_SwapHelper()) {
-            if (!swap->tenor()) {
-                QUANTRA_INVALID_ARGUMENT("SwapHelper.tenor is required");
-            }
-            QuantLib::Period tenor(
-                swap->tenor()->n(), TimeUnitToQL(swap->tenor()->unit()));
+            QuantLib::Period tenor =
+                requirePeriod(swap->tenor(), "SwapHelper.tenor");
             if (!swap->sw_fixed_leg_convention().has_value())
                 QUANTRA_INVALID_ARGUMENT("SwapHelper.sw_fixed_leg_convention is required");
             maturityDate = calendar.advance(
@@ -117,35 +114,25 @@ std::vector<QuantLib::Date> extractPillarDates(
                 maturityDate = DateToQL(bond->schedule()->termination_date()->str());
             }
         } else if (auto ois = point->point_as_OISHelper()) {
-            if (!ois->tenor()) {
-                QUANTRA_INVALID_ARGUMENT("OISHelper.tenor is required");
-            }
-            QuantLib::Period tenor(
-                ois->tenor()->n(), TimeUnitToQL(ois->tenor()->unit()));
+            QuantLib::Period tenor =
+                requirePeriod(ois->tenor(), "OISHelper.tenor");
             maturityDate = calendar.advance(
-                referenceDate, tenor, ConventionToQL(ois->fixed_leg_convention()));
+                referenceDate, tenor,
+                ConventionToQL(requireEnum(ois->fixed_leg_convention(),
+                                           "OISHelper.fixed_leg_convention")));
         } else if (auto datedOis = point->point_as_DatedOISHelper()) {
             maturityDate = DateToQL(datedOis->end_date()->str());
         } else if (auto basis = point->point_as_TenorBasisSwapHelper()) {
-            if (!basis->tenor()) {
-                QUANTRA_INVALID_ARGUMENT("TenorBasisSwapHelper.tenor is required");
-            }
-            QuantLib::Period tenor(
-                basis->tenor()->n(), TimeUnitToQL(basis->tenor()->unit()));
+            QuantLib::Period tenor =
+                requirePeriod(basis->tenor(), "TenorBasisSwapHelper.tenor");
             maturityDate = calendar.advance(referenceDate, tenor);
         } else if (auto fx = point->point_as_FxSwapHelper()) {
-            if (!fx->tenor()) {
-                QUANTRA_INVALID_ARGUMENT("FxSwapHelper.tenor is required");
-            }
-            QuantLib::Period tenor(
-                fx->tenor()->n(), TimeUnitToQL(fx->tenor()->unit()));
+            QuantLib::Period tenor =
+                requirePeriod(fx->tenor(), "FxSwapHelper.tenor");
             maturityDate = calendar.advance(referenceDate, tenor);
         } else if (auto xccy = point->point_as_CrossCcyBasisHelper()) {
-            if (!xccy->tenor()) {
-                QUANTRA_INVALID_ARGUMENT("CrossCcyBasisHelper.tenor is required");
-            }
-            QuantLib::Period tenor(
-                xccy->tenor()->n(), TimeUnitToQL(xccy->tenor()->unit()));
+            QuantLib::Period tenor =
+                requirePeriod(xccy->tenor(), "CrossCcyBasisHelper.tenor");
             maturityDate = calendar.advance(referenceDate, tenor);
         }
         if (maturityDate != QuantLib::Date()) {
@@ -181,8 +168,7 @@ ForwardSampleSpec extractForwardSpec(
         s.epsNumber = q->instantaneous_eps_number();
         s.epsUnit = TimeUnitToQL(q->instantaneous_eps_time_unit());
         if (q->tenor()) {
-            s.tenor = QuantLib::Period(
-                q->tenor()->n(), TimeUnitToQL(q->tenor()->unit()));
+            s.tenor = requirePeriod(q->tenor(), "ForwardRateQuery.tenor");
         }
         useGridCalendar = q->use_grid_calendar_for_advance();
     }

--- a/src/mappers/bootstrap_inflation_curves_mapper.cpp
+++ b/src/mappers/bootstrap_inflation_curves_mapper.cpp
@@ -6,6 +6,7 @@
 
 #include "date_convert.h"
 #include "enum_convert.h"
+#include "require_scalar.h"
 #include "error.h"
 #include "grid_utils.h"
 
@@ -82,9 +83,10 @@ BootstrapInflationCurvesQuery extractQuery(
     out.allowExtrapolation = !options || options->allow_extrapolation();
     out.strict = !options || options->strict();
 
-    const QuantLib::Calendar fallbackCal = CalendarToQL(curveSpec->calendar());
-    const QuantLib::BusinessDayConvention fallbackBdc =
-        ConventionToQL(curveSpec->business_day_convention());
+    const QuantLib::Calendar fallbackCal = CalendarToQL(
+        requireEnum(curveSpec->calendar(), "InflationCurveSpec.calendar"));
+    const QuantLib::BusinessDayConvention fallbackBdc = ConventionToQL(requireEnum(
+        curveSpec->business_day_convention(), "InflationCurveSpec.business_day_convention"));
     const QuantLib::Date referenceDate = DateToQL(curveSpec->reference_date()->str());
 
     const QuantLib::Calendar gridCal =

--- a/src/mappers/calibrate_swaption_model_mapper.cpp
+++ b/src/mappers/calibrate_swaption_model_mapper.cpp
@@ -3,6 +3,7 @@
 #include "enum_convert.h"
 #include "error.h"
 #include "model_generated.h"
+#include "require_period.h"
 
 namespace quantra {
 
@@ -20,12 +21,14 @@ SwaptionHwCalibrationDomain toCalibrationDomain(
     if (c->swap_index_id()) hw.swap_index_id = c->swap_index_id()->str();
     if (c->expiries()) {
         for (auto pit = c->expiries()->begin(); pit != c->expiries()->end(); ++pit) {
-            hw.expiries.emplace_back(pit->n(), TimeUnitToQL(pit->unit()));
+            hw.expiries.push_back(
+                requirePeriod(*pit, "SwaptionHwCalibrationSpec.expiries"));
         }
     }
     if (c->tenors()) {
         for (auto pit = c->tenors()->begin(); pit != c->tenors()->end(); ++pit) {
-            hw.tenors.emplace_back(pit->n(), TimeUnitToQL(pit->unit()));
+            hw.tenors.push_back(
+                requirePeriod(*pit, "SwaptionHwCalibrationSpec.tenors"));
         }
     }
     hw.calibrate_a = c->calibrate_a();

--- a/src/mappers/cds_mapper.cpp
+++ b/src/mappers/cds_mapper.cpp
@@ -59,10 +59,12 @@ CdsTrade extractTrade(const quantra::PriceCDS* pricing) {
     }
     trade.dayCounter = DayCounterToQL(cds->day_counter().value());
     trade.businessDayConvention = ConventionToQL(cds->business_day_convention().value());
-    trade.settlesAccrual = cds->settles_accrual();
-    trade.paysAtDefaultTime = cds->pays_at_default_time();
-    trade.rebatesAccrual = cds->rebates_accrual();
-    trade.lastPeriodDayCounter = DayCounterToQL(cds->last_period_day_counter());
+    trade.settlesAccrual = requireBool(cds->settles_accrual(), "CDS.settles_accrual");
+    trade.paysAtDefaultTime =
+        requireBool(cds->pays_at_default_time(), "CDS.pays_at_default_time");
+    trade.rebatesAccrual = requireBool(cds->rebates_accrual(), "CDS.rebates_accrual");
+    trade.lastPeriodDayCounter = DayCounterToQL(
+        requireEnum(cds->last_period_day_counter(), "CDS.last_period_day_counter"));
     if (cds->protection_start() && cds->protection_start()->size() > 0) {
         trade.protectionStart = DateToQL(cds->protection_start()->str());
     }
@@ -73,7 +75,8 @@ CdsTrade extractTrade(const quantra::PriceCDS* pricing) {
     if (cds->trade_date() && cds->trade_date()->size() > 0) {
         trade.tradeDate = DateToQL(cds->trade_date()->str());
     }
-    trade.cashSettlementDays = cds->cash_settlement_days();
+    trade.cashSettlementDays =
+        requireInt(cds->cash_settlement_days(), "CDS.cash_settlement_days");
 
     trade.discountingCurveId = pricing->discounting_curve()->str();
     trade.creditCurveId = pricing->credit_curve_id()->str();

--- a/src/mappers/sample_vol_surfaces_mapper.cpp
+++ b/src/mappers/sample_vol_surfaces_mapper.cpp
@@ -4,6 +4,7 @@
 
 #include "date_convert.h"
 #include "enum_convert.h"
+#include "require_scalar.h"
 #include "error.h"
 #include "swaption_vol_diagnostics.h"
 
@@ -80,8 +81,8 @@ SampleDateGridSpec extractGridSpec(const quantra::DateGridSpec* spec) {
                 for (flatbuffers::uoffset_t i = 0; i < g->tenors()->size(); ++i) {
                     const auto* t = g->tenors()->Get(i);
                     SampleTenor st;
-                    st.n = t->n();
-                    st.unit = t->unit();
+                    st.n = requireInt(t->n(), "SwaptionTenorGrid.tenors.n");
+                    st.unit = requireEnum(t->unit(), "SwaptionTenorGrid.tenors.unit");
                     out.tenor.tenors.push_back(st);
                 }
             }

--- a/src/mappers/vanilla_swap_mapper.cpp
+++ b/src/mappers/vanilla_swap_mapper.cpp
@@ -7,6 +7,7 @@
 #include "error.h"
 #include "leg_notionals.h"
 #include "require_scalar.h"
+#include "require_period.h"
 
 namespace quantra {
 
@@ -141,8 +142,7 @@ VanillaSwapTrade extractTrade(const quantra::PriceVanillaSwap* pricing) {
     trade.cms.schedule = *cmsSchedule;
     trade.cms.notional = requirePositive(cmsFb->notional(), "SwapCmsLeg.notional");
     trade.cms.swapIndexId = cmsFb->swap_index_id()->str();
-    trade.cms.swapTenor = QuantLib::Period(
-        cmsFb->swap_tenor()->n(), TimeUnitToQL(cmsFb->swap_tenor()->unit()));
+    trade.cms.swapTenor = requirePeriod(cmsFb->swap_tenor(), "SwapCmsLeg.swap_tenor");
     trade.cms.swaptionVolId = cmsFb->swaption_vol_id()->str();
     trade.cms.fixingDays = cmsFb->fixing_days();
     trade.cms.dayCounter = DayCounterToQL(cmsFb->day_counter().value());

--- a/src/mappers/year_on_year_inflation_cap_floor_mapper.cpp
+++ b/src/mappers/year_on_year_inflation_cap_floor_mapper.cpp
@@ -5,6 +5,7 @@
 #include "schedule_parser.h"
 #include "error.h"
 #include "require_scalar.h"
+#include "require_period.h"
 
 namespace quantra {
 
@@ -89,8 +90,8 @@ YoYInflationCapFloorTrade extractTrade(const quantra::PriceYoYInflationCapFloor*
     trade.notional = requirePositive(cf->notional(), "YoYInflationCapFloor.notional");
     trade.schedule = *schedule;
     trade.inflationIndexId = cf->inflation_index_id()->str();
-    trade.observationLag = QuantLib::Period(
-        cf->observation_lag()->n(), TimeUnitToQL(cf->observation_lag()->unit()));
+    trade.observationLag = requirePeriod(
+        cf->observation_lag(), "YoYInflationCapFloor.observation_lag");
     trade.dayCounter = DayCounterToQL(cf->day_counter().value());
     trade.paymentConvention = ConventionToQL(cf->payment_convention().value());
 

--- a/src/mappers/year_on_year_inflation_swap_mapper.cpp
+++ b/src/mappers/year_on_year_inflation_swap_mapper.cpp
@@ -7,6 +7,7 @@
 #include "enum_convert.h"
 #include "error.h"
 #include "require_scalar.h"
+#include "require_period.h"
 
 namespace quantra {
 
@@ -59,9 +60,8 @@ YearOnYearInflationSwapTrade extractTrade(const quantra::PriceYearOnYearInflatio
     trade.fixedDayCounter = DayCounterToQL(swap->fixed_day_counter());
     trade.yoySchedule = *yoySchedule;
     trade.inflationIndexId = swap->inflation_index_id()->str();
-    trade.observationLag = QuantLib::Period(
-        swap->observation_lag()->n(),
-        TimeUnitToQL(swap->observation_lag()->unit()));
+    trade.observationLag = requirePeriod(
+        swap->observation_lag(), "YearOnYearInflationSwap.observation_lag");
     trade.observationInterpolation = CPIInterpolationToQL(swap->observation_interpolation());
     trade.spread = swap->spread();
     trade.yoyDayCounter = DayCounterToQL(swap->yoy_day_counter());

--- a/src/mappers/zero_coupon_inflation_swap_mapper.cpp
+++ b/src/mappers/zero_coupon_inflation_swap_mapper.cpp
@@ -6,6 +6,7 @@
 #include "enum_convert.h"
 #include "error.h"
 #include "require_scalar.h"
+#include "require_period.h"
 
 namespace quantra {
 
@@ -56,9 +57,8 @@ ZeroCouponInflationSwapTrade extractTrade(const quantra::PriceZeroCouponInflatio
     trade.dayCounter = DayCounterToQL(swap->day_counter());
     trade.fixedRate = swap->fixed_rate();
     trade.inflationIndexId = swap->inflation_index_id()->str();
-    trade.observationLag = QuantLib::Period(
-        swap->observation_lag()->n(),
-        TimeUnitToQL(swap->observation_lag()->unit()));
+    trade.observationLag = requirePeriod(
+        swap->observation_lag(), "ZeroCouponInflationSwap.observation_lag");
     trade.observationInterpolation = CPIInterpolationToQL(swap->observation_interpolation());
     if (swap->adjust_observation_dates()) {
         QUANTRA_INVALID_ARGUMENT(

--- a/src/market/curve_cache_key.cpp
+++ b/src/market/curve_cache_key.cpp
@@ -135,7 +135,14 @@ void CurveKeyBuilder::writeSchedule(
     writeOptEnum(sched->convention());
     writeOptEnum(sched->termination_date_convention());
     writeOptEnum(sched->date_generation_rule());
-    buf.writeBool(sched->end_of_month());
+    // end_of_month is presence-required now; keep a presence byte so an absent
+    // flag never collides with an explicit false.
+    if (sched->end_of_month().has_value()) {
+        buf.writeU8(1);
+        buf.writeBool(sched->end_of_month().value());
+    } else {
+        buf.writeU8(0);
+    }
     // Optional stub-period control. writeFbString is length-prefixed and writes
     // a 0-length marker for an absent (null) string, so a present ISO date can
     // never collide with an absent field — same presence discipline already used
@@ -178,6 +185,30 @@ std::vector<uint8_t> CurveKeyBuilder::serializePoint(
             buf.writeU8(0);
         }
     };
+    // Same presence discipline for the newly-optional int / bool conventions and
+    // for the shared Period (both n and unit are presence-required now).
+    auto writeOptInt = [&buf](flatbuffers::Optional<int32_t> opt) {
+        if (opt.has_value()) {
+            buf.writeU8(1);
+            buf.writeI32(opt.value());
+        } else {
+            buf.writeU8(0);
+        }
+    };
+    auto writeOptBool = [&buf](flatbuffers::Optional<bool> opt) {
+        if (opt.has_value()) {
+            buf.writeU8(1);
+            buf.writeBool(opt.value());
+        } else {
+            buf.writeU8(0);
+        }
+    };
+    auto writeTenor = [&buf, &writeOptInt, &writeOptEnum](const quantra::Period* t) {
+        if (!t) { buf.writeU8(0); return; }
+        buf.writeU8(1);
+        writeOptInt(t->n());
+        writeOptEnum(t->unit());
+    };
 
     switch (ptype) {
 
@@ -185,8 +216,7 @@ std::vector<uint8_t> CurveKeyBuilder::serializePoint(
         auto p = pw->point_as_DepositHelper();
         buf.writeDouble(resolveQuoteValue(p->rate().value_or(0.0), p->quote_id(), ctx));
         buf.writeU8(p->rate().has_value() ? 1 : 0);
-        buf.writeI32(p->tenor() ? p->tenor()->n() : 0);
-        buf.writeU8(static_cast<uint8_t>(p->tenor() ? p->tenor()->unit() : quantra::enums::TimeUnit_Days));
+        writeTenor(p->tenor());
         buf.writeI32(p->fixing_days());
         writeOptEnum(p->calendar());
         writeOptEnum(p->business_day_convention());
@@ -235,8 +265,7 @@ std::vector<uint8_t> CurveKeyBuilder::serializePoint(
         auto p = pw->point_as_SwapHelper();
         buf.writeDouble(resolveQuoteValue(p->rate().value_or(0.0), p->quote_id(), ctx));
         buf.writeU8(p->rate().has_value() ? 1 : 0);
-        buf.writeI32(p->tenor() ? p->tenor()->n() : 0);
-        buf.writeU8(static_cast<uint8_t>(p->tenor() ? p->tenor()->unit() : quantra::enums::TimeUnit_Days));
+        writeTenor(p->tenor());
         writeOptEnum(p->calendar());
         writeOptEnum(p->sw_fixed_leg_frequency());
         writeOptEnum(p->sw_fixed_leg_convention());
@@ -277,14 +306,13 @@ std::vector<uint8_t> CurveKeyBuilder::serializePoint(
         auto p = pw->point_as_OISHelper();
         buf.writeDouble(resolveQuoteValue(p->rate().value_or(0.0), p->quote_id(), ctx));
         buf.writeU8(p->rate().has_value() ? 1 : 0);
-        buf.writeI32(p->tenor() ? p->tenor()->n() : 0);
-        buf.writeU8(static_cast<uint8_t>(p->tenor() ? p->tenor()->unit() : quantra::enums::TimeUnit_Days));
+        writeTenor(p->tenor());
         writeIndexRef(buf, p->overnight_index());
-        buf.writeI32(p->settlement_days());
-        buf.writeU8(static_cast<uint8_t>(p->calendar()));
-        buf.writeU8(static_cast<uint8_t>(p->fixed_leg_frequency()));
-        buf.writeU8(static_cast<uint8_t>(p->fixed_leg_convention()));
-        buf.writeU8(static_cast<uint8_t>(p->fixed_leg_day_counter()));
+        writeOptInt(p->settlement_days());
+        writeOptEnum(p->calendar());
+        writeOptEnum(p->fixed_leg_frequency());
+        writeOptEnum(p->fixed_leg_convention());
+        writeOptEnum(p->fixed_leg_day_counter());
         writeDeps(buf, p->deps());
         break;
     }
@@ -296,10 +324,10 @@ std::vector<uint8_t> CurveKeyBuilder::serializePoint(
         buf.writeFbString(p->start_date());
         buf.writeFbString(p->end_date());
         writeIndexRef(buf, p->overnight_index());
-        buf.writeI32(p->settlement_days());
-        buf.writeU8(static_cast<uint8_t>(p->calendar()));
-        buf.writeU8(static_cast<uint8_t>(p->fixed_leg_convention()));
-        buf.writeU8(static_cast<uint8_t>(p->fixed_leg_day_counter()));
+        writeOptInt(p->settlement_days());
+        writeOptEnum(p->calendar());
+        writeOptEnum(p->fixed_leg_convention());
+        writeOptEnum(p->fixed_leg_day_counter());
         writeDeps(buf, p->deps());
         break;
     }
@@ -309,12 +337,11 @@ std::vector<uint8_t> CurveKeyBuilder::serializePoint(
         buf.writeFbString(p->date());
         buf.writeDouble(p->zero_rate().value_or(0.0));
         buf.writeU8(p->zero_rate().has_value() ? 1 : 0);
-        buf.writeI32(p->tenor() ? p->tenor()->n() : 0);
-        buf.writeU8(static_cast<uint8_t>(p->tenor() ? p->tenor()->unit() : quantra::enums::TimeUnit_Days));
-        buf.writeU8(static_cast<uint8_t>(p->calendar()));
-        buf.writeU8(static_cast<uint8_t>(p->business_day_convention()));
-        buf.writeU8(static_cast<uint8_t>(p->compounding()));
-        buf.writeU8(static_cast<uint8_t>(p->frequency()));
+        writeTenor(p->tenor());
+        writeOptEnum(p->calendar());
+        writeOptEnum(p->business_day_convention());
+        writeOptEnum(p->compounding());
+        writeOptEnum(p->frequency());
         break;
     }
 
@@ -326,10 +353,9 @@ std::vector<uint8_t> CurveKeyBuilder::serializePoint(
         buf.writeFbString(p->date());
         buf.writeDouble(p->discount_factor().value_or(0.0));
         buf.writeU8(p->discount_factor().has_value() ? 1 : 0);
-        buf.writeI32(p->tenor() ? p->tenor()->n() : 0);
-        buf.writeU8(static_cast<uint8_t>(p->tenor() ? p->tenor()->unit() : quantra::enums::TimeUnit_Days));
-        buf.writeU8(static_cast<uint8_t>(p->calendar()));
-        buf.writeU8(static_cast<uint8_t>(p->business_day_convention()));
+        writeTenor(p->tenor());
+        writeOptEnum(p->calendar());
+        writeOptEnum(p->business_day_convention());
         break;
     }
 
@@ -342,10 +368,9 @@ std::vector<uint8_t> CurveKeyBuilder::serializePoint(
         buf.writeFbString(p->date());
         buf.writeDouble(p->forward_rate().value_or(0.0));
         buf.writeU8(p->forward_rate().has_value() ? 1 : 0);
-        buf.writeI32(p->tenor() ? p->tenor()->n() : 0);
-        buf.writeU8(static_cast<uint8_t>(p->tenor() ? p->tenor()->unit() : quantra::enums::TimeUnit_Days));
-        buf.writeU8(static_cast<uint8_t>(p->calendar()));
-        buf.writeU8(static_cast<uint8_t>(p->business_day_convention()));
+        writeTenor(p->tenor());
+        writeOptEnum(p->calendar());
+        writeOptEnum(p->business_day_convention());
         break;
     }
 
@@ -353,8 +378,7 @@ std::vector<uint8_t> CurveKeyBuilder::serializePoint(
         auto p = pw->point_as_TenorBasisSwapHelper();
         buf.writeDouble(resolveQuoteValue(p->spread().value_or(0.0), p->quote_id(), ctx));
         buf.writeU8(p->spread().has_value() ? 1 : 0);
-        buf.writeI32(p->tenor() ? p->tenor()->n() : 0);
-        buf.writeU8(static_cast<uint8_t>(p->tenor() ? p->tenor()->unit() : quantra::enums::TimeUnit_Days));
+        writeTenor(p->tenor());
         writeIndexRef(buf, p->index_short());
         writeIndexRef(buf, p->index_long());
         writeOptEnum(p->calendar());
@@ -366,11 +390,10 @@ std::vector<uint8_t> CurveKeyBuilder::serializePoint(
         auto p = pw->point_as_FxSwapHelper();
         buf.writeDouble(resolveQuoteValue(p->fx_points().value_or(0.0), p->quote_id(), ctx));
         buf.writeU8(p->fx_points().has_value() ? 1 : 0);
-        buf.writeI32(p->tenor() ? p->tenor()->n() : 0);
-        buf.writeU8(static_cast<uint8_t>(p->tenor() ? p->tenor()->unit() : quantra::enums::TimeUnit_Days));
-        buf.writeI32(p->spot_days());
-        buf.writeU8(static_cast<uint8_t>(p->calendar_domestic()));
-        buf.writeU8(static_cast<uint8_t>(p->calendar_foreign()));
+        writeTenor(p->tenor());
+        writeOptInt(p->spot_days());
+        writeOptEnum(p->calendar_domestic());
+        writeOptEnum(p->calendar_foreign());
         writeDeps(buf, p->deps());
         break;
     }
@@ -379,8 +402,7 @@ std::vector<uint8_t> CurveKeyBuilder::serializePoint(
         auto p = pw->point_as_CrossCcyBasisHelper();
         buf.writeDouble(resolveQuoteValue(p->spread().value_or(0.0), p->quote_id(), ctx));
         buf.writeU8(p->spread().has_value() ? 1 : 0);
-        buf.writeI32(p->tenor() ? p->tenor()->n() : 0);
-        buf.writeU8(static_cast<uint8_t>(p->tenor() ? p->tenor()->unit() : quantra::enums::TimeUnit_Days));
+        writeTenor(p->tenor());
         writeIndexRef(buf, p->index_domestic());
         writeIndexRef(buf, p->index_foreign());
         writeDeps(buf, p->deps());
@@ -474,17 +496,38 @@ void CurveKeyBuilder::writeReferencedIndices(
                 "' has no definition — curve must not be cached");
         }
 
+        // IndexDef conventions are presence-required now; serialize a presence
+        // byte plus the value for each optional field so an absent convention
+        // never collides with a present one in the cache key.
+        auto idxOptEnum = [&buf](auto opt) {
+            if (opt.has_value()) { buf.writeU8(1); buf.writeU8(static_cast<uint8_t>(opt.value())); }
+            else { buf.writeU8(0); }
+        };
+        auto idxOptInt = [&buf](flatbuffers::Optional<int32_t> opt) {
+            if (opt.has_value()) { buf.writeU8(1); buf.writeI32(opt.value()); }
+            else { buf.writeU8(0); }
+        };
+        auto idxOptBool = [&buf](flatbuffers::Optional<bool> opt) {
+            if (opt.has_value()) { buf.writeU8(1); buf.writeBool(opt.value()); }
+            else { buf.writeU8(0); }
+        };
+
         const auto* def = it->second;
         buf.writeFbString(def->id());
         buf.writeFbString(def->name());
-        buf.writeU8(static_cast<uint8_t>(def->index_type()));
-        buf.writeI32(def->tenor() ? def->tenor()->n() : 0);
-        buf.writeU8(static_cast<uint8_t>(def->tenor() ? def->tenor()->unit() : quantra::enums::TimeUnit_Days));
-        buf.writeI32(def->fixing_days());
-        buf.writeU8(static_cast<uint8_t>(def->calendar()));
-        buf.writeU8(static_cast<uint8_t>(def->business_day_convention()));
-        buf.writeU8(static_cast<uint8_t>(def->day_counter()));
-        buf.writeBool(def->end_of_month());
+        idxOptEnum(def->index_type());
+        if (def->tenor()) {
+            buf.writeU8(1);
+            idxOptInt(def->tenor()->n());
+            idxOptEnum(def->tenor()->unit());
+        } else {
+            buf.writeU8(0);
+        }
+        idxOptInt(def->fixing_days());
+        idxOptEnum(def->calendar());
+        idxOptEnum(def->business_day_convention());
+        idxOptEnum(def->day_counter());
+        idxOptBool(def->end_of_month());
         buf.writeFbString(def->currency());
 
         // Include fixings in key (they affect bootstrap)

--- a/src/market/grid_utils.cpp
+++ b/src/market/grid_utils.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <sstream>
 #include "date_convert.h"
+#include "require_period.h"
 
 namespace quantra {
 namespace grid_utils {
@@ -84,7 +85,7 @@ std::vector<QuantLib::Date> BuildTenorGrid(
         if (!tenor) {
             QUANTRA_INVALID_ARGUMENT("TenorGrid.tenors[] contains null");
         }
-        QuantLib::Period p(tenor->n(), TimeUnitToQL(tenor->unit()));
+        QuantLib::Period p = requirePeriod(tenor, "TenorGrid.tenors");
         if (p.length() == 0 && p.units() != QuantLib::Days) {
             QUANTRA_INVALID_ARGUMENT("TenorGrid only allows zero period as 0 Days");
         }

--- a/src/market/index_registry_builder.h
+++ b/src/market/index_registry_builder.h
@@ -6,6 +6,8 @@
 #include "enum_convert.h"
 #include "date_convert.h"
 #include "error.h"
+#include "require_scalar.h"
+#include "require_period.h"
 
 #include <ql/indexes/iborindex.hpp>
 #include <ql/indexes/ibor/all.hpp>
@@ -83,22 +85,26 @@ public:
                 ? def->currency()->str() : "EUR";
             QuantLib::Currency currency = CurrencyFromString(ccyStr);
 
-            // Parse conventions
-            if (!def->tenor()) {
-                QUANTRA_INVALID_ARGUMENT("IndexDef.tenor is required for id: " + id);
-            }
-            int tenorN = def->tenor()->n();
-            QuantLib::TimeUnit tenorUnit = TimeUnitToQL(def->tenor()->unit());
-            QuantLib::Period tenor(tenorN, tenorUnit);
-            int fixingDays = def->fixing_days();
-            QuantLib::Calendar calendar = CalendarToQL(def->calendar());
-            QuantLib::BusinessDayConvention bdc = ConventionToQL(def->business_day_convention());
-            QuantLib::DayCounter dayCounter = DayCounterToQL(def->day_counter());
-            bool eom = def->end_of_month();
+            // Parse conventions (every convention is presence-required)
+            QuantLib::Period tenor =
+                requirePeriod(def->tenor(), "IndexDef.tenor for id: " + id);
+            int fixingDays = requireInt(def->fixing_days(),
+                                        "IndexDef.fixing_days for id: " + id);
+            QuantLib::Calendar calendar = CalendarToQL(
+                requireEnum(def->calendar(), "IndexDef.calendar for id: " + id));
+            QuantLib::BusinessDayConvention bdc = ConventionToQL(requireEnum(
+                def->business_day_convention(),
+                "IndexDef.business_day_convention for id: " + id));
+            QuantLib::DayCounter dayCounter = DayCounterToQL(requireEnum(
+                def->day_counter(), "IndexDef.day_counter for id: " + id));
+            bool eom = requireBool(def->end_of_month(),
+                                   "IndexDef.end_of_month for id: " + id);
+            quantra::IndexType indexType = requireEnum(
+                def->index_type(), "IndexDef.index_type for id: " + id);
 
             std::shared_ptr<QuantLib::InterestRateIndex> index;
 
-            if (def->index_type() == quantra::IndexType_Overnight) {
+            if (indexType == quantra::IndexType_Overnight) {
                 // Build OvernightIndex
                 index = std::make_shared<QuantLib::OvernightIndex>(
                     name,

--- a/src/market/pricing_registry.cpp
+++ b/src/market/pricing_registry.cpp
@@ -23,6 +23,7 @@
 #include "quote_registry.h"
 #include "inflation_curve_parsers.h"
 #include "require_scalar.h"
+#include "require_period.h"
 
 namespace quantra {
 
@@ -258,12 +259,14 @@ PricingRegistry PricingRegistryBuilder::build(const quantra::Pricing* pricing,
                         if (c->swap_index_id()) hw.swap_index_id = c->swap_index_id()->str();
                         if (c->expiries()) {
                             for (auto pit = c->expiries()->begin(); pit != c->expiries()->end(); ++pit) {
-                                hw.expiries.emplace_back(pit->n(), TimeUnitToQL(pit->unit()));
+                                hw.expiries.push_back(requirePeriod(
+                                    *pit, "SwaptionHwCalibrationSpec.expiries"));
                             }
                         }
                         if (c->tenors()) {
                             for (auto pit = c->tenors()->begin(); pit != c->tenors()->end(); ++pit) {
-                                hw.tenors.emplace_back(pit->n(), TimeUnitToQL(pit->unit()));
+                                hw.tenors.push_back(requirePeriod(
+                                    *pit, "SwaptionHwCalibrationSpec.tenors"));
                             }
                         }
                         hw.calibrate_a = c->calibrate_a();
@@ -334,22 +337,39 @@ PricingRegistry PricingRegistryBuilder::build(const quantra::Pricing* pricing,
             CreditCurveDomain d;
             d.id = id;
             d.reference_date = DateToQL(spec->reference_date()->str());
-            d.calendar = CalendarToQL(spec->calendar());
-            d.day_counter = DayCounterToQL(spec->day_counter());
-            d.recovery_rate = spec->recovery_rate();
-            d.curve_interpolator =
-                static_cast<CreditCurveInterpolatorKind>(spec->curve_interpolator());
+            d.calendar = CalendarToQL(
+                requireEnum(spec->calendar(), "CreditCurveSpec.calendar"));
+            d.day_counter = DayCounterToQL(
+                requireEnum(spec->day_counter(), "CreditCurveSpec.day_counter"));
+            d.recovery_rate =
+                requireFinite(spec->recovery_rate(), "CreditCurveSpec.recovery_rate");
+            d.curve_interpolator = static_cast<CreditCurveInterpolatorKind>(
+                requireEnum(spec->curve_interpolator(),
+                            "CreditCurveSpec.curve_interpolator"));
             if (const auto* h = spec->helper_conventions()) {
                 CdsHelperConventionsDomain hc;
-                hc.settlement_days = h->settlement_days();
-                hc.frequency = FrequencyToQL(h->frequency());
-                hc.business_day_convention = ConventionToQL(h->business_day_convention());
-                hc.date_generation_rule = DateGenerationToQL(h->date_generation_rule());
-                hc.last_period_day_counter = DayCounterToQL(h->last_period_day_counter());
-                hc.settles_accrual = h->settles_accrual();
-                hc.pays_at_default_time = h->pays_at_default_time();
-                hc.rebates_accrual = h->rebates_accrual();
-                hc.helper_model = static_cast<CdsHelperModelKind>(h->helper_model());
+                hc.settlement_days = requireInt(
+                    h->settlement_days(), "CdsHelperConventions.settlement_days");
+                hc.frequency = FrequencyToQL(
+                    requireEnum(h->frequency(), "CdsHelperConventions.frequency"));
+                hc.business_day_convention = ConventionToQL(requireEnum(
+                    h->business_day_convention(),
+                    "CdsHelperConventions.business_day_convention"));
+                hc.date_generation_rule = DateGenerationToQL(requireEnum(
+                    h->date_generation_rule(),
+                    "CdsHelperConventions.date_generation_rule"));
+                hc.last_period_day_counter = DayCounterToQL(requireEnum(
+                    h->last_period_day_counter(),
+                    "CdsHelperConventions.last_period_day_counter"));
+                hc.settles_accrual = requireBool(
+                    h->settles_accrual(), "CdsHelperConventions.settles_accrual");
+                hc.pays_at_default_time = requireBool(
+                    h->pays_at_default_time(),
+                    "CdsHelperConventions.pays_at_default_time");
+                hc.rebates_accrual = requireBool(
+                    h->rebates_accrual(), "CdsHelperConventions.rebates_accrual");
+                hc.helper_model = static_cast<CdsHelperModelKind>(
+                    requireEnum(h->helper_model(), "CdsHelperConventions.helper_model"));
                 d.helper_conventions = hc;
             }
             if (spec->flat_hazard_rate().has_value()) {
@@ -360,8 +380,7 @@ PricingRegistry PricingRegistryBuilder::build(const quantra::Pricing* pricing,
                 for (auto qit = qs->begin(); qit != qs->end(); ++qit) {
                     CdsQuoteDomain q;
                     if (qit->tenor()) {
-                        q.tenor = QuantLib::Period(qit->tenor()->n(),
-                                                   TimeUnitToQL(qit->tenor()->unit()));
+                        q.tenor = requirePeriod(qit->tenor(), "CdsQuote.tenor");
                     }
                     if (!qit->quote_type().has_value()) {
                         QUANTRA_INVALID_ARGUMENT("CdsQuote.quote_type is required");

--- a/src/market/swap_index_registry.cpp
+++ b/src/market/swap_index_registry.cpp
@@ -1,5 +1,8 @@
 #include "swap_index_registry.h"
 
+#include "require_scalar.h"
+#include "require_period.h"
+
 namespace quantra {
 
 namespace {
@@ -62,12 +65,17 @@ SwapIndexRegistry SwapIndexRegistryBuilder::build(
         if (!d->float_index_id()) {
             QUANTRA_INVALID_ARGUMENT("SwapIndexDef.float_index_id is required");
         }
+        const std::string sid = d->id()->str();
         SwapIndexRuntime r;
-        r.kind = d->kind();
-        r.spotDays = d->spot_days();
-        r.calendar = CalendarToQL(d->calendar());
-        r.bdc = ConventionToQL(d->business_day_convention());
-        r.endOfMonth = d->end_of_month();
+        r.kind = requireEnum(d->kind(), "SwapIndexDef.kind for id: " + sid);
+        r.spotDays = requireInt(d->spot_days(), "SwapIndexDef.spot_days for id: " + sid);
+        r.calendar = CalendarToQL(
+            requireEnum(d->calendar(), "SwapIndexDef.calendar for id: " + sid));
+        r.bdc = ConventionToQL(requireEnum(
+            d->business_day_convention(),
+            "SwapIndexDef.business_day_convention for id: " + sid));
+        r.endOfMonth = requireBool(
+            d->end_of_month(), "SwapIndexDef.end_of_month for id: " + sid);
         r.floatIndexId = d->float_index_id()->str();
 
         // Validate index kind against referenced index definition.
@@ -81,15 +89,24 @@ SwapIndexRegistry SwapIndexRegistryBuilder::build(
             QUANTRA_INVALID_ARGUMENT("SwapIndexDef.fixed_leg is required for id: " + d->id()->str());
         }
         const auto* f = d->fixed_leg();
-        r.fixedFrequency = FrequencyToQL(f->fixed_frequency());
-        r.fixedDayCounter = DayCounterToQL(f->fixed_day_counter());
-        r.fixedCalendar = CalendarToQL(f->fixed_calendar());
-        r.fixedCalendarFb = f->fixed_calendar();
-        r.fixedBdc = ConventionToQL(f->fixed_bdc());
-        r.fixedBdcFb = f->fixed_bdc();
-        r.fixedTermBdc = ConventionToQL(f->fixed_term_bdc());
-        r.fixedDateRule = DateGenerationToQL(f->fixed_date_rule());
-        r.fixedEom = f->fixed_eom();
+        const auto fixedCalFb =
+            requireEnum(f->fixed_calendar(), "SwapIndexFixedLegSpec.fixed_calendar for id: " + sid);
+        const auto fixedBdcFb =
+            requireEnum(f->fixed_bdc(), "SwapIndexFixedLegSpec.fixed_bdc for id: " + sid);
+        r.fixedFrequency = FrequencyToQL(requireEnum(
+            f->fixed_frequency(), "SwapIndexFixedLegSpec.fixed_frequency for id: " + sid));
+        r.fixedDayCounter = DayCounterToQL(requireEnum(
+            f->fixed_day_counter(), "SwapIndexFixedLegSpec.fixed_day_counter for id: " + sid));
+        r.fixedCalendar = CalendarToQL(fixedCalFb);
+        r.fixedCalendarFb = fixedCalFb;
+        r.fixedBdc = ConventionToQL(fixedBdcFb);
+        r.fixedBdcFb = fixedBdcFb;
+        r.fixedTermBdc = ConventionToQL(requireEnum(
+            f->fixed_term_bdc(), "SwapIndexFixedLegSpec.fixed_term_bdc for id: " + sid));
+        r.fixedDateRule = DateGenerationToQL(requireEnum(
+            f->fixed_date_rule(), "SwapIndexFixedLegSpec.fixed_date_rule for id: " + sid));
+        r.fixedEom = requireBool(
+            f->fixed_eom(), "SwapIndexFixedLegSpec.fixed_eom for id: " + sid);
         if (r.calendar != r.fixedCalendar || r.bdc != r.fixedBdc || r.endOfMonth != r.fixedEom) {
             QUANTRA_INVALID_ARGUMENT(
                 "SwapIndexDef top-level calendar/business_day_convention/end_of_month must match fixed_leg for id: " +
@@ -103,14 +120,18 @@ SwapIndexRegistry SwapIndexRegistryBuilder::build(
         if (!fl->float_tenor()) {
             QUANTRA_INVALID_ARGUMENT("SwapIndexDef.float_leg.float_tenor is required for id: " + d->id()->str());
         }
-        r.floatTenor = QuantLib::Period(
-            fl->float_tenor()->n(),
-            TimeUnitToQL(fl->float_tenor()->unit()));
-        r.floatCalendar = CalendarToQL(fl->float_calendar());
-        r.floatBdc = ConventionToQL(fl->float_bdc());
-        r.floatTermBdc = ConventionToQL(fl->float_term_bdc());
-        r.floatDateRule = DateGenerationToQL(fl->float_date_rule());
-        r.floatEom = fl->float_eom();
+        r.floatTenor = requirePeriod(
+            fl->float_tenor(), "SwapIndexFloatLegSpec.float_tenor for id: " + sid);
+        r.floatCalendar = CalendarToQL(requireEnum(
+            fl->float_calendar(), "SwapIndexFloatLegSpec.float_calendar for id: " + sid));
+        r.floatBdc = ConventionToQL(requireEnum(
+            fl->float_bdc(), "SwapIndexFloatLegSpec.float_bdc for id: " + sid));
+        r.floatTermBdc = ConventionToQL(requireEnum(
+            fl->float_term_bdc(), "SwapIndexFloatLegSpec.float_term_bdc for id: " + sid));
+        r.floatDateRule = DateGenerationToQL(requireEnum(
+            fl->float_date_rule(), "SwapIndexFloatLegSpec.float_date_rule for id: " + sid));
+        r.floatEom = requireBool(
+            fl->float_eom(), "SwapIndexFloatLegSpec.float_eom for id: " + sid);
 
         if (r.spotDays < 0) {
             QUANTRA_INVALID_ARGUMENT("SwapIndexDef.spot_days must be >= 0 for id: " + d->id()->str());

--- a/src/market/swaption_model_calibration.cpp
+++ b/src/market/swaption_model_calibration.cpp
@@ -1,5 +1,7 @@
 #include "swaption_model_calibration.h"
 
+#include "require_period.h"
+
 #include <cmath>
 #include <atomic>
 #include <iostream>
@@ -46,10 +48,7 @@ QuantLib::Period frequencyToPeriod(QuantLib::Frequency f) {
 }
 
 QuantLib::Period toQlPeriod(const quantra::Period* p) {
-    if (!p) {
-        QUANTRA_INVALID_ARGUMENT("Calibration Period is null");
-    }
-    return QuantLib::Period(p->n(), TimeUnitToQL(p->unit()));
+    return requirePeriod(p, "Calibration Period");
 }
 
 double marketVolAtNode(

--- a/src/parsers/cms_leg_parser.cpp
+++ b/src/parsers/cms_leg_parser.cpp
@@ -4,6 +4,7 @@
 #include <limits>
 
 #include "require_scalar.h"
+#include "require_period.h"
 
 #include "vanilla_swap_generated.h"
 
@@ -73,9 +74,7 @@ QuantLib::Leg CmsLegParser::parse(
 
     ScheduleParser scheduleParser;
     auto schedule = scheduleParser.parse(leg->schedule());
-    QuantLib::Period cmsTenor(
-        leg->swap_tenor()->n(),
-        TimeUnitToQL(leg->swap_tenor()->unit()));
+    QuantLib::Period cmsTenor = requirePeriod(leg->swap_tenor(), "SwapCmsLeg.swap_tenor");
     const std::string swapIndexId = leg->swap_index_id()->str();
     auto swapIndex = swapIndices.getIborSwapIndexWithCurves(
         swapIndexId, cmsTenor, indices, forwardingCurve, discountCurve);

--- a/src/parsers/inflation_curve_parsers.cpp
+++ b/src/parsers/inflation_curve_parsers.cpp
@@ -23,6 +23,7 @@
 #include "enum_convert.h"
 #include "error.h"
 #include "require_scalar.h"
+#include "require_period.h"
 #include "index_registry_builder.h" // CurrencyFromString
 
 namespace quantra {
@@ -56,10 +57,7 @@ std::unordered_map<std::string, const quantra::InflationIndexSpec*> buildInflati
 }
 
 QuantLib::Period toQlPeriodReq(const quantra::Period* p, const std::string& label) {
-    if (!p) {
-        QUANTRA_INVALID_ARGUMENT(label + " is required");
-    }
-    return QuantLib::Period(p->n(), TimeUnitToQL(p->unit()));
+    return requirePeriod(p, label);
 }
 
 QuantLib::CPI::InterpolationType cpiInterpolationToQL(quantra::enums::CPIInterpolationType interpolation) {
@@ -219,8 +217,9 @@ QuantLib::Schedule buildSchedule(
         !scheduleSpec->frequency().has_value() ||
         !scheduleSpec->convention().has_value() ||
         !scheduleSpec->termination_date_convention().has_value() ||
-        !scheduleSpec->date_generation_rule().has_value()) {
-        QUANTRA_INVALID_ARGUMENT(helperLabel + ".schedule requires calendar, frequency, convention, termination_date_convention and date_generation_rule for curve id: " + curveId);
+        !scheduleSpec->date_generation_rule().has_value() ||
+        !scheduleSpec->end_of_month().has_value()) {
+        QUANTRA_INVALID_ARGUMENT(helperLabel + ".schedule requires calendar, frequency, convention, termination_date_convention, date_generation_rule and end_of_month for curve id: " + curveId);
     }
     return QuantLib::Schedule(
         DateToQL(scheduleSpec->effective_date()->str()),
@@ -230,7 +229,7 @@ QuantLib::Schedule buildSchedule(
         ConventionToQL(scheduleSpec->convention().value()),
         ConventionToQL(scheduleSpec->termination_date_convention().value()),
         DateGenerationToQL(scheduleSpec->date_generation_rule().value()),
-        scheduleSpec->end_of_month());
+        scheduleSpec->end_of_month().value());
 }
 
 template <typename TTermStructure>
@@ -267,17 +266,20 @@ InflationIndexPtr buildInflationIndex(
     const std::string ccyStr = hasText(spec->currency()) ? spec->currency()->str() : "EUR";
     QuantLib::Currency ccy = CurrencyFromString(ccyStr);
     QuantLib::Region region = regionFromCurrency(ccyStr);
-    QuantLib::Frequency freq = FrequencyToQL(spec->frequency());
+    QuantLib::Frequency freq = FrequencyToQL(
+        requireEnum(spec->frequency(), "InflationIndexSpec.frequency"));
+    const bool revised = requireBool(spec->revised(), "InflationIndexSpec.revised");
     QuantLib::Period availLag = toQlPeriodReq(spec->availability_lag(), "InflationIndexSpec.availability_lag");
 
-    if (spec->kind() == enums::InflationCurveKind_ZeroInflation) {
+    if (requireEnum(spec->kind(), "InflationIndexSpec.kind") ==
+        enums::InflationCurveKind_ZeroInflation) {
         auto curveIt = zeroCurveHandles.find(id);
         QuantLib::Handle<QuantLib::ZeroInflationTermStructure> handle =
             curveIt != zeroCurveHandles.end() ? curveIt->second : QuantLib::Handle<QuantLib::ZeroInflationTermStructure>();
         auto index = QuantLib::ext::make_shared<QuantLib::ZeroInflationIndex>(
             family,
             region,
-            spec->revised(),
+            revised,
             freq,
             availLag,
             ccy,
@@ -311,7 +313,7 @@ InflationIndexPtr buildInflationIndex(
         yoyIndex = QuantLib::ext::make_shared<QuantLib::YoYInflationIndex>(
             family,
             region,
-            spec->revised(),
+            revised,
             freq,
             availLag,
             ccy,
@@ -359,7 +361,8 @@ std::map<std::string, InflationCurveEntry> buildInflationCurves(
         if (!spec->points() || spec->points()->size() == 0) {
             QUANTRA_INVALID_ARGUMENT("InflationCurveSpec.points are required for curve id: " + id);
         }
-        validateInterpolator(spec->interpolator(), id);
+        validateInterpolator(
+            requireEnum(spec->interpolator(), "InflationCurveSpec.interpolator"), id);
 
         const std::string indexId = spec->index_id()->str();
         std::string discountCurveId;
@@ -376,11 +379,14 @@ std::map<std::string, InflationCurveEntry> buildInflationCurves(
         }
 
         QuantLib::Date ref = DateToQL(spec->reference_date()->str());
-        QuantLib::Calendar cal = CalendarToQL(spec->calendar());
-        QuantLib::BusinessDayConvention bdc = ConventionToQL(spec->business_day_convention());
-        QuantLib::DayCounter dc = DayCounterToQL(spec->day_counter());
-        const auto kind = spec->kind();
-        if (idxSpec->kind() != kind) {
+        QuantLib::Calendar cal = CalendarToQL(
+            requireEnum(spec->calendar(), "InflationCurveSpec.calendar"));
+        QuantLib::BusinessDayConvention bdc = ConventionToQL(requireEnum(
+            spec->business_day_convention(), "InflationCurveSpec.business_day_convention"));
+        QuantLib::DayCounter dc = DayCounterToQL(
+            requireEnum(spec->day_counter(), "InflationCurveSpec.day_counter"));
+        const auto kind = requireEnum(spec->kind(), "InflationCurveSpec.kind");
+        if (requireEnum(idxSpec->kind(), "InflationIndexSpec.kind") != kind) {
             QUANTRA_INVALID_ARGUMENT("Inflation kind mismatch for curve id '" + id +
                           "': curve.kind and index.kind must match");
         }
@@ -388,8 +394,10 @@ std::map<std::string, InflationCurveEntry> buildInflationCurves(
 
         QuantLib::Period obsLag = toQlPeriodReq(idxSpec->observation_lag(), "InflationIndexSpec.observation_lag");
         QuantLib::Period availLag = toQlPeriodReq(idxSpec->availability_lag(), "InflationIndexSpec.availability_lag");
-        QuantLib::Frequency freq = FrequencyToQL(idxSpec->frequency());
-        const bool idxInterpolated = idxSpec->interpolated();
+        QuantLib::Frequency freq = FrequencyToQL(
+            requireEnum(idxSpec->frequency(), "InflationIndexSpec.frequency"));
+        const bool idxInterpolated =
+            requireBool(idxSpec->interpolated(), "InflationIndexSpec.interpolated");
         std::vector<QuantLib::Date> pillarDates;
 
         std::unordered_map<std::string, InflationIndexPtr> localIndexCache;
@@ -423,11 +431,15 @@ std::map<std::string, InflationCurveEntry> buildInflationCurves(
                 if (!std::isfinite(quoteValue)) {
                     QUANTRA_INVALID_ARGUMENT(label + ".quote_value must be finite for curve id: " + id);
                 }
-                auto helperCalendar = CalendarToQL(helper->calendar());
-                auto helperBdc = ConventionToQL(helper->payment_convention());
-                auto helperDc = DayCounterToQL(helper->day_counter());
+                auto helperCalendar = CalendarToQL(
+                    requireEnum(helper->calendar(), label + ".calendar"));
+                auto helperBdc = ConventionToQL(
+                    requireEnum(helper->payment_convention(), label + ".payment_convention"));
+                auto helperDc = DayCounterToQL(
+                    requireEnum(helper->day_counter(), label + ".day_counter"));
                 auto helperObsLag = toQlPeriodReq(helper->swap_observation_lag(), label + ".swap_observation_lag");
-                auto helperInterpolation = cpiInterpolationToQL(helper->observation_interpolation());
+                auto helperInterpolation = cpiInterpolationToQL(requireEnum(
+                    helper->observation_interpolation(), label + ".observation_interpolation"));
                 auto dates = resolveHelperDates(helper, ref, helperCalendar, helperBdc, id, label);
                 auto quote = QuantLib::Handle<QuantLib::Quote>(
                     QuantLib::ext::make_shared<QuantLib::SimpleQuote>(quoteValue));
@@ -512,11 +524,15 @@ std::map<std::string, InflationCurveEntry> buildInflationCurves(
                 if (!std::isfinite(quoteValue)) {
                     QUANTRA_INVALID_ARGUMENT(label + ".quote_value must be finite for curve id: " + id);
                 }
-                auto helperCalendar = CalendarToQL(helper->calendar());
-                auto helperBdc = ConventionToQL(helper->payment_convention());
-                auto helperDc = DayCounterToQL(helper->day_counter());
+                auto helperCalendar = CalendarToQL(
+                    requireEnum(helper->calendar(), label + ".calendar"));
+                auto helperBdc = ConventionToQL(
+                    requireEnum(helper->payment_convention(), label + ".payment_convention"));
+                auto helperDc = DayCounterToQL(
+                    requireEnum(helper->day_counter(), label + ".day_counter"));
                 auto helperObsLag = toQlPeriodReq(helper->swap_observation_lag(), label + ".swap_observation_lag");
-                auto helperInterpolation = cpiInterpolationToQL(helper->observation_interpolation());
+                auto helperInterpolation = cpiInterpolationToQL(requireEnum(
+                    helper->observation_interpolation(), label + ".observation_interpolation"));
                 auto dates = resolveHelperDates(helper, ref, helperCalendar, helperBdc, id, label);
                 auto quote = QuantLib::Handle<QuantLib::Quote>(
                     QuantLib::ext::make_shared<QuantLib::SimpleQuote>(quoteValue));

--- a/src/parsers/schedule_parser.cpp
+++ b/src/parsers/schedule_parser.cpp
@@ -50,6 +50,8 @@ std::shared_ptr<QuantLib::Schedule> ScheduleParser::parse(const quantra::Schedul
         QUANTRA_INVALID_ARGUMENT("Schedule.termination_date_convention is required");
     if (!schedule->date_generation_rule().has_value())
         QUANTRA_INVALID_ARGUMENT("Schedule.date_generation_rule is required");
+    if (!schedule->end_of_month().has_value())
+        QUANTRA_INVALID_ARGUMENT("Schedule.end_of_month is required");
 
     const QuantLib::Date effective = DateToQL(schedule->effective_date()->str());
     const QuantLib::Date termination = DateToQL(schedule->termination_date()->str());
@@ -133,7 +135,7 @@ std::shared_ptr<QuantLib::Schedule> ScheduleParser::parse(const quantra::Schedul
                 ConventionToQL(schedule->convention().value()),
                 ConventionToQL(schedule->termination_date_convention().value()),
                 DateGenerationToQL(schedule->date_generation_rule().value()),
-                schedule->end_of_month(),
+                schedule->end_of_month().value(),
                 firstDate,
                 nextToLastDate);
         }
@@ -153,5 +155,5 @@ std::shared_ptr<QuantLib::Schedule> ScheduleParser::parse(const quantra::Schedul
         ConventionToQL(schedule->convention().value()),
         ConventionToQL(schedule->termination_date_convention().value()),
         DateGenerationToQL(schedule->date_generation_rule().value()),
-        schedule->end_of_month());
+        schedule->end_of_month().value());
 }

--- a/src/parsers/term_structure_parser.cpp
+++ b/src/parsers/term_structure_parser.cpp
@@ -9,6 +9,9 @@
 
 #include <cmath>
 
+#include "require_scalar.h"
+#include "require_period.h"
+
 using namespace QuantLib;
 
 namespace quantra {
@@ -126,18 +129,17 @@ std::shared_ptr<YieldTermStructure> TermStructureParser::parse(
             if (p->date()) {
                 d = DateToQL(p->date()->str());
             } else {
-                if (!p->tenor()) {
-                    QUANTRA_INVALID_ARGUMENT(
-                        "DiscountFactorPoint.tenor is required when date is not provided");
-                }
-                int tenorN = p->tenor()->n();
-                auto tenorUnit = p->tenor()->unit();
-                if (tenorN <= 0) {
+                QuantLib::Period tenor =
+                    requirePeriod(p->tenor(), "DiscountFactorPoint.tenor");
+                if (tenor.length() <= 0) {
                     QUANTRA_INVALID_ARGUMENT("DiscountFactorPoint requires date or tenor");
                 }
-                auto cal = CalendarToQL(p->calendar());
-                auto bdc = ConventionToQL(p->business_day_convention());
-                d = cal.advance(ref, tenorN * TimeUnitToQL(tenorUnit), bdc);
+                auto cal = CalendarToQL(
+                    requireEnum(p->calendar(), "DiscountFactorPoint.calendar"));
+                auto bdc = ConventionToQL(requireEnum(
+                    p->business_day_convention(),
+                    "DiscountFactorPoint.business_day_convention"));
+                d = cal.advance(ref, tenor, bdc);
             }
 
             if (!p->discount_factor().has_value()) {
@@ -205,18 +207,17 @@ std::shared_ptr<YieldTermStructure> TermStructureParser::parse(
             if (p->date()) {
                 d = DateToQL(p->date()->str());
             } else {
-                if (!p->tenor()) {
-                    QUANTRA_INVALID_ARGUMENT(
-                        "ForwardRatePoint.tenor is required when date is not provided");
-                }
-                int tenorN = p->tenor()->n();
-                auto tenorUnit = p->tenor()->unit();
-                if (tenorN <= 0) {
+                QuantLib::Period tenor =
+                    requirePeriod(p->tenor(), "ForwardRatePoint.tenor");
+                if (tenor.length() <= 0) {
                     QUANTRA_INVALID_ARGUMENT("ForwardRatePoint requires date or tenor");
                 }
-                auto cal = CalendarToQL(p->calendar());
-                auto bdc = ConventionToQL(p->business_day_convention());
-                d = cal.advance(ref, tenorN * TimeUnitToQL(tenorUnit), bdc);
+                auto cal = CalendarToQL(
+                    requireEnum(p->calendar(), "ForwardRatePoint.calendar"));
+                auto bdc = ConventionToQL(requireEnum(
+                    p->business_day_convention(),
+                    "ForwardRatePoint.business_day_convention"));
+                d = cal.advance(ref, tenor, bdc);
             }
 
             if (!p->forward_rate().has_value()) {
@@ -272,17 +273,17 @@ std::shared_ptr<YieldTermStructure> TermStructureParser::parse(
             if (p->date()) {
                 d = DateToQL(p->date()->str());
             } else {
-                if (!p->tenor()) {
-                    QUANTRA_INVALID_ARGUMENT("ZeroRatePoint.tenor is required when date is not provided");
-                }
-                int tenorN = p->tenor()->n();
-                auto tenorUnit = p->tenor()->unit();
-                if (tenorN <= 0) {
+                QuantLib::Period tenor =
+                    requirePeriod(p->tenor(), "ZeroRatePoint.tenor");
+                if (tenor.length() <= 0) {
                     QUANTRA_INVALID_ARGUMENT("ZeroRatePoint requires date or tenor");
                 }
-                auto cal = CalendarToQL(p->calendar());
-                auto bdc = ConventionToQL(p->business_day_convention());
-                d = cal.advance(ref, tenorN * TimeUnitToQL(tenorUnit), bdc);
+                auto cal = CalendarToQL(
+                    requireEnum(p->calendar(), "ZeroRatePoint.calendar"));
+                auto bdc = ConventionToQL(requireEnum(
+                    p->business_day_convention(),
+                    "ZeroRatePoint.business_day_convention"));
+                d = cal.advance(ref, tenor, bdc);
             }
             dates.push_back(d);
             if (!p->zero_rate().has_value()) {
@@ -294,8 +295,10 @@ std::shared_ptr<YieldTermStructure> TermStructureParser::parse(
             // convention. Applying the first point's pair to every rate would
             // silently mis-build the curve if the points disagree, so require
             // them identical across all points.
-            Compounding pointComp = CompoundingToQL(p->compounding());
-            Frequency pointFreq = FrequencyToQL(p->frequency());
+            Compounding pointComp = CompoundingToQL(
+                requireEnum(p->compounding(), "ZeroRatePoint.compounding"));
+            Frequency pointFreq = FrequencyToQL(
+                requireEnum(p->frequency(), "ZeroRatePoint.frequency"));
             if (!convSet) {
                 comp = pointComp;
                 freq = pointFreq;

--- a/src/parsers/term_structure_point_parser.cpp
+++ b/src/parsers/term_structure_point_parser.cpp
@@ -7,6 +7,7 @@
 #include <ql/settings.hpp>
 
 #include "require_scalar.h"
+#include "require_period.h"
 
 using namespace QuantLib;
 
@@ -103,7 +104,7 @@ std::shared_ptr<RateHelper> TermStructurePointParser::parse(
 
         return std::make_shared<DepositRateHelper>(
             q,
-            point->tenor()->n() * TimeUnitToQL(point->tenor()->unit()),
+            requirePeriod(point->tenor(), "DepositHelper.tenor"),
             point->fixing_days(),
             CalendarToQL(point->calendar().value()),
             ConventionToQL(point->business_day_convention().value()),
@@ -276,7 +277,7 @@ std::shared_ptr<RateHelper> TermStructurePointParser::parse(
 
         return std::make_shared<SwapRateHelper>(
             q,
-            point->tenor()->n() * TimeUnitToQL(point->tenor()->unit()),
+            requirePeriod(point->tenor(), "SwapHelper.tenor"),
             CalendarToQL(point->calendar().value()),
             FrequencyToQL(point->sw_fixed_leg_frequency().value()),
             ConventionToQL(point->sw_fixed_leg_convention().value()),
@@ -394,8 +395,8 @@ std::shared_ptr<RateHelper> TermStructurePointParser::parse(
         }
 
         return std::make_shared<OISRateHelper>(
-            point->settlement_days(),
-            point->tenor()->n() * TimeUnitToQL(point->tenor()->unit()),
+            requireInt(point->settlement_days(), "OISHelper.settlement_days"),
+            requirePeriod(point->tenor(), "OISHelper.tenor"),
             q,
             on,
             discount
@@ -454,16 +455,17 @@ std::shared_ptr<RateHelper> TermStructurePointParser::parse(
         auto tenor = (end - start) * Days;
 
         return std::make_shared<OISRateHelper>(
-            point->settlement_days(),
+            requireInt(point->settlement_days(), "DatedOISHelper.settlement_days"),
             tenor,
             q,
             on,
             discount,
             false,
             0,
-            ConventionToQL(point->fixed_leg_convention()),
+            ConventionToQL(requireEnum(point->fixed_leg_convention(),
+                                       "DatedOISHelper.fixed_leg_convention")),
             Frequency::Annual,
-            CalendarToQL(point->calendar()),
+            CalendarToQL(requireEnum(point->calendar(), "DatedOISHelper.calendar")),
             forwardStart,
             0.0,
             QuantLib::Pillar::LastRelevantDate,

--- a/src/parsers/vol_surface_parsers.cpp
+++ b/src/parsers/vol_surface_parsers.cpp
@@ -6,6 +6,8 @@
 
 #include "vol_surface_parsers.h"
 
+#include "require_period.h"
+
 #include <ql/termstructures/volatility/swaption/swaptionvolmatrix.hpp>
 #include <ql/termstructures/volatility/equityfx/blackvariancecurve.hpp>
 #include <ql/termstructures/volatility/equityfx/blackvariancesurface.hpp>
@@ -151,27 +153,7 @@ void validateBlackVolBase(const quantra::BlackVolBaseSpec* b, const std::string&
 }
 
 QuantLib::Period toQlPeriod(const quantra::Period* p) {
-    if (!p) {
-        QUANTRA_INVALID_ARGUMENT("Period is null");
-    }
-    QuantLib::TimeUnit unit;
-    switch (p->unit()) {
-        case quantra::enums::TimeUnit_Days:
-            unit = QuantLib::Days;
-            break;
-        case quantra::enums::TimeUnit_Weeks:
-            unit = QuantLib::Weeks;
-            break;
-        case quantra::enums::TimeUnit_Months:
-            unit = QuantLib::Months;
-            break;
-        case quantra::enums::TimeUnit_Years:
-            unit = QuantLib::Years;
-            break;
-        default:
-            QUANTRA_INVALID_ARGUMENT("Unknown TimeUnit for Period");
-    }
-    return QuantLib::Period(p->n(), unit);
+    return requirePeriod(p, "Period");
 }
 
 double resolveMatrixValue(
@@ -2383,8 +2365,8 @@ YoYOptionletVolEntry parseYoYOptionletVol(const quantra::VolSurfaceSpec* spec) {
     entry.dayCounter = DayCounterToQL(p->day_counter().value());
     entry.calendar = CalendarToQL(p->calendar().value());
     entry.businessDayConvention = ConventionToQL(p->business_day_convention().value());
-    entry.observationLag = QuantLib::Period(
-        p->observation_lag()->n(), TimeUnitToQL(p->observation_lag()->unit()));
+    entry.observationLag = requirePeriod(
+        p->observation_lag(), "ConstantYoYOptionletVolSpec.observation_lag");
     return entry;
 }
 

--- a/tests/client/test_python_client.py
+++ b/tests/client/test_python_client.py
@@ -574,6 +574,7 @@ def test_vanilla_swap(client: Client, curve_handle: ql.YieldTermStructureHandle)
     fixed_schedule_q.convention = BusinessDayConvention.ModifiedFollowing
     fixed_schedule_q.terminationDateConvention = BusinessDayConvention.ModifiedFollowing
     fixed_schedule_q.dateGenerationRule = DateGenerationRule.Forward
+    fixed_schedule_q.endOfMonth = False
     
     fixed_leg = SwapFixedLegT()
     fixed_leg.notional = notional
@@ -590,6 +591,7 @@ def test_vanilla_swap(client: Client, curve_handle: ql.YieldTermStructureHandle)
     float_schedule_q.convention = BusinessDayConvention.ModifiedFollowing
     float_schedule_q.terminationDateConvention = BusinessDayConvention.ModifiedFollowing
     float_schedule_q.dateGenerationRule = DateGenerationRule.Forward
+    float_schedule_q.endOfMonth = False
     
     float_leg = SwapFloatingLegT()
     float_leg.notional = notional
@@ -744,6 +746,7 @@ def test_cap(client: Client, curve_handle: ql.YieldTermStructureHandle):
     schedule_q.convention = BusinessDayConvention.ModifiedFollowing
     schedule_q.terminationDateConvention = BusinessDayConvention.ModifiedFollowing
     schedule_q.dateGenerationRule = DateGenerationRule.Forward
+    schedule_q.endOfMonth = False
     
     cap = CapFloorT()
     cap.capFloorType = CapFloorType.Cap
@@ -840,6 +843,7 @@ def test_swaption(client: Client, curve_handle: ql.YieldTermStructureHandle):
     fixed_schedule_q.convention = BusinessDayConvention.ModifiedFollowing
     fixed_schedule_q.terminationDateConvention = BusinessDayConvention.ModifiedFollowing
     fixed_schedule_q.dateGenerationRule = DateGenerationRule.Forward
+    fixed_schedule_q.endOfMonth = False
     
     fixed_leg = SwapFixedLegT()
     fixed_leg.notional = notional
@@ -856,6 +860,7 @@ def test_swaption(client: Client, curve_handle: ql.YieldTermStructureHandle):
     float_schedule_q.convention = BusinessDayConvention.ModifiedFollowing
     float_schedule_q.terminationDateConvention = BusinessDayConvention.ModifiedFollowing
     float_schedule_q.dateGenerationRule = DateGenerationRule.Forward
+    float_schedule_q.endOfMonth = False
     
     float_leg = SwapFloatingLegT()
     float_leg.notional = notional
@@ -952,6 +957,7 @@ def test_cds(client: Client, curve_handle: ql.YieldTermStructureHandle):
     schedule_q.convention = BusinessDayConvention.Following
     schedule_q.terminationDateConvention = BusinessDayConvention.Unadjusted
     schedule_q.dateGenerationRule = DateGenerationRule.TwentiethIMM
+    schedule_q.endOfMonth = False
     
     cds = CDST()
     cds.side = ProtectionSide.Buyer
@@ -960,7 +966,12 @@ def test_cds(client: Client, curve_handle: ql.YieldTermStructureHandle):
     cds.schedule = schedule_q
     cds.dayCounter = DayCounter.Actual360
     cds.businessDayConvention = BusinessDayConvention.Following
-    
+    cds.settlesAccrual = True
+    cds.paysAtDefaultTime = True
+    cds.rebatesAccrual = True
+    cds.lastPeriodDayCounter = DayCounter.Actual360
+    cds.cashSettlementDays = 3
+
     credit_curve = CreditCurveSpecT()
     credit_curve.id = "credit"
     credit_curve.referenceDate = EVAL_DATE_STR

--- a/tests/contract/contract_checks.py
+++ b/tests/contract/contract_checks.py
@@ -338,6 +338,7 @@ def check_bootstrap_inflation_curves_smoke(client: ApiClient) -> dict:
                     "calendar": "TARGET",
                     "business_day_convention": "ModifiedFollowing",
                     "day_counter": "Actual360",
+                    "end_of_month": true,
                     "currency": "EUR",
                     "tenor": {
                         "n": 6,
@@ -658,7 +659,7 @@ def check_price_zero_coupon_inflation_swap_smoke(client: ApiClient) -> dict:
                         "tenor": {"n": 6, "unit": "Months"},
                         "fixing_days": 2, "calendar": "TARGET",
                         "business_day_convention": "ModifiedFollowing",
-                        "day_counter": "Actual360", "currency": "EUR"
+                        "day_counter": "Actual360", "end_of_month": True, "currency": "EUR"
                     }],
                     "curves": [{
                         "id": "DISC", "reference_date": "2025-01-15",
@@ -864,7 +865,7 @@ def check_price_year_on_year_inflation_swap_smoke(client: ApiClient) -> dict:
                         "tenor": {"n": 6, "unit": "Months"},
                         "fixing_days": 2, "calendar": "TARGET",
                         "business_day_convention": "ModifiedFollowing",
-                        "day_counter": "Actual360", "currency": "EUR"
+                        "day_counter": "Actual360", "end_of_month": True, "currency": "EUR"
                     }],
                     "curves": [{
                         "id": "DISC", "reference_date": "2025-01-15",
@@ -1002,7 +1003,8 @@ def check_price_year_on_year_inflation_swap_smoke(client: ApiClient) -> dict:
                         "frequency": "Annual",
                         "convention": "ModifiedFollowing",
                         "termination_date_convention": "ModifiedFollowing",
-                        "date_generation_rule": "Forward"
+                        "date_generation_rule": "Forward",
+                        "end_of_month": False
                     },
                     "fixed_rate": 0.0204,
                     "fixed_day_counter": "Actual365Fixed",
@@ -1013,7 +1015,8 @@ def check_price_year_on_year_inflation_swap_smoke(client: ApiClient) -> dict:
                         "frequency": "Annual",
                         "convention": "ModifiedFollowing",
                         "termination_date_convention": "ModifiedFollowing",
-                        "date_generation_rule": "Forward"
+                        "date_generation_rule": "Forward",
+                        "end_of_month": False
                     },
                     "inflation_index_id": "EUHICP_YY",
                     "observation_lag": {"n": 3, "unit": "Months"},

--- a/tests/contract/error_contract_test.py
+++ b/tests/contract/error_contract_test.py
@@ -127,6 +127,54 @@ def _ec_del_curve_field(field):
     return f
 
 
+def _ec_del_credit_field(field):
+    """Drop a convention field from the first credit curve (CreditCurveSpec).
+    recovery_rate / curve_interpolator / calendar / day_counter are
+    presence-required conventions: an omission is a named 400, never a silent
+    market-default assumption."""
+    def f(req):
+        req["pricing"]["credit"]["credit_curves"][0].pop(field, None)
+        return req
+    return f
+
+
+def _ec_del_credit_helper_field(field):
+    """Drop a convention field from the first credit curve's CdsHelperConventions
+    (e.g. settlement_days). Presence-required: an omission is a named 400."""
+    def f(req):
+        req["pricing"]["credit"]["credit_curves"][0]["helper_conventions"].pop(field, None)
+        return req
+    return f
+
+
+def _ec_del_index_field(field):
+    """Drop a convention field from the first registered IndexDef
+    (fixing_days / calendar / business_day_convention / day_counter /
+    end_of_month / index_type). Presence-required: an omission is a named 400."""
+    def f(req):
+        req["pricing"]["rates"]["indices"][0].pop(field, None)
+        return req
+    return f
+
+
+def _ec_del_index_tenor_unit():
+    """Drop `unit` from the first IndexDef's tenor Period. An omitted period unit
+    would otherwise silently mean Months, so it must be a named 400."""
+    def f(req):
+        req["pricing"]["rates"]["indices"][0]["tenor"].pop("unit", None)
+        return req
+    return f
+
+
+def _ec_del_cds_schedule_field(field):
+    """Drop a field from the CDS trade schedule (e.g. end_of_month). Presence-
+    required: absent-vs-false silently changes schedule dates."""
+    def f(req):
+        req["cds_list"][0]["cds"]["schedule"].pop(field, None)
+        return req
+    return f
+
+
 def _ec_set_curve_field(field, value):
     """Set a top-level field on the first pricing curve (TermStructure). Used to
     drive bootstrap_trait to a value that conflicts with the curve's points."""
@@ -669,6 +717,39 @@ SCENARIOS = [
      "vanilla_swap_request.json", 400,
      _ec_del_swap_leg_field("swaps", "vanilla_swap", "fixed_leg", "payment_convention"),
      _ec_body_contains("SwapFixedLeg.payment_convention is required")),
+    # ---- 400 INVALID_ARGUMENT: hard-coded convention-default presence ----
+    # Conventions that previously carried a hard-coded default (recovery 0.4,
+    # fixing_days 2, calendar TARGET, period unit Months, schedule end-of-month,
+    # a helper settlement lag) are now presence-required: an omission is a named
+    # 400 rather than a silent market-default assumption.
+    ("ec:400 cds credit curve missing recovery_rate", "cds",
+     "cds_request.json", 400,
+     _ec_del_credit_field("recovery_rate"),
+     _ec_body_contains("CreditCurveSpec.recovery_rate is required")),
+    ("ec:400 cds credit curve missing curve_interpolator", "cds",
+     "cds_request.json", 400,
+     _ec_del_credit_field("curve_interpolator"),
+     _ec_body_contains("CreditCurveSpec.curve_interpolator is required")),
+    ("ec:400 cds credit helper missing settlement_days", "cds",
+     "cds_request.json", 400,
+     _ec_del_credit_helper_field("settlement_days"),
+     _ec_body_contains("CdsHelperConventions.settlement_days is required")),
+    ("ec:400 cds index missing fixing_days", "cds",
+     "cds_request.json", 400,
+     _ec_del_index_field("fixing_days"),
+     _ec_body_contains("IndexDef.fixing_days")),
+    ("ec:400 cds index missing calendar", "cds",
+     "cds_request.json", 400,
+     _ec_del_index_field("calendar"),
+     _ec_body_contains("IndexDef.calendar")),
+    ("ec:400 cds index tenor missing period unit", "cds",
+     "cds_request.json", 400,
+     _ec_del_index_tenor_unit(),
+     _ec_body_contains("unit is required")),
+    ("ec:400 cds schedule missing end_of_month", "cds",
+     "cds_request.json", 400,
+     _ec_del_cds_schedule_field("end_of_month"),
+     _ec_body_contains("Schedule.end_of_month is required")),
     # ---- 400 INVALID_ARGUMENT: bond / yield convention presence ----
     # A bond or yield convention enum omitted from the request must be rejected,
     # not silently defaulted to the alphabetical-0 value.

--- a/tests/contract/ql_reference.py
+++ b/tests/contract/ql_reference.py
@@ -2920,6 +2920,7 @@ def _make_multicurve_exogenous_request() -> dict:
                     "calendar": "TARGET",
                     "business_day_convention": "Following",
                     "day_counter": "Actual360",
+                    "end_of_month": true,
                     "currency": "EUR",
                     "tenor": {
                         "n": 0,

--- a/tests/integration/test_server_client.cpp
+++ b/tests/integration/test_server_client.cpp
@@ -214,6 +214,7 @@ protected:
         idb.add_calendar(quantra::enums::Calendar_UnitedStatesGovernmentBond);
         idb.add_business_day_convention(quantra::enums::BusinessDayConvention_Following);
         idb.add_day_counter(quantra::enums::DayCounter_Actual360);
+        idb.add_end_of_month(true);
         idb.add_currency(ccy);
         return idb.Finish();
     }
@@ -512,6 +513,7 @@ TEST_F(ServerClientTest, VanillaSwap_RoundTrip) {
     fsb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     fsb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     fsb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    fsb.add_end_of_month(false);
     auto fixedSch = fsb.Finish();
     
     quantra::SwapFixedLegBuilder flb(b);
@@ -528,6 +530,7 @@ TEST_F(ServerClientTest, VanillaSwap_RoundTrip) {
     flsb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     flsb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     flsb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    flsb.add_end_of_month(false);
     auto floatSch = flsb.Finish();
     
     auto idx6m = buildIndexRef(b, "EUR_6M");
@@ -588,6 +591,7 @@ TEST_F(ServerClientTest, OisSwap_RoundTrip) {
     fsb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     fsb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     fsb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    fsb.add_end_of_month(false);
     auto fixedSch = fsb.Finish();
 
     quantra::SwapFixedLegBuilder fixedB(b);
@@ -606,6 +610,7 @@ TEST_F(ServerClientTest, OisSwap_RoundTrip) {
     osb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     osb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     osb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    osb.add_end_of_month(false);
     auto overnightSch = osb.Finish();
 
     auto sofr = buildIndexRef(b, "USD_SOFR");
@@ -674,6 +679,7 @@ TEST_F(ServerClientTest, BasisSwap_RoundTrip) {
     l1b.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     l1b.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     l1b.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    l1b.add_end_of_month(false);
     auto sch1 = l1b.Finish();
 
     quantra::ScheduleBuilder l2b(b);
@@ -684,6 +690,7 @@ TEST_F(ServerClientTest, BasisSwap_RoundTrip) {
     l2b.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     l2b.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     l2b.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    l2b.add_end_of_month(false);
     auto sch2 = l2b.Finish();
 
     auto eur3m = buildIndexRef(b, "EUR_3M");
@@ -797,6 +804,7 @@ TEST_F(ServerClientTest, CDS_RoundTrip) {
     sb.add_convention(quantra::enums::BusinessDayConvention_Following);
     sb.add_termination_date_convention(quantra::enums::BusinessDayConvention_Unadjusted);
     sb.add_date_generation_rule(quantra::enums::DateGenerationRule_TwentiethIMM);
+    sb.add_end_of_month(false);
     auto schedule = sb.Finish();
     
     quantra::CDSBuilder cdsb(b);
@@ -805,6 +813,11 @@ TEST_F(ServerClientTest, CDS_RoundTrip) {
     cdsb.add_schedule(schedule);
     cdsb.add_day_counter(quantra::enums::DayCounter_Actual360);
     cdsb.add_business_day_convention(quantra::enums::BusinessDayConvention_Following);
+    cdsb.add_settles_accrual(true);
+    cdsb.add_pays_at_default_time(true);
+    cdsb.add_rebates_accrual(true);
+    cdsb.add_last_period_day_counter(quantra::enums::DayCounter_Actual360);
+    cdsb.add_cash_settlement_days(3);
     auto cds = cdsb.Finish();
 
     auto dc = b.CreateString("discount");
@@ -1271,6 +1284,7 @@ TEST_F(ServerClientTest, PriceYearOnYearInflationSwap_RoundTrip) {
     fixedSb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     fixedSb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     fixedSb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    fixedSb.add_end_of_month(false);
     auto fixedSchedule = fixedSb.Finish();
 
     quantra::ScheduleBuilder yoySb(b);
@@ -1281,6 +1295,7 @@ TEST_F(ServerClientTest, PriceYearOnYearInflationSwap_RoundTrip) {
     yoySb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     yoySb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     yoySb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    yoySb.add_end_of_month(false);
     auto yoySchedule = yoySb.Finish();
 
     quantra::YearOnYearInflationSwapBuilder yyb(b);
@@ -1531,6 +1546,7 @@ TEST_F(ServerClientTest, Latency_MultipleRequests) {
         sb.add_convention(quantra::enums::BusinessDayConvention_Unadjusted);
         sb.add_termination_date_convention(quantra::enums::BusinessDayConvention_Unadjusted);
         sb.add_date_generation_rule(quantra::enums::DateGenerationRule_Backward);
+        sb.add_end_of_month(false);
         auto schedule = sb.Finish();
         
         auto idate = b.CreateString("2024-01-15");

--- a/tests/parity/basis_swap_test.cpp
+++ b/tests/parity/basis_swap_test.cpp
@@ -36,6 +36,7 @@ flatbuffers::Offset<quantra::Schedule> buildSchedule(
     sb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     sb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     sb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    sb.add_end_of_month(false);
     return sb.Finish();
 }
 

--- a/tests/parity/cap_floor_test.cpp
+++ b/tests/parity/cap_floor_test.cpp
@@ -50,6 +50,7 @@ TEST_F(QuantraComparisonTest, Cap_NPVMatches) {
     sb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     sb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     sb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    sb.add_end_of_month(false);
     auto schedule = sb.Finish();
     
     auto idx3m = buildIndexRef(b, "EUR_3M");
@@ -135,6 +136,7 @@ TEST_F(QuantraComparisonTest, Floor_NPVMatches) {
     sb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     sb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     sb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    sb.add_end_of_month(false);
     auto schedule = sb.Finish();
 
     auto idx3m = buildIndexRef(b, "EUR_3M");
@@ -216,6 +218,7 @@ TEST_F(QuantraComparisonTest, Cap_Bachelier_NormalVol) {
     sb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     sb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     sb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    sb.add_end_of_month(false);
     auto schedule = sb.Finish();
 
     auto idx3m = buildIndexRef(b, "EUR_3M");

--- a/tests/parity/cds_test.cpp
+++ b/tests/parity/cds_test.cpp
@@ -79,6 +79,7 @@ TEST_F(QuantraComparisonTest, CDS_NPVMatches) {
     sb.add_convention(quantra::enums::BusinessDayConvention_Following);
     sb.add_termination_date_convention(quantra::enums::BusinessDayConvention_Unadjusted);
     sb.add_date_generation_rule(quantra::enums::DateGenerationRule_TwentiethIMM);
+    sb.add_end_of_month(false);
     auto schedule = sb.Finish();
     
     quantra::CDSBuilder cdsb(b);
@@ -88,6 +89,11 @@ TEST_F(QuantraComparisonTest, CDS_NPVMatches) {
     cdsb.add_schedule(schedule);
     cdsb.add_day_counter(quantra::enums::DayCounter_Actual360);
     cdsb.add_business_day_convention(quantra::enums::BusinessDayConvention_Following);
+    cdsb.add_settles_accrual(true);
+    cdsb.add_pays_at_default_time(true);
+    cdsb.add_rebates_accrual(true);
+    cdsb.add_last_period_day_counter(quantra::enums::DayCounter_Actual360);
+    cdsb.add_cash_settlement_days(3);
     auto cds = cdsb.Finish();
 
     auto dc = b.CreateString("discount");
@@ -212,6 +218,7 @@ TEST_F(QuantraComparisonTest, CDS_Seller_NPVMatches) {
     sb.add_convention(quantra::enums::BusinessDayConvention_Following);
     sb.add_termination_date_convention(quantra::enums::BusinessDayConvention_Unadjusted);
     sb.add_date_generation_rule(quantra::enums::DateGenerationRule_TwentiethIMM);
+    sb.add_end_of_month(false);
     auto schedule = sb.Finish();
 
     quantra::CDSBuilder cdsb(b);
@@ -221,6 +228,11 @@ TEST_F(QuantraComparisonTest, CDS_Seller_NPVMatches) {
     cdsb.add_schedule(schedule);
     cdsb.add_day_counter(quantra::enums::DayCounter_Actual360);
     cdsb.add_business_day_convention(quantra::enums::BusinessDayConvention_Following);
+    cdsb.add_settles_accrual(true);
+    cdsb.add_pays_at_default_time(true);
+    cdsb.add_rebates_accrual(true);
+    cdsb.add_last_period_day_counter(quantra::enums::DayCounter_Actual360);
+    cdsb.add_cash_settlement_days(3);
     auto cds = cdsb.Finish();
 
     auto dc = b.CreateString("discount");
@@ -318,6 +330,7 @@ TEST_F(QuantraComparisonTest, CDS_Semiannual_LowRecovery) {
     sb.add_convention(quantra::enums::BusinessDayConvention_Following);
     sb.add_termination_date_convention(quantra::enums::BusinessDayConvention_Unadjusted);
     sb.add_date_generation_rule(quantra::enums::DateGenerationRule_TwentiethIMM);
+    sb.add_end_of_month(false);
     auto schedule = sb.Finish();
 
     quantra::CDSBuilder cdsb(b);
@@ -327,6 +340,11 @@ TEST_F(QuantraComparisonTest, CDS_Semiannual_LowRecovery) {
     cdsb.add_schedule(schedule);
     cdsb.add_day_counter(quantra::enums::DayCounter_Actual360);
     cdsb.add_business_day_convention(quantra::enums::BusinessDayConvention_Following);
+    cdsb.add_settles_accrual(true);
+    cdsb.add_pays_at_default_time(true);
+    cdsb.add_rebates_accrual(true);
+    cdsb.add_last_period_day_counter(quantra::enums::DayCounter_Actual360);
+    cdsb.add_cash_settlement_days(3);
     auto cds = cdsb.Finish();
 
     auto dc = b.CreateString("discount");

--- a/tests/parity/fixed_rate_bond_test.cpp
+++ b/tests/parity/fixed_rate_bond_test.cpp
@@ -119,6 +119,7 @@ TEST_F(QuantraComparisonTest, FixedRateBond_Semiannual_Thirty360_Details) {
     sb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     sb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     sb.add_date_generation_rule(quantra::enums::DateGenerationRule_Backward);
+    sb.add_end_of_month(false);
     auto schedule = sb.Finish();
 
     auto idate = b.CreateString("2024-07-15");
@@ -192,6 +193,7 @@ TEST_F(QuantraComparisonTest, FixedRateBond_Quarterly_NonParRedemption) {
     sb.add_convention(quantra::enums::BusinessDayConvention_Following);
     sb.add_termination_date_convention(quantra::enums::BusinessDayConvention_Following);
     sb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    sb.add_end_of_month(false);
     auto schedule = sb.Finish();
 
     auto idate = b.CreateString("2025-01-15");

--- a/tests/parity/floating_rate_bond_test.cpp
+++ b/tests/parity/floating_rate_bond_test.cpp
@@ -66,6 +66,7 @@ TEST_F(QuantraComparisonTest, FloatingRateBond_NPVMatches) {
     sb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     sb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     sb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    sb.add_end_of_month(false);
     auto schedule = sb.Finish();
 
     auto idate = b.CreateString("2025-01-17");
@@ -152,6 +153,7 @@ TEST_F(QuantraComparisonTest, FloatingRateBond_Annual_Thirty360_Details) {
     sb.add_convention(quantra::enums::BusinessDayConvention_Following);
     sb.add_termination_date_convention(quantra::enums::BusinessDayConvention_Following);
     sb.add_date_generation_rule(quantra::enums::DateGenerationRule_Backward);
+    sb.add_end_of_month(false);
     auto schedule = sb.Finish();
 
     auto idate = b.CreateString("2025-01-17");

--- a/tests/parity/helper_presence_test.cpp
+++ b/tests/parity/helper_presence_test.cpp
@@ -35,6 +35,7 @@ flatbuffers::Offset<quantra::Schedule> makeBondSchedule(
     sb.add_convention(quantra::enums::BusinessDayConvention_Unadjusted);
     sb.add_termination_date_convention(quantra::enums::BusinessDayConvention_Unadjusted);
     sb.add_date_generation_rule(quantra::enums::DateGenerationRule_Backward);
+    sb.add_end_of_month(false);
     return sb.Finish();
 }
 

--- a/tests/parity/ois_swap_test.cpp
+++ b/tests/parity/ois_swap_test.cpp
@@ -70,6 +70,7 @@ TEST_F(QuantraComparisonTest, OisSwap_NPVMatches) {
     fsb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     fsb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     fsb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    fsb.add_end_of_month(false);
     auto fixedSchOff = fsb.Finish();
 
     quantra::SwapFixedLegBuilder flb(b);
@@ -90,6 +91,7 @@ TEST_F(QuantraComparisonTest, OisSwap_NPVMatches) {
     osb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     osb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     osb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    osb.add_end_of_month(false);
     auto onSchOff = osb.Finish();
 
     auto sofrRef = buildIndexRef(b, "USD_SOFR");
@@ -183,6 +185,7 @@ TEST_F(QuantraComparisonTest, OisSwap_Receiver_Semiannual_SpreadLag) {
     fsb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     fsb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     fsb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    fsb.add_end_of_month(false);
     auto fixedSchOff = fsb.Finish();
 
     quantra::SwapFixedLegBuilder flb(b);
@@ -203,6 +206,7 @@ TEST_F(QuantraComparisonTest, OisSwap_Receiver_Semiannual_SpreadLag) {
     osb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     osb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     osb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    osb.add_end_of_month(false);
     auto onSchOff = osb.Finish();
 
     auto sofrRef = buildIndexRef(b, "USD_SOFR");

--- a/tests/parity/parity_fixture.h
+++ b/tests/parity/parity_fixture.h
@@ -188,6 +188,7 @@ protected:
         idb.add_calendar(quantra::enums::Calendar_UnitedStatesGovernmentBond);
         idb.add_business_day_convention(quantra::enums::BusinessDayConvention_Following);
         idb.add_day_counter(quantra::enums::DayCounter_Actual360);
+        idb.add_end_of_month(true);
         idb.add_currency(ccy);
         return idb.Finish();
     }

--- a/tests/parity/swaption_test.cpp
+++ b/tests/parity/swaption_test.cpp
@@ -55,6 +55,7 @@ TEST_F(QuantraComparisonTest, Swaption_NPVMatches) {
     fsb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     fsb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     fsb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    fsb.add_end_of_month(false);
     auto fixedSch = fsb.Finish();
     
     quantra::SwapFixedLegBuilder flb(b);
@@ -76,6 +77,7 @@ TEST_F(QuantraComparisonTest, Swaption_NPVMatches) {
     flsb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     flsb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     flsb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    flsb.add_end_of_month(false);
     auto floatSch = flsb.Finish();
     
     auto idx6m = buildIndexRef(b, "EUR_6M");
@@ -188,6 +190,7 @@ TEST_F(QuantraComparisonTest, Swaption_Bermudan_HullWhiteLattice_NPVMatches) {
     fsb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     fsb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     fsb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    fsb.add_end_of_month(false);
     auto fixedSch = fsb.Finish();
 
     quantra::SwapFixedLegBuilder flb(b);
@@ -209,6 +212,7 @@ TEST_F(QuantraComparisonTest, Swaption_Bermudan_HullWhiteLattice_NPVMatches) {
     flsb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     flsb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     flsb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    flsb.add_end_of_month(false);
     auto floatSch = flsb.Finish();
 
     auto idx6m = buildIndexRef(b, "EUR_6M");
@@ -305,6 +309,7 @@ TEST_F(QuantraComparisonTest, PriceSwaption_InlineCalibrate_MatchesEndpoint) {
         fsb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
         fsb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
         fsb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+        fsb.add_end_of_month(false);
         auto fixedSch = fsb.Finish();
 
         quantra::SwapFixedLegBuilder flb(b);
@@ -325,6 +330,7 @@ TEST_F(QuantraComparisonTest, PriceSwaption_InlineCalibrate_MatchesEndpoint) {
         flsb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
         flsb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
         flsb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+        flsb.add_end_of_month(false);
         auto floatSch = flsb.Finish();
 
         auto idx6m = buildIndexRef(b, "EUR_6M");
@@ -466,6 +472,7 @@ TEST_F(QuantraComparisonTest, PriceSwaption_InlineCalibrate_CachesPerModel) {
     fsb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     fsb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     fsb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    fsb.add_end_of_month(false);
     auto fixedSch = fsb.Finish();
 
     quantra::SwapFixedLegBuilder flb(b);
@@ -486,6 +493,7 @@ TEST_F(QuantraComparisonTest, PriceSwaption_InlineCalibrate_CachesPerModel) {
     flsb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     flsb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     flsb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    flsb.add_end_of_month(false);
     auto floatSch = flsb.Finish();
 
     auto idx6m = buildIndexRef(b, "EUR_6M");
@@ -603,6 +611,7 @@ TEST_F(QuantraComparisonTest, Swaption_ATMMatrix_NPVMatches) {
     fsb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     fsb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     fsb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    fsb.add_end_of_month(false);
     auto fixedSch = fsb.Finish();
 
     quantra::SwapFixedLegBuilder flb(b);
@@ -623,6 +632,7 @@ TEST_F(QuantraComparisonTest, Swaption_ATMMatrix_NPVMatches) {
     flsb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     flsb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     flsb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    flsb.add_end_of_month(false);
     auto floatSch = flsb.Finish();
 
     auto idx6m = buildIndexRef(b, "EUR_6M");
@@ -732,6 +742,7 @@ TEST_F(QuantraComparisonTest, Swaption_SmileCube_ConstantMatches) {
     fsb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     fsb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     fsb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    fsb.add_end_of_month(false);
     auto fixedSch = fsb.Finish();
 
     quantra::SwapFixedLegBuilder flb(b);
@@ -752,6 +763,7 @@ TEST_F(QuantraComparisonTest, Swaption_SmileCube_ConstantMatches) {
     flsb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     flsb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     flsb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    flsb.add_end_of_month(false);
     auto floatSch = flsb.Finish();
 
     auto idx6m = buildIndexRef(b, "EUR_6M");
@@ -848,6 +860,7 @@ TEST_F(QuantraComparisonTest, Swaption_SmileCube_IndexMismatchThrows) {
     fsb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     fsb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     fsb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    fsb.add_end_of_month(false);
     auto fixedSch = fsb.Finish();
 
     quantra::SwapFixedLegBuilder flb(b);
@@ -868,6 +881,7 @@ TEST_F(QuantraComparisonTest, Swaption_SmileCube_IndexMismatchThrows) {
     flsb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     flsb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     flsb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    flsb.add_end_of_month(false);
     auto floatSch = flsb.Finish();
 
     auto idx6m = buildIndexRef(b, "EUR_6M");
@@ -1162,6 +1176,7 @@ TEST_F(QuantraComparisonTest, Swaption_SabrParams_PriceWithBlackProducesFinitePo
     fsb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     fsb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     fsb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    fsb.add_end_of_month(false);
     auto fixedSch = fsb.Finish();
     quantra::SwapFixedLegBuilder flb(b);
     flb.add_notional(notional);
@@ -1181,6 +1196,7 @@ TEST_F(QuantraComparisonTest, Swaption_SabrParams_PriceWithBlackProducesFinitePo
     flsb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     flsb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     flsb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    flsb.add_end_of_month(false);
     auto floatSch = flsb.Finish();
     auto idx6m = buildIndexRef(b, "EUR_6M");
     quantra::SwapFloatingLegBuilder flgb(b);
@@ -1262,6 +1278,7 @@ TEST_F(QuantraComparisonTest, Swaption_SabrParams_BachelierEnginePairingRejected
     fsb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     fsb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     fsb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    fsb.add_end_of_month(false);
     auto fixedSch = fsb.Finish();
     quantra::SwapFixedLegBuilder flb(b);
     flb.add_notional(notional);
@@ -1281,6 +1298,7 @@ TEST_F(QuantraComparisonTest, Swaption_SabrParams_BachelierEnginePairingRejected
     flsb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     flsb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     flsb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    flsb.add_end_of_month(false);
     auto floatSch = flsb.Finish();
     auto idx6m = buildIndexRef(b, "EUR_6M");
     quantra::SwapFloatingLegBuilder flgb(b);
@@ -1773,6 +1791,7 @@ TEST_F(QuantraComparisonTest, Swaption_SabrCalibrate_PriceWithBlackEqualsParamsP
         fsb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
         fsb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
         fsb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+        fsb.add_end_of_month(false);
         auto fixedSch = fsb.Finish();
         quantra::SwapFixedLegBuilder flb(*b);
         flb.add_notional(notional);
@@ -1792,6 +1811,7 @@ TEST_F(QuantraComparisonTest, Swaption_SabrCalibrate_PriceWithBlackEqualsParamsP
         flsb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
         flsb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
         flsb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+        flsb.add_end_of_month(false);
         auto floatSch = flsb.Finish();
         auto idx6m = buildIndexRef(*b, "EUR_6M");
         quantra::SwapFloatingLegBuilder flgb(*b);
@@ -1894,6 +1914,7 @@ TEST_F(QuantraComparisonTest, Swaption_SabrCalibrate_BachelierEnginePairingRejec
     fsb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     fsb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     fsb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    fsb.add_end_of_month(false);
     auto fixedSch = fsb.Finish();
     quantra::SwapFixedLegBuilder flb(b);
     flb.add_notional(notional);
@@ -1913,6 +1934,7 @@ TEST_F(QuantraComparisonTest, Swaption_SabrCalibrate_BachelierEnginePairingRejec
     flsb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     flsb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     flsb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    flsb.add_end_of_month(false);
     auto floatSch = flsb.Finish();
     auto idx6m = buildIndexRef(b, "EUR_6M");
     quantra::SwapFloatingLegBuilder flgb(b);
@@ -2081,6 +2103,7 @@ TEST_F(QuantraComparisonTest, Swaption_Bachelier_NPVMatches) {
     fsb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     fsb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     fsb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    fsb.add_end_of_month(false);
     auto fixedSch = fsb.Finish();
 
     quantra::SwapFixedLegBuilder flb(b);
@@ -2102,6 +2125,7 @@ TEST_F(QuantraComparisonTest, Swaption_Bachelier_NPVMatches) {
     flsb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     flsb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     flsb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    flsb.add_end_of_month(false);
     auto floatSch = flsb.Finish();
 
     auto idx6m = buildIndexRef(b, "EUR_6M");
@@ -2334,6 +2358,7 @@ TEST_F(QuantraComparisonTest, Swaption_OIS_Bachelier_NPVMatches) {
     fsb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     fsb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     fsb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    fsb.add_end_of_month(false);
     auto fixedSch = fsb.Finish();
 
     quantra::SwapFixedLegBuilder flb(b);
@@ -2355,6 +2380,7 @@ TEST_F(QuantraComparisonTest, Swaption_OIS_Bachelier_NPVMatches) {
     osb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     osb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     osb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    osb.add_end_of_month(false);
     auto overnightSch = osb.Finish();
 
     auto idxRef = buildIndexRef(b, "USD_SOFR");
@@ -2466,6 +2492,7 @@ TEST_F(QuantraComparisonTest, Swaption_OIS_SmileCubeSpreadFromATM_UsesSwapIndexR
     fsb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     fsb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     fsb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    fsb.add_end_of_month(false);
     auto fixedSch = fsb.Finish();
 
     quantra::SwapFixedLegBuilder flb(b);
@@ -2486,6 +2513,7 @@ TEST_F(QuantraComparisonTest, Swaption_OIS_SmileCubeSpreadFromATM_UsesSwapIndexR
     osb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     osb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     osb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    osb.add_end_of_month(false);
     auto overnightSch = osb.Finish();
 
     auto idxRef = buildIndexRef(b, "USD_SOFR");

--- a/tests/parity/vanilla_swap_test.cpp
+++ b/tests/parity/vanilla_swap_test.cpp
@@ -43,6 +43,7 @@ TEST_F(QuantraComparisonTest, VanillaSwap_NPVMatches) {
     fsb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     fsb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     fsb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    fsb.add_end_of_month(false);
     auto fixedSch = fsb.Finish();
     
     quantra::SwapFixedLegBuilder flb(b);
@@ -64,6 +65,7 @@ TEST_F(QuantraComparisonTest, VanillaSwap_NPVMatches) {
     flsb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     flsb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     flsb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    flsb.add_end_of_month(false);
     auto floatSch = flsb.Finish();
     
     auto idx6m = buildIndexRef(b, "EUR_6M");
@@ -194,6 +196,7 @@ TEST_F(QuantraComparisonTest, VanillaSwap_CMS_NPVMatches) {
     fsb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     fsb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     fsb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    fsb.add_end_of_month(false);
     auto fixedSch = fsb.Finish();
 
     quantra::SwapFixedLegBuilder flb(b);
@@ -214,6 +217,7 @@ TEST_F(QuantraComparisonTest, VanillaSwap_CMS_NPVMatches) {
     cmsSb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     cmsSb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     cmsSb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    cmsSb.add_end_of_month(false);
     auto cmsSchOff = cmsSb.Finish();
 
     auto cmsTenor = buildPeriod(b, 5, quantra::enums::TimeUnit_Years);
@@ -282,6 +286,7 @@ TEST_F(QuantraComparisonTest, VanillaSwap_CMS_MissingVolThrows) {
     sb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     sb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     sb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    sb.add_end_of_month(false);
     auto sch = sb.Finish();
 
     quantra::SwapFixedLegBuilder flb(b);
@@ -353,6 +358,7 @@ TEST_F(QuantraComparisonTest, VanillaSwap_CMS_UnknownSwapIndexThrows) {
     sb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     sb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     sb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    sb.add_end_of_month(false);
     auto sch = sb.Finish();
 
     quantra::SwapFixedLegBuilder flb(b);
@@ -430,6 +436,7 @@ TEST_F(QuantraComparisonTest, CMSCoupons_PricerAttached) {
     sb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     sb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     sb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    sb.add_end_of_month(false);
     auto sch = sb.Finish();
 
     auto cmsTenor = buildPeriod(b, 5, quantra::enums::TimeUnit_Years);

--- a/tests/parity/year_on_year_inflation_swap_test.cpp
+++ b/tests/parity/year_on_year_inflation_swap_test.cpp
@@ -119,6 +119,7 @@ TEST_F(QuantraComparisonTest, PriceYearOnYearInflationSwap_MatchesQuantLib) {
     fixedSb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     fixedSb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     fixedSb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    fixedSb.add_end_of_month(false);
     auto fixedSchedule = fixedSb.Finish();
 
     quantra::ScheduleBuilder yoySb(b);
@@ -129,6 +130,7 @@ TEST_F(QuantraComparisonTest, PriceYearOnYearInflationSwap_MatchesQuantLib) {
     yoySb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     yoySb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     yoySb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    yoySb.add_end_of_month(false);
     auto yoySchedule = yoySb.Finish();
 
     quantra::YearOnYearInflationSwapBuilder yyb(b);
@@ -326,6 +328,7 @@ TEST_F(QuantraComparisonTest, PriceYearOnYearInflationSwap_Payer_3Y) {
     fixedSb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     fixedSb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     fixedSb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    fixedSb.add_end_of_month(false);
     auto fixedSchedule = fixedSb.Finish();
 
     quantra::ScheduleBuilder yoySb(b);
@@ -336,6 +339,7 @@ TEST_F(QuantraComparisonTest, PriceYearOnYearInflationSwap_Payer_3Y) {
     yoySb.add_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     yoySb.add_termination_date_convention(quantra::enums::BusinessDayConvention_ModifiedFollowing);
     yoySb.add_date_generation_rule(quantra::enums::DateGenerationRule_Forward);
+    yoySb.add_end_of_month(false);
     auto yoySchedule = yoySb.Finish();
 
     quantra::YearOnYearInflationSwapBuilder yyb(b);


### PR DESCRIPTION
**Market conventions are now explicit on every request** (0.5.0 batch). Convention fields that carried a hard default now must be stated — an omitted calendar, day counter, frequency, business-day convention, settlement/fixing days, recovery rate, end-of-month rule, `Period` unit, curve interpolator or CDS accrual flag returns a 400 naming the field instead of silently assuming a value. Legitimate conventions, but leaving them implicit let a client price against an assumption it never made.

- Covers the index, swap-index, curve-helper (OIS / dated-OIS / zero / discount / forward / fx-swap), inflation, credit-curve and schedule convention sets, plus `Period` unit/count.
- **Per-bool judgment:** mispricing-risk bools (`end_of_month`, inflation `interpolated`) and the CDS ISDA accrual flags are now required; genuine numerical/behavioral fields (`convexity_adjustment` = a real 0, `bootstrap_accuracy`, `allow_extrapolation`) are **left as-is** — they are not conventions.
- Presence flows through the curve cache key (added `writeOptInt`/`writeOptBool`/`writeTenor`) so an absent convention can no longer collide with a present one.

**132 example payloads** + the C++/Python builders migrated to state the prior defaults verbatim; **no priced result changed** (catalog in-sync, unchanged expected values). Seven error-contract scenarios. Full suite green (675 cases). Wire-breaking; part of 0.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
