### PR TITLE
Make inapplicable response fields absent and reject duplicate ids

### DIFF
--- a/flatbuffers/cpp/swaption_response_generated.h
+++ b/flatbuffers/cpp/swaption_response_generated.h
@@ -47,13 +47,13 @@ struct SwaptionResponseT : public ::flatbuffers::NativeTable {
   double used_cube_node_atm = 0.0;
   quantra::enums::SwaptionVolKind vol_kind = quantra::enums::SwaptionVolKind_Constant;
   quantra::enums::ModelParamMode used_model_param_mode = quantra::enums::ModelParamMode_Explicit;
-  double used_hw_a = -1.0;
-  double used_hw_sigma = -1.0;
-  double used_hw_rmse = -1.0;
-  int32_t used_hw_num_helpers = -1;
-  int32_t used_hw_grid_rows = -1;
-  int32_t used_hw_grid_cols = -1;
-  int32_t used_hw_grid_points = -1;
+  ::flatbuffers::Optional<double> used_hw_a = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<double> used_hw_sigma = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<double> used_hw_rmse = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<int32_t> used_hw_num_helpers = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<int32_t> used_hw_grid_rows = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<int32_t> used_hw_grid_cols = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<int32_t> used_hw_grid_points = ::flatbuffers::nullopt;
 };
 
 /// Swaption pricing response with NPV, Greeks, and diagnostics.
@@ -164,33 +164,33 @@ struct SwaptionResponse FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   quantra::enums::ModelParamMode used_model_param_mode() const {
     return static_cast<quantra::enums::ModelParamMode>(GetField<int8_t>(VT_USED_MODEL_PARAM_MODE, 0));
   }
-  /// Effective Hull-White mean reversion "a" used by pricing. -1.0 when model is not HullWhiteLattice.
-  double used_hw_a() const {
-    return GetField<double>(VT_USED_HW_A, -1.0);
+  /// Effective Hull-White mean reversion "a" used by pricing. Absent when model is not HullWhiteLattice.
+  ::flatbuffers::Optional<double> used_hw_a() const {
+    return GetOptional<double, double>(VT_USED_HW_A);
   }
-  /// Effective Hull-White sigma used by pricing. -1.0 when model is not HullWhiteLattice.
-  double used_hw_sigma() const {
-    return GetField<double>(VT_USED_HW_SIGMA, -1.0);
+  /// Effective Hull-White sigma used by pricing. Absent when model is not HullWhiteLattice.
+  ::flatbuffers::Optional<double> used_hw_sigma() const {
+    return GetOptional<double, double>(VT_USED_HW_SIGMA);
   }
-  /// Calibration RMSE for inline-calibrated Hull-White. -1.0 when no inline calibration.
-  double used_hw_rmse() const {
-    return GetField<double>(VT_USED_HW_RMSE, -1.0);
+  /// Calibration RMSE for inline-calibrated Hull-White. Absent when no inline calibration.
+  ::flatbuffers::Optional<double> used_hw_rmse() const {
+    return GetOptional<double, double>(VT_USED_HW_RMSE);
   }
-  /// Number of calibration helpers for inline-calibrated Hull-White. -1 when no inline calibration.
-  int32_t used_hw_num_helpers() const {
-    return GetField<int32_t>(VT_USED_HW_NUM_HELPERS, -1);
+  /// Number of calibration helpers for inline-calibrated Hull-White. Absent when no inline calibration.
+  ::flatbuffers::Optional<int32_t> used_hw_num_helpers() const {
+    return GetOptional<int32_t, int32_t>(VT_USED_HW_NUM_HELPERS);
   }
-  /// Calibration grid rows for inline-calibrated Hull-White. -1 when no inline calibration.
-  int32_t used_hw_grid_rows() const {
-    return GetField<int32_t>(VT_USED_HW_GRID_ROWS, -1);
+  /// Calibration grid rows for inline-calibrated Hull-White. Absent when no inline calibration.
+  ::flatbuffers::Optional<int32_t> used_hw_grid_rows() const {
+    return GetOptional<int32_t, int32_t>(VT_USED_HW_GRID_ROWS);
   }
-  /// Calibration grid columns for inline-calibrated Hull-White. -1 when no inline calibration.
-  int32_t used_hw_grid_cols() const {
-    return GetField<int32_t>(VT_USED_HW_GRID_COLS, -1);
+  /// Calibration grid columns for inline-calibrated Hull-White. Absent when no inline calibration.
+  ::flatbuffers::Optional<int32_t> used_hw_grid_cols() const {
+    return GetOptional<int32_t, int32_t>(VT_USED_HW_GRID_COLS);
   }
-  /// Calibration grid points for inline-calibrated Hull-White. -1 when no inline calibration.
-  int32_t used_hw_grid_points() const {
-    return GetField<int32_t>(VT_USED_HW_GRID_POINTS, -1);
+  /// Calibration grid points for inline-calibrated Hull-White. Absent when no inline calibration.
+  ::flatbuffers::Optional<int32_t> used_hw_grid_points() const {
+    return GetOptional<int32_t, int32_t>(VT_USED_HW_GRID_POINTS);
   }
   bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -291,25 +291,25 @@ struct SwaptionResponseBuilder {
     fbb_.AddElement<int8_t>(SwaptionResponse::VT_USED_MODEL_PARAM_MODE, static_cast<int8_t>(used_model_param_mode), 0);
   }
   void add_used_hw_a(double used_hw_a) {
-    fbb_.AddElement<double>(SwaptionResponse::VT_USED_HW_A, used_hw_a, -1.0);
+    fbb_.AddElement<double>(SwaptionResponse::VT_USED_HW_A, used_hw_a);
   }
   void add_used_hw_sigma(double used_hw_sigma) {
-    fbb_.AddElement<double>(SwaptionResponse::VT_USED_HW_SIGMA, used_hw_sigma, -1.0);
+    fbb_.AddElement<double>(SwaptionResponse::VT_USED_HW_SIGMA, used_hw_sigma);
   }
   void add_used_hw_rmse(double used_hw_rmse) {
-    fbb_.AddElement<double>(SwaptionResponse::VT_USED_HW_RMSE, used_hw_rmse, -1.0);
+    fbb_.AddElement<double>(SwaptionResponse::VT_USED_HW_RMSE, used_hw_rmse);
   }
   void add_used_hw_num_helpers(int32_t used_hw_num_helpers) {
-    fbb_.AddElement<int32_t>(SwaptionResponse::VT_USED_HW_NUM_HELPERS, used_hw_num_helpers, -1);
+    fbb_.AddElement<int32_t>(SwaptionResponse::VT_USED_HW_NUM_HELPERS, used_hw_num_helpers);
   }
   void add_used_hw_grid_rows(int32_t used_hw_grid_rows) {
-    fbb_.AddElement<int32_t>(SwaptionResponse::VT_USED_HW_GRID_ROWS, used_hw_grid_rows, -1);
+    fbb_.AddElement<int32_t>(SwaptionResponse::VT_USED_HW_GRID_ROWS, used_hw_grid_rows);
   }
   void add_used_hw_grid_cols(int32_t used_hw_grid_cols) {
-    fbb_.AddElement<int32_t>(SwaptionResponse::VT_USED_HW_GRID_COLS, used_hw_grid_cols, -1);
+    fbb_.AddElement<int32_t>(SwaptionResponse::VT_USED_HW_GRID_COLS, used_hw_grid_cols);
   }
   void add_used_hw_grid_points(int32_t used_hw_grid_points) {
-    fbb_.AddElement<int32_t>(SwaptionResponse::VT_USED_HW_GRID_POINTS, used_hw_grid_points, -1);
+    fbb_.AddElement<int32_t>(SwaptionResponse::VT_USED_HW_GRID_POINTS, used_hw_grid_points);
   }
   explicit SwaptionResponseBuilder(::flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
@@ -343,17 +343,17 @@ inline ::flatbuffers::Offset<SwaptionResponse> CreateSwaptionResponse(
     double used_cube_node_atm = 0.0,
     quantra::enums::SwaptionVolKind vol_kind = quantra::enums::SwaptionVolKind_Constant,
     quantra::enums::ModelParamMode used_model_param_mode = quantra::enums::ModelParamMode_Explicit,
-    double used_hw_a = -1.0,
-    double used_hw_sigma = -1.0,
-    double used_hw_rmse = -1.0,
-    int32_t used_hw_num_helpers = -1,
-    int32_t used_hw_grid_rows = -1,
-    int32_t used_hw_grid_cols = -1,
-    int32_t used_hw_grid_points = -1) {
+    ::flatbuffers::Optional<double> used_hw_a = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<double> used_hw_sigma = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<double> used_hw_rmse = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<int32_t> used_hw_num_helpers = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<int32_t> used_hw_grid_rows = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<int32_t> used_hw_grid_cols = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<int32_t> used_hw_grid_points = ::flatbuffers::nullopt) {
   SwaptionResponseBuilder builder_(_fbb);
-  builder_.add_used_hw_rmse(used_hw_rmse);
-  builder_.add_used_hw_sigma(used_hw_sigma);
-  builder_.add_used_hw_a(used_hw_a);
+  if(used_hw_rmse) { builder_.add_used_hw_rmse(*used_hw_rmse); }
+  if(used_hw_sigma) { builder_.add_used_hw_sigma(*used_hw_sigma); }
+  if(used_hw_a) { builder_.add_used_hw_a(*used_hw_a); }
   builder_.add_used_cube_node_atm(used_cube_node_atm);
   builder_.add_used_spread_from_atm(used_spread_from_atm);
   builder_.add_used_atm_forward(used_atm_forward);
@@ -368,10 +368,10 @@ inline ::flatbuffers::Offset<SwaptionResponse> CreateSwaptionResponse(
   builder_.add_atm_forward(atm_forward);
   builder_.add_implied_volatility(implied_volatility);
   builder_.add_npv(npv);
-  builder_.add_used_hw_grid_points(used_hw_grid_points);
-  builder_.add_used_hw_grid_cols(used_hw_grid_cols);
-  builder_.add_used_hw_grid_rows(used_hw_grid_rows);
-  builder_.add_used_hw_num_helpers(used_hw_num_helpers);
+  if(used_hw_grid_points) { builder_.add_used_hw_grid_points(*used_hw_grid_points); }
+  if(used_hw_grid_cols) { builder_.add_used_hw_grid_cols(*used_hw_grid_cols); }
+  if(used_hw_grid_rows) { builder_.add_used_hw_grid_rows(*used_hw_grid_rows); }
+  if(used_hw_num_helpers) { builder_.add_used_hw_num_helpers(*used_hw_num_helpers); }
   builder_.add_used_swap_tenor(used_swap_tenor);
   builder_.add_used_option_expiry(used_option_expiry);
   builder_.add_used_model_param_mode(used_model_param_mode);
@@ -401,13 +401,13 @@ inline ::flatbuffers::Offset<SwaptionResponse> CreateSwaptionResponseDirect(
     double used_cube_node_atm = 0.0,
     quantra::enums::SwaptionVolKind vol_kind = quantra::enums::SwaptionVolKind_Constant,
     quantra::enums::ModelParamMode used_model_param_mode = quantra::enums::ModelParamMode_Explicit,
-    double used_hw_a = -1.0,
-    double used_hw_sigma = -1.0,
-    double used_hw_rmse = -1.0,
-    int32_t used_hw_num_helpers = -1,
-    int32_t used_hw_grid_rows = -1,
-    int32_t used_hw_grid_cols = -1,
-    int32_t used_hw_grid_points = -1) {
+    ::flatbuffers::Optional<double> used_hw_a = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<double> used_hw_sigma = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<double> used_hw_rmse = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<int32_t> used_hw_num_helpers = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<int32_t> used_hw_grid_rows = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<int32_t> used_hw_grid_cols = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<int32_t> used_hw_grid_points = ::flatbuffers::nullopt) {
   auto used_option_expiry__ = used_option_expiry ? _fbb.CreateString(used_option_expiry) : 0;
   auto used_swap_tenor__ = used_swap_tenor ? _fbb.CreateString(used_swap_tenor) : 0;
   return quantra::CreateSwaptionResponse(

--- a/flatbuffers/cpp/vanilla_swap_response_generated.h
+++ b/flatbuffers/cpp/vanilla_swap_response_generated.h
@@ -46,8 +46,7 @@ struct SwapLegFlowT : public ::flatbuffers::NativeTable {
   double present_value = 0.0;
   std::string fixing_date{};
   double index_fixing = 0.0;
-  bool has_cms_swap_rate = false;
-  double cms_swap_rate = 0.0;
+  ::flatbuffers::Optional<double> cms_swap_rate = ::flatbuffers::nullopt;
   double spread = 0.0;
   double rate = 0.0;
 };
@@ -67,10 +66,9 @@ struct SwapLegFlow FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
     VT_PRESENT_VALUE = 18,
     VT_FIXING_DATE = 20,
     VT_INDEX_FIXING = 22,
-    VT_HAS_CMS_SWAP_RATE = 24,
-    VT_CMS_SWAP_RATE = 26,
-    VT_SPREAD = 28,
-    VT_RATE = 30
+    VT_CMS_SWAP_RATE = 24,
+    VT_SPREAD = 26,
+    VT_RATE = 28
   };
   const ::flatbuffers::String *payment_date() const {
     return GetPointer<const ::flatbuffers::String *>(VT_PAYMENT_DATE);
@@ -106,13 +104,9 @@ struct SwapLegFlow FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   double index_fixing() const {
     return GetField<double>(VT_INDEX_FIXING, 0.0);
   }
-  /// True when cms_swap_rate is populated for a CMS coupon.
-  bool has_cms_swap_rate() const {
-    return GetField<uint8_t>(VT_HAS_CMS_SWAP_RATE, 0) != 0;
-  }
-  /// CMS swap-rate fixing when has_cms_swap_rate is true.
-  double cms_swap_rate() const {
-    return GetField<double>(VT_CMS_SWAP_RATE, 0.0);
+  /// CMS swap-rate fixing for a CMS coupon. Absent for non-CMS coupons.
+  ::flatbuffers::Optional<double> cms_swap_rate() const {
+    return GetOptional<double, double>(VT_CMS_SWAP_RATE);
   }
   double spread() const {
     return GetField<double>(VT_SPREAD, 0.0);
@@ -137,7 +131,6 @@ struct SwapLegFlow FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
            VerifyOffset(verifier, VT_FIXING_DATE) &&
            verifier.VerifyString(fixing_date()) &&
            VerifyField<double>(verifier, VT_INDEX_FIXING, 8) &&
-           VerifyField<uint8_t>(verifier, VT_HAS_CMS_SWAP_RATE, 1) &&
            VerifyField<double>(verifier, VT_CMS_SWAP_RATE, 8) &&
            VerifyField<double>(verifier, VT_SPREAD, 8) &&
            VerifyField<double>(verifier, VT_RATE, 8) &&
@@ -182,11 +175,8 @@ struct SwapLegFlowBuilder {
   void add_index_fixing(double index_fixing) {
     fbb_.AddElement<double>(SwapLegFlow::VT_INDEX_FIXING, index_fixing, 0.0);
   }
-  void add_has_cms_swap_rate(bool has_cms_swap_rate) {
-    fbb_.AddElement<uint8_t>(SwapLegFlow::VT_HAS_CMS_SWAP_RATE, static_cast<uint8_t>(has_cms_swap_rate), 0);
-  }
   void add_cms_swap_rate(double cms_swap_rate) {
-    fbb_.AddElement<double>(SwapLegFlow::VT_CMS_SWAP_RATE, cms_swap_rate, 0.0);
+    fbb_.AddElement<double>(SwapLegFlow::VT_CMS_SWAP_RATE, cms_swap_rate);
   }
   void add_spread(double spread) {
     fbb_.AddElement<double>(SwapLegFlow::VT_SPREAD, spread, 0.0);
@@ -217,14 +207,13 @@ inline ::flatbuffers::Offset<SwapLegFlow> CreateSwapLegFlow(
     double present_value = 0.0,
     ::flatbuffers::Offset<::flatbuffers::String> fixing_date = 0,
     double index_fixing = 0.0,
-    bool has_cms_swap_rate = false,
-    double cms_swap_rate = 0.0,
+    ::flatbuffers::Optional<double> cms_swap_rate = ::flatbuffers::nullopt,
     double spread = 0.0,
     double rate = 0.0) {
   SwapLegFlowBuilder builder_(_fbb);
   builder_.add_rate(rate);
   builder_.add_spread(spread);
-  builder_.add_cms_swap_rate(cms_swap_rate);
+  if(cms_swap_rate) { builder_.add_cms_swap_rate(*cms_swap_rate); }
   builder_.add_index_fixing(index_fixing);
   builder_.add_present_value(present_value);
   builder_.add_discount(discount);
@@ -235,7 +224,6 @@ inline ::flatbuffers::Offset<SwapLegFlow> CreateSwapLegFlow(
   builder_.add_accrual_end_date(accrual_end_date);
   builder_.add_accrual_start_date(accrual_start_date);
   builder_.add_payment_date(payment_date);
-  builder_.add_has_cms_swap_rate(has_cms_swap_rate);
   return builder_.Finish();
 }
 
@@ -251,8 +239,7 @@ inline ::flatbuffers::Offset<SwapLegFlow> CreateSwapLegFlowDirect(
     double present_value = 0.0,
     const char *fixing_date = nullptr,
     double index_fixing = 0.0,
-    bool has_cms_swap_rate = false,
-    double cms_swap_rate = 0.0,
+    ::flatbuffers::Optional<double> cms_swap_rate = ::flatbuffers::nullopt,
     double spread = 0.0,
     double rate = 0.0) {
   auto payment_date__ = payment_date ? _fbb.CreateString(payment_date) : 0;
@@ -271,7 +258,6 @@ inline ::flatbuffers::Offset<SwapLegFlow> CreateSwapLegFlowDirect(
       present_value,
       fixing_date__,
       index_fixing,
-      has_cms_swap_rate,
       cms_swap_rate,
       spread,
       rate);
@@ -386,11 +372,11 @@ struct VanillaSwapResponseT : public ::flatbuffers::NativeTable {
   std::vector<std::unique_ptr<quantra::SwapLegFlowT>> floating_leg_flows{};
   quantra::enums::CmsPricerType used_cms_pricer_type = quantra::enums::CmsPricerType_LinearTsr;
   quantra::enums::CmsYieldCurveModel used_cms_yield_curve_model = quantra::enums::CmsYieldCurveModel_Standard;
-  double used_cms_mean_reversion = -1.0;
-  double used_cms_hagan_lower_limit = -1.0;
-  double used_cms_hagan_upper_limit = -1.0;
-  double used_cms_hagan_precision = -1.0;
-  double used_cms_hagan_hard_upper_limit = -1.0;
+  ::flatbuffers::Optional<double> used_cms_mean_reversion = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<double> used_cms_hagan_lower_limit = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<double> used_cms_hagan_upper_limit = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<double> used_cms_hagan_precision = ::flatbuffers::nullopt;
+  ::flatbuffers::Optional<double> used_cms_hagan_hard_upper_limit = ::flatbuffers::nullopt;
   VanillaSwapResponseT() = default;
   VanillaSwapResponseT(const VanillaSwapResponseT &o);
   VanillaSwapResponseT(VanillaSwapResponseT&&) FLATBUFFERS_NOEXCEPT = default;
@@ -455,25 +441,25 @@ struct VanillaSwapResponse FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Tabl
   quantra::enums::CmsYieldCurveModel used_cms_yield_curve_model() const {
     return static_cast<quantra::enums::CmsYieldCurveModel>(GetField<int8_t>(VT_USED_CMS_YIELD_CURVE_MODEL, 0));
   }
-  /// Effective CMS mean reversion used by pricer (-1.0 when no CMS leg).
-  double used_cms_mean_reversion() const {
-    return GetField<double>(VT_USED_CMS_MEAN_REVERSION, -1.0);
+  /// Effective CMS mean reversion used by pricer. Absent when no CMS leg.
+  ::flatbuffers::Optional<double> used_cms_mean_reversion() const {
+    return GetOptional<double, double>(VT_USED_CMS_MEAN_REVERSION);
   }
-  /// Effective Numeric Hagan lower integration limit (-1.0 when not applicable).
-  double used_cms_hagan_lower_limit() const {
-    return GetField<double>(VT_USED_CMS_HAGAN_LOWER_LIMIT, -1.0);
+  /// Effective Numeric Hagan lower integration limit. Absent when not applicable.
+  ::flatbuffers::Optional<double> used_cms_hagan_lower_limit() const {
+    return GetOptional<double, double>(VT_USED_CMS_HAGAN_LOWER_LIMIT);
   }
-  /// Effective Numeric Hagan upper integration limit (-1.0 when not applicable).
-  double used_cms_hagan_upper_limit() const {
-    return GetField<double>(VT_USED_CMS_HAGAN_UPPER_LIMIT, -1.0);
+  /// Effective Numeric Hagan upper integration limit. Absent when not applicable.
+  ::flatbuffers::Optional<double> used_cms_hagan_upper_limit() const {
+    return GetOptional<double, double>(VT_USED_CMS_HAGAN_UPPER_LIMIT);
   }
-  /// Effective Numeric Hagan integration precision (-1.0 when not applicable).
-  double used_cms_hagan_precision() const {
-    return GetField<double>(VT_USED_CMS_HAGAN_PRECISION, -1.0);
+  /// Effective Numeric Hagan integration precision. Absent when not applicable.
+  ::flatbuffers::Optional<double> used_cms_hagan_precision() const {
+    return GetOptional<double, double>(VT_USED_CMS_HAGAN_PRECISION);
   }
-  /// Effective Numeric Hagan hard upper integration limit (-1.0 when not applicable).
-  double used_cms_hagan_hard_upper_limit() const {
-    return GetField<double>(VT_USED_CMS_HAGAN_HARD_UPPER_LIMIT, -1.0);
+  /// Effective Numeric Hagan hard upper integration limit. Absent when not applicable.
+  ::flatbuffers::Optional<double> used_cms_hagan_hard_upper_limit() const {
+    return GetOptional<double, double>(VT_USED_CMS_HAGAN_HARD_UPPER_LIMIT);
   }
   bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -542,19 +528,19 @@ struct VanillaSwapResponseBuilder {
     fbb_.AddElement<int8_t>(VanillaSwapResponse::VT_USED_CMS_YIELD_CURVE_MODEL, static_cast<int8_t>(used_cms_yield_curve_model), 0);
   }
   void add_used_cms_mean_reversion(double used_cms_mean_reversion) {
-    fbb_.AddElement<double>(VanillaSwapResponse::VT_USED_CMS_MEAN_REVERSION, used_cms_mean_reversion, -1.0);
+    fbb_.AddElement<double>(VanillaSwapResponse::VT_USED_CMS_MEAN_REVERSION, used_cms_mean_reversion);
   }
   void add_used_cms_hagan_lower_limit(double used_cms_hagan_lower_limit) {
-    fbb_.AddElement<double>(VanillaSwapResponse::VT_USED_CMS_HAGAN_LOWER_LIMIT, used_cms_hagan_lower_limit, -1.0);
+    fbb_.AddElement<double>(VanillaSwapResponse::VT_USED_CMS_HAGAN_LOWER_LIMIT, used_cms_hagan_lower_limit);
   }
   void add_used_cms_hagan_upper_limit(double used_cms_hagan_upper_limit) {
-    fbb_.AddElement<double>(VanillaSwapResponse::VT_USED_CMS_HAGAN_UPPER_LIMIT, used_cms_hagan_upper_limit, -1.0);
+    fbb_.AddElement<double>(VanillaSwapResponse::VT_USED_CMS_HAGAN_UPPER_LIMIT, used_cms_hagan_upper_limit);
   }
   void add_used_cms_hagan_precision(double used_cms_hagan_precision) {
-    fbb_.AddElement<double>(VanillaSwapResponse::VT_USED_CMS_HAGAN_PRECISION, used_cms_hagan_precision, -1.0);
+    fbb_.AddElement<double>(VanillaSwapResponse::VT_USED_CMS_HAGAN_PRECISION, used_cms_hagan_precision);
   }
   void add_used_cms_hagan_hard_upper_limit(double used_cms_hagan_hard_upper_limit) {
-    fbb_.AddElement<double>(VanillaSwapResponse::VT_USED_CMS_HAGAN_HARD_UPPER_LIMIT, used_cms_hagan_hard_upper_limit, -1.0);
+    fbb_.AddElement<double>(VanillaSwapResponse::VT_USED_CMS_HAGAN_HARD_UPPER_LIMIT, used_cms_hagan_hard_upper_limit);
   }
   explicit VanillaSwapResponseBuilder(::flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
@@ -580,17 +566,17 @@ inline ::flatbuffers::Offset<VanillaSwapResponse> CreateVanillaSwapResponse(
     ::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<quantra::SwapLegFlow>>> floating_leg_flows = 0,
     quantra::enums::CmsPricerType used_cms_pricer_type = quantra::enums::CmsPricerType_LinearTsr,
     quantra::enums::CmsYieldCurveModel used_cms_yield_curve_model = quantra::enums::CmsYieldCurveModel_Standard,
-    double used_cms_mean_reversion = -1.0,
-    double used_cms_hagan_lower_limit = -1.0,
-    double used_cms_hagan_upper_limit = -1.0,
-    double used_cms_hagan_precision = -1.0,
-    double used_cms_hagan_hard_upper_limit = -1.0) {
+    ::flatbuffers::Optional<double> used_cms_mean_reversion = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<double> used_cms_hagan_lower_limit = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<double> used_cms_hagan_upper_limit = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<double> used_cms_hagan_precision = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<double> used_cms_hagan_hard_upper_limit = ::flatbuffers::nullopt) {
   VanillaSwapResponseBuilder builder_(_fbb);
-  builder_.add_used_cms_hagan_hard_upper_limit(used_cms_hagan_hard_upper_limit);
-  builder_.add_used_cms_hagan_precision(used_cms_hagan_precision);
-  builder_.add_used_cms_hagan_upper_limit(used_cms_hagan_upper_limit);
-  builder_.add_used_cms_hagan_lower_limit(used_cms_hagan_lower_limit);
-  builder_.add_used_cms_mean_reversion(used_cms_mean_reversion);
+  if(used_cms_hagan_hard_upper_limit) { builder_.add_used_cms_hagan_hard_upper_limit(*used_cms_hagan_hard_upper_limit); }
+  if(used_cms_hagan_precision) { builder_.add_used_cms_hagan_precision(*used_cms_hagan_precision); }
+  if(used_cms_hagan_upper_limit) { builder_.add_used_cms_hagan_upper_limit(*used_cms_hagan_upper_limit); }
+  if(used_cms_hagan_lower_limit) { builder_.add_used_cms_hagan_lower_limit(*used_cms_hagan_lower_limit); }
+  if(used_cms_mean_reversion) { builder_.add_used_cms_mean_reversion(*used_cms_mean_reversion); }
   builder_.add_floating_leg_npv(floating_leg_npv);
   builder_.add_fixed_leg_npv(fixed_leg_npv);
   builder_.add_floating_leg_bps(floating_leg_bps);
@@ -618,11 +604,11 @@ inline ::flatbuffers::Offset<VanillaSwapResponse> CreateVanillaSwapResponseDirec
     const std::vector<::flatbuffers::Offset<quantra::SwapLegFlow>> *floating_leg_flows = nullptr,
     quantra::enums::CmsPricerType used_cms_pricer_type = quantra::enums::CmsPricerType_LinearTsr,
     quantra::enums::CmsYieldCurveModel used_cms_yield_curve_model = quantra::enums::CmsYieldCurveModel_Standard,
-    double used_cms_mean_reversion = -1.0,
-    double used_cms_hagan_lower_limit = -1.0,
-    double used_cms_hagan_upper_limit = -1.0,
-    double used_cms_hagan_precision = -1.0,
-    double used_cms_hagan_hard_upper_limit = -1.0) {
+    ::flatbuffers::Optional<double> used_cms_mean_reversion = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<double> used_cms_hagan_lower_limit = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<double> used_cms_hagan_upper_limit = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<double> used_cms_hagan_precision = ::flatbuffers::nullopt,
+    ::flatbuffers::Optional<double> used_cms_hagan_hard_upper_limit = ::flatbuffers::nullopt) {
   auto fixed_leg_flows__ = fixed_leg_flows ? _fbb.CreateVector<::flatbuffers::Offset<quantra::SwapLegFlow>>(*fixed_leg_flows) : 0;
   auto floating_leg_flows__ = floating_leg_flows ? _fbb.CreateVector<::flatbuffers::Offset<quantra::SwapLegFlow>>(*floating_leg_flows) : 0;
   return quantra::CreateVanillaSwapResponse(
@@ -735,7 +721,6 @@ inline void SwapLegFlow::UnPackTo(SwapLegFlowT *_o, const ::flatbuffers::resolve
   { auto _e = present_value(); _o->present_value = _e; }
   { auto _e = fixing_date(); if (_e) _o->fixing_date = _e->str(); }
   { auto _e = index_fixing(); _o->index_fixing = _e; }
-  { auto _e = has_cms_swap_rate(); _o->has_cms_swap_rate = _e; }
   { auto _e = cms_swap_rate(); _o->cms_swap_rate = _e; }
   { auto _e = spread(); _o->spread = _e; }
   { auto _e = rate(); _o->rate = _e; }
@@ -759,7 +744,6 @@ inline ::flatbuffers::Offset<SwapLegFlow> CreateSwapLegFlow(::flatbuffers::FlatB
   auto _present_value = _o->present_value;
   auto _fixing_date = _o->fixing_date.empty() ? 0 : _fbb.CreateString(_o->fixing_date);
   auto _index_fixing = _o->index_fixing;
-  auto _has_cms_swap_rate = _o->has_cms_swap_rate;
   auto _cms_swap_rate = _o->cms_swap_rate;
   auto _spread = _o->spread;
   auto _rate = _o->rate;
@@ -775,7 +759,6 @@ inline ::flatbuffers::Offset<SwapLegFlow> CreateSwapLegFlow(::flatbuffers::FlatB
       _present_value,
       _fixing_date,
       _index_fixing,
-      _has_cms_swap_rate,
       _cms_swap_rate,
       _spread,
       _rate);

--- a/flatbuffers/fbs/swaption_response.fbs
+++ b/flatbuffers/fbs/swaption_response.fbs
@@ -43,20 +43,20 @@ table SwaptionResponse {
     vol_kind:enums.SwaptionVolKind;
     /// Effective model parameter mode used by the swaption engine.
     used_model_param_mode:enums.ModelParamMode = Explicit;
-    /// Effective Hull-White mean reversion "a" used by pricing. -1.0 when model is not HullWhiteLattice.
-    used_hw_a:double = -1.0;
-    /// Effective Hull-White sigma used by pricing. -1.0 when model is not HullWhiteLattice.
-    used_hw_sigma:double = -1.0;
-    /// Calibration RMSE for inline-calibrated Hull-White. -1.0 when no inline calibration.
-    used_hw_rmse:double = -1.0;
-    /// Number of calibration helpers for inline-calibrated Hull-White. -1 when no inline calibration.
-    used_hw_num_helpers:int = -1;
-    /// Calibration grid rows for inline-calibrated Hull-White. -1 when no inline calibration.
-    used_hw_grid_rows:int = -1;
-    /// Calibration grid columns for inline-calibrated Hull-White. -1 when no inline calibration.
-    used_hw_grid_cols:int = -1;
-    /// Calibration grid points for inline-calibrated Hull-White. -1 when no inline calibration.
-    used_hw_grid_points:int = -1;
+    /// Effective Hull-White mean reversion "a" used by pricing. Absent when model is not HullWhiteLattice.
+    used_hw_a:double = null;
+    /// Effective Hull-White sigma used by pricing. Absent when model is not HullWhiteLattice.
+    used_hw_sigma:double = null;
+    /// Calibration RMSE for inline-calibrated Hull-White. Absent when no inline calibration.
+    used_hw_rmse:double = null;
+    /// Number of calibration helpers for inline-calibrated Hull-White. Absent when no inline calibration.
+    used_hw_num_helpers:int = null;
+    /// Calibration grid rows for inline-calibrated Hull-White. Absent when no inline calibration.
+    used_hw_grid_rows:int = null;
+    /// Calibration grid columns for inline-calibrated Hull-White. Absent when no inline calibration.
+    used_hw_grid_cols:int = null;
+    /// Calibration grid points for inline-calibrated Hull-White. Absent when no inline calibration.
+    used_hw_grid_points:int = null;
 }
 
 /// Response wrapper for multiple swaptions.

--- a/flatbuffers/fbs/vanilla_swap_response.fbs
+++ b/flatbuffers/fbs/vanilla_swap_response.fbs
@@ -19,10 +19,8 @@ table SwapLegFlow {
     fixing_date:string;
     /// Underlying index fixing. For CMS coupons this is the CMS swap-rate fixing.
     index_fixing:double;
-    /// True when cms_swap_rate is populated for a CMS coupon.
-    has_cms_swap_rate:bool = false;
-    /// CMS swap-rate fixing when has_cms_swap_rate is true.
-    cms_swap_rate:double;
+    /// CMS swap-rate fixing for a CMS coupon. Absent for non-CMS coupons.
+    cms_swap_rate:double = null;
     spread:double;
     /// Coupon rate: fixed-leg rate or effective floating coupon rate.
     rate:double;
@@ -51,16 +49,16 @@ table VanillaSwapResponse {
     used_cms_pricer_type:enums.CmsPricerType = LinearTsr;
     /// Effective yield-curve model used by CMS Hagan-family pricers.
     used_cms_yield_curve_model:enums.CmsYieldCurveModel = Standard;
-    /// Effective CMS mean reversion used by pricer (-1.0 when no CMS leg).
-    used_cms_mean_reversion:double = -1.0;
-    /// Effective Numeric Hagan lower integration limit (-1.0 when not applicable).
-    used_cms_hagan_lower_limit:double = -1.0;
-    /// Effective Numeric Hagan upper integration limit (-1.0 when not applicable).
-    used_cms_hagan_upper_limit:double = -1.0;
-    /// Effective Numeric Hagan integration precision (-1.0 when not applicable).
-    used_cms_hagan_precision:double = -1.0;
-    /// Effective Numeric Hagan hard upper integration limit (-1.0 when not applicable).
-    used_cms_hagan_hard_upper_limit:double = -1.0;
+    /// Effective CMS mean reversion used by pricer. Absent when no CMS leg.
+    used_cms_mean_reversion:double = null;
+    /// Effective Numeric Hagan lower integration limit. Absent when not applicable.
+    used_cms_hagan_lower_limit:double = null;
+    /// Effective Numeric Hagan upper integration limit. Absent when not applicable.
+    used_cms_hagan_upper_limit:double = null;
+    /// Effective Numeric Hagan integration precision. Absent when not applicable.
+    used_cms_hagan_precision:double = null;
+    /// Effective Numeric Hagan hard upper integration limit. Absent when not applicable.
+    used_cms_hagan_hard_upper_limit:double = null;
 }
 
 /// Response wrapper for multiple vanilla swaps.

--- a/flatbuffers/json/basis_swap_response.schema.json
+++ b/flatbuffers/json/basis_swap_response.schema.json
@@ -336,13 +336,9 @@
                 "type" : "number",
                 "description" : "Underlying index fixing. For CMS coupons this is the CMS swap-rate fixing."
               },
-        "has_cms_swap_rate" : {
-                "type" : "boolean",
-                "description" : "True when cms_swap_rate is populated for a CMS coupon."
-              },
         "cms_swap_rate" : {
                 "type" : "number",
-                "description" : "CMS swap-rate fixing when has_cms_swap_rate is true."
+                "description" : "CMS swap-rate fixing for a CMS coupon. Absent for non-CMS coupons."
               },
         "spread" : {
                 "type" : "number"
@@ -412,23 +408,23 @@
               },
         "used_cms_mean_reversion" : {
                 "type" : "number",
-                "description" : "Effective CMS mean reversion used by pricer (-1.0 when no CMS leg)."
+                "description" : "Effective CMS mean reversion used by pricer. Absent when no CMS leg."
               },
         "used_cms_hagan_lower_limit" : {
                 "type" : "number",
-                "description" : "Effective Numeric Hagan lower integration limit (-1.0 when not applicable)."
+                "description" : "Effective Numeric Hagan lower integration limit. Absent when not applicable."
               },
         "used_cms_hagan_upper_limit" : {
                 "type" : "number",
-                "description" : "Effective Numeric Hagan upper integration limit (-1.0 when not applicable)."
+                "description" : "Effective Numeric Hagan upper integration limit. Absent when not applicable."
               },
         "used_cms_hagan_precision" : {
                 "type" : "number",
-                "description" : "Effective Numeric Hagan integration precision (-1.0 when not applicable)."
+                "description" : "Effective Numeric Hagan integration precision. Absent when not applicable."
               },
         "used_cms_hagan_hard_upper_limit" : {
                 "type" : "number",
-                "description" : "Effective Numeric Hagan hard upper integration limit (-1.0 when not applicable)."
+                "description" : "Effective Numeric Hagan hard upper integration limit. Absent when not applicable."
               }
       },
       "additionalProperties" : false

--- a/flatbuffers/json/ois_swap_response.schema.json
+++ b/flatbuffers/json/ois_swap_response.schema.json
@@ -336,13 +336,9 @@
                 "type" : "number",
                 "description" : "Underlying index fixing. For CMS coupons this is the CMS swap-rate fixing."
               },
-        "has_cms_swap_rate" : {
-                "type" : "boolean",
-                "description" : "True when cms_swap_rate is populated for a CMS coupon."
-              },
         "cms_swap_rate" : {
                 "type" : "number",
-                "description" : "CMS swap-rate fixing when has_cms_swap_rate is true."
+                "description" : "CMS swap-rate fixing for a CMS coupon. Absent for non-CMS coupons."
               },
         "spread" : {
                 "type" : "number"
@@ -412,23 +408,23 @@
               },
         "used_cms_mean_reversion" : {
                 "type" : "number",
-                "description" : "Effective CMS mean reversion used by pricer (-1.0 when no CMS leg)."
+                "description" : "Effective CMS mean reversion used by pricer. Absent when no CMS leg."
               },
         "used_cms_hagan_lower_limit" : {
                 "type" : "number",
-                "description" : "Effective Numeric Hagan lower integration limit (-1.0 when not applicable)."
+                "description" : "Effective Numeric Hagan lower integration limit. Absent when not applicable."
               },
         "used_cms_hagan_upper_limit" : {
                 "type" : "number",
-                "description" : "Effective Numeric Hagan upper integration limit (-1.0 when not applicable)."
+                "description" : "Effective Numeric Hagan upper integration limit. Absent when not applicable."
               },
         "used_cms_hagan_precision" : {
                 "type" : "number",
-                "description" : "Effective Numeric Hagan integration precision (-1.0 when not applicable)."
+                "description" : "Effective Numeric Hagan integration precision. Absent when not applicable."
               },
         "used_cms_hagan_hard_upper_limit" : {
                 "type" : "number",
-                "description" : "Effective Numeric Hagan hard upper integration limit (-1.0 when not applicable)."
+                "description" : "Effective Numeric Hagan hard upper integration limit. Absent when not applicable."
               }
       },
       "additionalProperties" : false

--- a/flatbuffers/json/swaption_response.schema.json
+++ b/flatbuffers/json/swaption_response.schema.json
@@ -477,31 +477,31 @@
               },
         "used_hw_a" : {
                 "type" : "number",
-                "description" : "Effective Hull-White mean reversion \"a\" used by pricing. -1.0 when model is not HullWhiteLattice."
+                "description" : "Effective Hull-White mean reversion \"a\" used by pricing. Absent when model is not HullWhiteLattice."
               },
         "used_hw_sigma" : {
                 "type" : "number",
-                "description" : "Effective Hull-White sigma used by pricing. -1.0 when model is not HullWhiteLattice."
+                "description" : "Effective Hull-White sigma used by pricing. Absent when model is not HullWhiteLattice."
               },
         "used_hw_rmse" : {
                 "type" : "number",
-                "description" : "Calibration RMSE for inline-calibrated Hull-White. -1.0 when no inline calibration."
+                "description" : "Calibration RMSE for inline-calibrated Hull-White. Absent when no inline calibration."
               },
         "used_hw_num_helpers" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647,
-                "description" : "Number of calibration helpers for inline-calibrated Hull-White. -1 when no inline calibration."
+                "description" : "Number of calibration helpers for inline-calibrated Hull-White. Absent when no inline calibration."
               },
         "used_hw_grid_rows" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647,
-                "description" : "Calibration grid rows for inline-calibrated Hull-White. -1 when no inline calibration."
+                "description" : "Calibration grid rows for inline-calibrated Hull-White. Absent when no inline calibration."
               },
         "used_hw_grid_cols" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647,
-                "description" : "Calibration grid columns for inline-calibrated Hull-White. -1 when no inline calibration."
+                "description" : "Calibration grid columns for inline-calibrated Hull-White. Absent when no inline calibration."
               },
         "used_hw_grid_points" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647,
-                "description" : "Calibration grid points for inline-calibrated Hull-White. -1 when no inline calibration."
+                "description" : "Calibration grid points for inline-calibrated Hull-White. Absent when no inline calibration."
               }
       },
       "additionalProperties" : false

--- a/flatbuffers/json/vanilla_swap_response.schema.json
+++ b/flatbuffers/json/vanilla_swap_response.schema.json
@@ -336,13 +336,9 @@
                 "type" : "number",
                 "description" : "Underlying index fixing. For CMS coupons this is the CMS swap-rate fixing."
               },
-        "has_cms_swap_rate" : {
-                "type" : "boolean",
-                "description" : "True when cms_swap_rate is populated for a CMS coupon."
-              },
         "cms_swap_rate" : {
                 "type" : "number",
-                "description" : "CMS swap-rate fixing when has_cms_swap_rate is true."
+                "description" : "CMS swap-rate fixing for a CMS coupon. Absent for non-CMS coupons."
               },
         "spread" : {
                 "type" : "number"
@@ -412,23 +408,23 @@
               },
         "used_cms_mean_reversion" : {
                 "type" : "number",
-                "description" : "Effective CMS mean reversion used by pricer (-1.0 when no CMS leg)."
+                "description" : "Effective CMS mean reversion used by pricer. Absent when no CMS leg."
               },
         "used_cms_hagan_lower_limit" : {
                 "type" : "number",
-                "description" : "Effective Numeric Hagan lower integration limit (-1.0 when not applicable)."
+                "description" : "Effective Numeric Hagan lower integration limit. Absent when not applicable."
               },
         "used_cms_hagan_upper_limit" : {
                 "type" : "number",
-                "description" : "Effective Numeric Hagan upper integration limit (-1.0 when not applicable)."
+                "description" : "Effective Numeric Hagan upper integration limit. Absent when not applicable."
               },
         "used_cms_hagan_precision" : {
                 "type" : "number",
-                "description" : "Effective Numeric Hagan integration precision (-1.0 when not applicable)."
+                "description" : "Effective Numeric Hagan integration precision. Absent when not applicable."
               },
         "used_cms_hagan_hard_upper_limit" : {
                 "type" : "number",
-                "description" : "Effective Numeric Hagan hard upper integration limit (-1.0 when not applicable)."
+                "description" : "Effective Numeric Hagan hard upper integration limit. Absent when not applicable."
               }
       },
       "additionalProperties" : false

--- a/flatbuffers/json/year_on_year_inflation_swap_response.schema.json
+++ b/flatbuffers/json/year_on_year_inflation_swap_response.schema.json
@@ -336,13 +336,9 @@
                 "type" : "number",
                 "description" : "Underlying index fixing. For CMS coupons this is the CMS swap-rate fixing."
               },
-        "has_cms_swap_rate" : {
-                "type" : "boolean",
-                "description" : "True when cms_swap_rate is populated for a CMS coupon."
-              },
         "cms_swap_rate" : {
                 "type" : "number",
-                "description" : "CMS swap-rate fixing when has_cms_swap_rate is true."
+                "description" : "CMS swap-rate fixing for a CMS coupon. Absent for non-CMS coupons."
               },
         "spread" : {
                 "type" : "number"
@@ -412,23 +408,23 @@
               },
         "used_cms_mean_reversion" : {
                 "type" : "number",
-                "description" : "Effective CMS mean reversion used by pricer (-1.0 when no CMS leg)."
+                "description" : "Effective CMS mean reversion used by pricer. Absent when no CMS leg."
               },
         "used_cms_hagan_lower_limit" : {
                 "type" : "number",
-                "description" : "Effective Numeric Hagan lower integration limit (-1.0 when not applicable)."
+                "description" : "Effective Numeric Hagan lower integration limit. Absent when not applicable."
               },
         "used_cms_hagan_upper_limit" : {
                 "type" : "number",
-                "description" : "Effective Numeric Hagan upper integration limit (-1.0 when not applicable)."
+                "description" : "Effective Numeric Hagan upper integration limit. Absent when not applicable."
               },
         "used_cms_hagan_precision" : {
                 "type" : "number",
-                "description" : "Effective Numeric Hagan integration precision (-1.0 when not applicable)."
+                "description" : "Effective Numeric Hagan integration precision. Absent when not applicable."
               },
         "used_cms_hagan_hard_upper_limit" : {
                 "type" : "number",
-                "description" : "Effective Numeric Hagan hard upper integration limit (-1.0 when not applicable)."
+                "description" : "Effective Numeric Hagan hard upper integration limit. Absent when not applicable."
               }
       },
       "additionalProperties" : false

--- a/flatbuffers/json/zero_coupon_inflation_swap_response.schema.json
+++ b/flatbuffers/json/zero_coupon_inflation_swap_response.schema.json
@@ -336,13 +336,9 @@
                 "type" : "number",
                 "description" : "Underlying index fixing. For CMS coupons this is the CMS swap-rate fixing."
               },
-        "has_cms_swap_rate" : {
-                "type" : "boolean",
-                "description" : "True when cms_swap_rate is populated for a CMS coupon."
-              },
         "cms_swap_rate" : {
                 "type" : "number",
-                "description" : "CMS swap-rate fixing when has_cms_swap_rate is true."
+                "description" : "CMS swap-rate fixing for a CMS coupon. Absent for non-CMS coupons."
               },
         "spread" : {
                 "type" : "number"
@@ -412,23 +408,23 @@
               },
         "used_cms_mean_reversion" : {
                 "type" : "number",
-                "description" : "Effective CMS mean reversion used by pricer (-1.0 when no CMS leg)."
+                "description" : "Effective CMS mean reversion used by pricer. Absent when no CMS leg."
               },
         "used_cms_hagan_lower_limit" : {
                 "type" : "number",
-                "description" : "Effective Numeric Hagan lower integration limit (-1.0 when not applicable)."
+                "description" : "Effective Numeric Hagan lower integration limit. Absent when not applicable."
               },
         "used_cms_hagan_upper_limit" : {
                 "type" : "number",
-                "description" : "Effective Numeric Hagan upper integration limit (-1.0 when not applicable)."
+                "description" : "Effective Numeric Hagan upper integration limit. Absent when not applicable."
               },
         "used_cms_hagan_precision" : {
                 "type" : "number",
-                "description" : "Effective Numeric Hagan integration precision (-1.0 when not applicable)."
+                "description" : "Effective Numeric Hagan integration precision. Absent when not applicable."
               },
         "used_cms_hagan_hard_upper_limit" : {
                 "type" : "number",
-                "description" : "Effective Numeric Hagan hard upper integration limit (-1.0 when not applicable)."
+                "description" : "Effective Numeric Hagan hard upper integration limit. Absent when not applicable."
               }
       },
       "additionalProperties" : false

--- a/flatbuffers/python/quantra/SwapLegFlow.py
+++ b/flatbuffers/python/quantra/SwapLegFlow.py
@@ -99,25 +99,17 @@ class SwapLegFlow(object):
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
         return 0.0
 
-    # True when cms_swap_rate is populated for a CMS coupon.
-    # SwapLegFlow
-    def HasCmsSwapRate(self):
-        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(24))
-        if o != 0:
-            return bool(self._tab.Get(flatbuffers.number_types.BoolFlags, o + self._tab.Pos))
-        return False
-
-    # CMS swap-rate fixing when has_cms_swap_rate is true.
+    # CMS swap-rate fixing for a CMS coupon. Absent for non-CMS coupons.
     # SwapLegFlow
     def CmsSwapRate(self):
-        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(26))
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(24))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return 0.0
+        return None
 
     # SwapLegFlow
     def Spread(self):
-        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(28))
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(26))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
         return 0.0
@@ -125,13 +117,13 @@ class SwapLegFlow(object):
     # Coupon rate: fixed-leg rate or effective floating coupon rate.
     # SwapLegFlow
     def Rate(self):
-        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(30))
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(28))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
         return 0.0
 
 def SwapLegFlowStart(builder):
-    builder.StartObject(14)
+    builder.StartObject(13)
 
 def Start(builder):
     SwapLegFlowStart(builder)
@@ -196,26 +188,20 @@ def SwapLegFlowAddIndexFixing(builder, indexFixing):
 def AddIndexFixing(builder, indexFixing):
     SwapLegFlowAddIndexFixing(builder, indexFixing)
 
-def SwapLegFlowAddHasCmsSwapRate(builder, hasCmsSwapRate):
-    builder.PrependBoolSlot(10, hasCmsSwapRate, 0)
-
-def AddHasCmsSwapRate(builder, hasCmsSwapRate):
-    SwapLegFlowAddHasCmsSwapRate(builder, hasCmsSwapRate)
-
 def SwapLegFlowAddCmsSwapRate(builder, cmsSwapRate):
-    builder.PrependFloat64Slot(11, cmsSwapRate, 0.0)
+    builder.PrependFloat64Slot(10, cmsSwapRate, None)
 
 def AddCmsSwapRate(builder, cmsSwapRate):
     SwapLegFlowAddCmsSwapRate(builder, cmsSwapRate)
 
 def SwapLegFlowAddSpread(builder, spread):
-    builder.PrependFloat64Slot(12, spread, 0.0)
+    builder.PrependFloat64Slot(11, spread, 0.0)
 
 def AddSpread(builder, spread):
     SwapLegFlowAddSpread(builder, spread)
 
 def SwapLegFlowAddRate(builder, rate):
-    builder.PrependFloat64Slot(13, rate, 0.0)
+    builder.PrependFloat64Slot(12, rate, 0.0)
 
 def AddRate(builder, rate):
     SwapLegFlowAddRate(builder, rate)
@@ -241,8 +227,7 @@ class SwapLegFlowT(object):
         self.presentValue = 0.0  # type: float
         self.fixingDate = None  # type: str
         self.indexFixing = 0.0  # type: float
-        self.hasCmsSwapRate = False  # type: bool
-        self.cmsSwapRate = 0.0  # type: float
+        self.cmsSwapRate = None  # type: Optional[float]
         self.spread = 0.0  # type: float
         self.rate = 0.0  # type: float
 
@@ -277,7 +262,6 @@ class SwapLegFlowT(object):
         self.presentValue = swapLegFlow.PresentValue()
         self.fixingDate = swapLegFlow.FixingDate()
         self.indexFixing = swapLegFlow.IndexFixing()
-        self.hasCmsSwapRate = swapLegFlow.HasCmsSwapRate()
         self.cmsSwapRate = swapLegFlow.CmsSwapRate()
         self.spread = swapLegFlow.Spread()
         self.rate = swapLegFlow.Rate()
@@ -307,7 +291,6 @@ class SwapLegFlowT(object):
         if self.fixingDate is not None:
             SwapLegFlowAddFixingDate(builder, fixingDate)
         SwapLegFlowAddIndexFixing(builder, self.indexFixing)
-        SwapLegFlowAddHasCmsSwapRate(builder, self.hasCmsSwapRate)
         SwapLegFlowAddCmsSwapRate(builder, self.cmsSwapRate)
         SwapLegFlowAddSpread(builder, self.spread)
         SwapLegFlowAddRate(builder, self.rate)

--- a/flatbuffers/python/quantra/SwaptionResponse.py
+++ b/flatbuffers/python/quantra/SwaptionResponse.py
@@ -177,61 +177,61 @@ class SwaptionResponse(object):
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
         return 0
 
-    # Effective Hull-White mean reversion "a" used by pricing. -1.0 when model is not HullWhiteLattice.
+    # Effective Hull-White mean reversion "a" used by pricing. Absent when model is not HullWhiteLattice.
     # SwaptionResponse
     def UsedHwA(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(42))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return -1.0
+        return None
 
-    # Effective Hull-White sigma used by pricing. -1.0 when model is not HullWhiteLattice.
+    # Effective Hull-White sigma used by pricing. Absent when model is not HullWhiteLattice.
     # SwaptionResponse
     def UsedHwSigma(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(44))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return -1.0
+        return None
 
-    # Calibration RMSE for inline-calibrated Hull-White. -1.0 when no inline calibration.
+    # Calibration RMSE for inline-calibrated Hull-White. Absent when no inline calibration.
     # SwaptionResponse
     def UsedHwRmse(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(46))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return -1.0
+        return None
 
-    # Number of calibration helpers for inline-calibrated Hull-White. -1 when no inline calibration.
+    # Number of calibration helpers for inline-calibrated Hull-White. Absent when no inline calibration.
     # SwaptionResponse
     def UsedHwNumHelpers(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(48))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int32Flags, o + self._tab.Pos)
-        return -1
+        return None
 
-    # Calibration grid rows for inline-calibrated Hull-White. -1 when no inline calibration.
+    # Calibration grid rows for inline-calibrated Hull-White. Absent when no inline calibration.
     # SwaptionResponse
     def UsedHwGridRows(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(50))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int32Flags, o + self._tab.Pos)
-        return -1
+        return None
 
-    # Calibration grid columns for inline-calibrated Hull-White. -1 when no inline calibration.
+    # Calibration grid columns for inline-calibrated Hull-White. Absent when no inline calibration.
     # SwaptionResponse
     def UsedHwGridCols(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(52))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int32Flags, o + self._tab.Pos)
-        return -1
+        return None
 
-    # Calibration grid points for inline-calibrated Hull-White. -1 when no inline calibration.
+    # Calibration grid points for inline-calibrated Hull-White. Absent when no inline calibration.
     # SwaptionResponse
     def UsedHwGridPoints(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(54))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int32Flags, o + self._tab.Pos)
-        return -1
+        return None
 
 def SwaptionResponseStart(builder):
     builder.StartObject(26)
@@ -354,43 +354,43 @@ def AddUsedModelParamMode(builder, usedModelParamMode):
     SwaptionResponseAddUsedModelParamMode(builder, usedModelParamMode)
 
 def SwaptionResponseAddUsedHwA(builder, usedHwA):
-    builder.PrependFloat64Slot(19, usedHwA, -1.0)
+    builder.PrependFloat64Slot(19, usedHwA, None)
 
 def AddUsedHwA(builder, usedHwA):
     SwaptionResponseAddUsedHwA(builder, usedHwA)
 
 def SwaptionResponseAddUsedHwSigma(builder, usedHwSigma):
-    builder.PrependFloat64Slot(20, usedHwSigma, -1.0)
+    builder.PrependFloat64Slot(20, usedHwSigma, None)
 
 def AddUsedHwSigma(builder, usedHwSigma):
     SwaptionResponseAddUsedHwSigma(builder, usedHwSigma)
 
 def SwaptionResponseAddUsedHwRmse(builder, usedHwRmse):
-    builder.PrependFloat64Slot(21, usedHwRmse, -1.0)
+    builder.PrependFloat64Slot(21, usedHwRmse, None)
 
 def AddUsedHwRmse(builder, usedHwRmse):
     SwaptionResponseAddUsedHwRmse(builder, usedHwRmse)
 
 def SwaptionResponseAddUsedHwNumHelpers(builder, usedHwNumHelpers):
-    builder.PrependInt32Slot(22, usedHwNumHelpers, -1)
+    builder.PrependInt32Slot(22, usedHwNumHelpers, None)
 
 def AddUsedHwNumHelpers(builder, usedHwNumHelpers):
     SwaptionResponseAddUsedHwNumHelpers(builder, usedHwNumHelpers)
 
 def SwaptionResponseAddUsedHwGridRows(builder, usedHwGridRows):
-    builder.PrependInt32Slot(23, usedHwGridRows, -1)
+    builder.PrependInt32Slot(23, usedHwGridRows, None)
 
 def AddUsedHwGridRows(builder, usedHwGridRows):
     SwaptionResponseAddUsedHwGridRows(builder, usedHwGridRows)
 
 def SwaptionResponseAddUsedHwGridCols(builder, usedHwGridCols):
-    builder.PrependInt32Slot(24, usedHwGridCols, -1)
+    builder.PrependInt32Slot(24, usedHwGridCols, None)
 
 def AddUsedHwGridCols(builder, usedHwGridCols):
     SwaptionResponseAddUsedHwGridCols(builder, usedHwGridCols)
 
 def SwaptionResponseAddUsedHwGridPoints(builder, usedHwGridPoints):
-    builder.PrependInt32Slot(25, usedHwGridPoints, -1)
+    builder.PrependInt32Slot(25, usedHwGridPoints, None)
 
 def AddUsedHwGridPoints(builder, usedHwGridPoints):
     SwaptionResponseAddUsedHwGridPoints(builder, usedHwGridPoints)
@@ -425,13 +425,13 @@ class SwaptionResponseT(object):
         self.usedCubeNodeAtm = 0.0  # type: float
         self.volKind = 0  # type: int
         self.usedModelParamMode = 0  # type: int
-        self.usedHwA = -1.0  # type: float
-        self.usedHwSigma = -1.0  # type: float
-        self.usedHwRmse = -1.0  # type: float
-        self.usedHwNumHelpers = -1  # type: int
-        self.usedHwGridRows = -1  # type: int
-        self.usedHwGridCols = -1  # type: int
-        self.usedHwGridPoints = -1  # type: int
+        self.usedHwA = None  # type: Optional[float]
+        self.usedHwSigma = None  # type: Optional[float]
+        self.usedHwRmse = None  # type: Optional[float]
+        self.usedHwNumHelpers = None  # type: Optional[int]
+        self.usedHwGridRows = None  # type: Optional[int]
+        self.usedHwGridCols = None  # type: Optional[int]
+        self.usedHwGridPoints = None  # type: Optional[int]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):

--- a/flatbuffers/python/quantra/VanillaSwapResponse.py
+++ b/flatbuffers/python/quantra/VanillaSwapResponse.py
@@ -140,45 +140,45 @@ class VanillaSwapResponse(object):
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
         return 0
 
-    # Effective CMS mean reversion used by pricer (-1.0 when no CMS leg).
+    # Effective CMS mean reversion used by pricer. Absent when no CMS leg.
     # VanillaSwapResponse
     def UsedCmsMeanReversion(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(26))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return -1.0
+        return None
 
-    # Effective Numeric Hagan lower integration limit (-1.0 when not applicable).
+    # Effective Numeric Hagan lower integration limit. Absent when not applicable.
     # VanillaSwapResponse
     def UsedCmsHaganLowerLimit(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(28))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return -1.0
+        return None
 
-    # Effective Numeric Hagan upper integration limit (-1.0 when not applicable).
+    # Effective Numeric Hagan upper integration limit. Absent when not applicable.
     # VanillaSwapResponse
     def UsedCmsHaganUpperLimit(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(30))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return -1.0
+        return None
 
-    # Effective Numeric Hagan integration precision (-1.0 when not applicable).
+    # Effective Numeric Hagan integration precision. Absent when not applicable.
     # VanillaSwapResponse
     def UsedCmsHaganPrecision(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(32))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return -1.0
+        return None
 
-    # Effective Numeric Hagan hard upper integration limit (-1.0 when not applicable).
+    # Effective Numeric Hagan hard upper integration limit. Absent when not applicable.
     # VanillaSwapResponse
     def UsedCmsHaganHardUpperLimit(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(34))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Float64Flags, o + self._tab.Pos)
-        return -1.0
+        return None
 
 def VanillaSwapResponseStart(builder):
     builder.StartObject(16)
@@ -265,31 +265,31 @@ def AddUsedCmsYieldCurveModel(builder, usedCmsYieldCurveModel):
     VanillaSwapResponseAddUsedCmsYieldCurveModel(builder, usedCmsYieldCurveModel)
 
 def VanillaSwapResponseAddUsedCmsMeanReversion(builder, usedCmsMeanReversion):
-    builder.PrependFloat64Slot(11, usedCmsMeanReversion, -1.0)
+    builder.PrependFloat64Slot(11, usedCmsMeanReversion, None)
 
 def AddUsedCmsMeanReversion(builder, usedCmsMeanReversion):
     VanillaSwapResponseAddUsedCmsMeanReversion(builder, usedCmsMeanReversion)
 
 def VanillaSwapResponseAddUsedCmsHaganLowerLimit(builder, usedCmsHaganLowerLimit):
-    builder.PrependFloat64Slot(12, usedCmsHaganLowerLimit, -1.0)
+    builder.PrependFloat64Slot(12, usedCmsHaganLowerLimit, None)
 
 def AddUsedCmsHaganLowerLimit(builder, usedCmsHaganLowerLimit):
     VanillaSwapResponseAddUsedCmsHaganLowerLimit(builder, usedCmsHaganLowerLimit)
 
 def VanillaSwapResponseAddUsedCmsHaganUpperLimit(builder, usedCmsHaganUpperLimit):
-    builder.PrependFloat64Slot(13, usedCmsHaganUpperLimit, -1.0)
+    builder.PrependFloat64Slot(13, usedCmsHaganUpperLimit, None)
 
 def AddUsedCmsHaganUpperLimit(builder, usedCmsHaganUpperLimit):
     VanillaSwapResponseAddUsedCmsHaganUpperLimit(builder, usedCmsHaganUpperLimit)
 
 def VanillaSwapResponseAddUsedCmsHaganPrecision(builder, usedCmsHaganPrecision):
-    builder.PrependFloat64Slot(14, usedCmsHaganPrecision, -1.0)
+    builder.PrependFloat64Slot(14, usedCmsHaganPrecision, None)
 
 def AddUsedCmsHaganPrecision(builder, usedCmsHaganPrecision):
     VanillaSwapResponseAddUsedCmsHaganPrecision(builder, usedCmsHaganPrecision)
 
 def VanillaSwapResponseAddUsedCmsHaganHardUpperLimit(builder, usedCmsHaganHardUpperLimit):
-    builder.PrependFloat64Slot(15, usedCmsHaganHardUpperLimit, -1.0)
+    builder.PrependFloat64Slot(15, usedCmsHaganHardUpperLimit, None)
 
 def AddUsedCmsHaganHardUpperLimit(builder, usedCmsHaganHardUpperLimit):
     VanillaSwapResponseAddUsedCmsHaganHardUpperLimit(builder, usedCmsHaganHardUpperLimit)
@@ -320,11 +320,11 @@ class VanillaSwapResponseT(object):
         self.floatingLegFlows = None  # type: List[SwapLegFlowT]
         self.usedCmsPricerType = 0  # type: int
         self.usedCmsYieldCurveModel = 0  # type: int
-        self.usedCmsMeanReversion = -1.0  # type: float
-        self.usedCmsHaganLowerLimit = -1.0  # type: float
-        self.usedCmsHaganUpperLimit = -1.0  # type: float
-        self.usedCmsHaganPrecision = -1.0  # type: float
-        self.usedCmsHaganHardUpperLimit = -1.0  # type: float
+        self.usedCmsMeanReversion = None  # type: Optional[float]
+        self.usedCmsHaganLowerLimit = None  # type: Optional[float]
+        self.usedCmsHaganUpperLimit = None  # type: Optional[float]
+        self.usedCmsHaganPrecision = None  # type: Optional[float]
+        self.usedCmsHaganHardUpperLimit = None  # type: Optional[float]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):

--- a/jsonserver/openapi/openapi3.json
+++ b/jsonserver/openapi/openapi3.json
@@ -2568,13 +2568,9 @@
             "type": "number",
             "description": "Underlying index fixing. For CMS coupons this is the CMS swap-rate fixing."
           },
-          "has_cms_swap_rate": {
-            "type": "boolean",
-            "description": "True when cms_swap_rate is populated for a CMS coupon."
-          },
           "cms_swap_rate": {
             "type": "number",
-            "description": "CMS swap-rate fixing when has_cms_swap_rate is true."
+            "description": "CMS swap-rate fixing for a CMS coupon. Absent for non-CMS coupons."
           },
           "spread": {
             "type": "number"
@@ -2651,23 +2647,23 @@
           },
           "used_cms_mean_reversion": {
             "type": "number",
-            "description": "Effective CMS mean reversion used by pricer (-1.0 when no CMS leg)."
+            "description": "Effective CMS mean reversion used by pricer. Absent when no CMS leg."
           },
           "used_cms_hagan_lower_limit": {
             "type": "number",
-            "description": "Effective Numeric Hagan lower integration limit (-1.0 when not applicable)."
+            "description": "Effective Numeric Hagan lower integration limit. Absent when not applicable."
           },
           "used_cms_hagan_upper_limit": {
             "type": "number",
-            "description": "Effective Numeric Hagan upper integration limit (-1.0 when not applicable)."
+            "description": "Effective Numeric Hagan upper integration limit. Absent when not applicable."
           },
           "used_cms_hagan_precision": {
             "type": "number",
-            "description": "Effective Numeric Hagan integration precision (-1.0 when not applicable)."
+            "description": "Effective Numeric Hagan integration precision. Absent when not applicable."
           },
           "used_cms_hagan_hard_upper_limit": {
             "type": "number",
-            "description": "Effective Numeric Hagan hard upper integration limit (-1.0 when not applicable)."
+            "description": "Effective Numeric Hagan hard upper integration limit. Absent when not applicable."
           }
         },
         "additionalProperties": false
@@ -7865,37 +7861,37 @@
           },
           "used_hw_a": {
             "type": "number",
-            "description": "Effective Hull-White mean reversion \"a\" used by pricing. -1.0 when model is not HullWhiteLattice."
+            "description": "Effective Hull-White mean reversion \"a\" used by pricing. Absent when model is not HullWhiteLattice."
           },
           "used_hw_sigma": {
             "type": "number",
-            "description": "Effective Hull-White sigma used by pricing. -1.0 when model is not HullWhiteLattice."
+            "description": "Effective Hull-White sigma used by pricing. Absent when model is not HullWhiteLattice."
           },
           "used_hw_rmse": {
             "type": "number",
-            "description": "Calibration RMSE for inline-calibrated Hull-White. -1.0 when no inline calibration."
+            "description": "Calibration RMSE for inline-calibrated Hull-White. Absent when no inline calibration."
           },
           "used_hw_num_helpers": {
             "type": "integer",
-            "description": "Number of calibration helpers for inline-calibrated Hull-White. -1 when no inline calibration.",
+            "description": "Number of calibration helpers for inline-calibrated Hull-White. Absent when no inline calibration.",
             "minimum": -2147483648,
             "maximum": 2147483647
           },
           "used_hw_grid_rows": {
             "type": "integer",
-            "description": "Calibration grid rows for inline-calibrated Hull-White. -1 when no inline calibration.",
+            "description": "Calibration grid rows for inline-calibrated Hull-White. Absent when no inline calibration.",
             "minimum": -2147483648,
             "maximum": 2147483647
           },
           "used_hw_grid_cols": {
             "type": "integer",
-            "description": "Calibration grid columns for inline-calibrated Hull-White. -1 when no inline calibration.",
+            "description": "Calibration grid columns for inline-calibrated Hull-White. Absent when no inline calibration.",
             "minimum": -2147483648,
             "maximum": 2147483647
           },
           "used_hw_grid_points": {
             "type": "integer",
-            "description": "Calibration grid points for inline-calibrated Hull-White. -1 when no inline calibration.",
+            "description": "Calibration grid points for inline-calibrated Hull-White. Absent when no inline calibration.",
             "minimum": -2147483648,
             "maximum": 2147483647
           }

--- a/jsonserver/openapi/openapi3.yaml
+++ b/jsonserver/openapi/openapi3.yaml
@@ -1842,12 +1842,9 @@ components:
           type: number
           description: Underlying index fixing. For CMS coupons this is the CMS swap-rate
             fixing.
-        has_cms_swap_rate:
-          type: boolean
-          description: True when cms_swap_rate is populated for a CMS coupon.
         cms_swap_rate:
           type: number
-          description: CMS swap-rate fixing when has_cms_swap_rate is true.
+          description: CMS swap-rate fixing for a CMS coupon. Absent for non-CMS coupons.
         spread:
           type: number
         rate:
@@ -1900,24 +1897,24 @@ components:
           $ref: '#/components/schemas/quantra_enums_CmsYieldCurveModel'
         used_cms_mean_reversion:
           type: number
-          description: Effective CMS mean reversion used by pricer (-1.0 when no CMS
-            leg).
+          description: Effective CMS mean reversion used by pricer. Absent when no
+            CMS leg.
         used_cms_hagan_lower_limit:
           type: number
-          description: Effective Numeric Hagan lower integration limit (-1.0 when
-            not applicable).
+          description: Effective Numeric Hagan lower integration limit. Absent when
+            not applicable.
         used_cms_hagan_upper_limit:
           type: number
-          description: Effective Numeric Hagan upper integration limit (-1.0 when
-            not applicable).
+          description: Effective Numeric Hagan upper integration limit. Absent when
+            not applicable.
         used_cms_hagan_precision:
           type: number
-          description: Effective Numeric Hagan integration precision (-1.0 when not
-            applicable).
+          description: Effective Numeric Hagan integration precision. Absent when
+            not applicable.
         used_cms_hagan_hard_upper_limit:
           type: number
-          description: Effective Numeric Hagan hard upper integration limit (-1.0
-            when not applicable).
+          description: Effective Numeric Hagan hard upper integration limit. Absent
+            when not applicable.
       additionalProperties: false
     quantra_PriceVanillaSwapResponse:
       type: object
@@ -5991,37 +5988,37 @@ components:
           $ref: '#/components/schemas/quantra_enums_ModelParamMode'
         used_hw_a:
           type: number
-          description: Effective Hull-White mean reversion "a" used by pricing. -1.0
+          description: Effective Hull-White mean reversion "a" used by pricing. Absent
             when model is not HullWhiteLattice.
         used_hw_sigma:
           type: number
-          description: Effective Hull-White sigma used by pricing. -1.0 when model
+          description: Effective Hull-White sigma used by pricing. Absent when model
             is not HullWhiteLattice.
         used_hw_rmse:
           type: number
-          description: Calibration RMSE for inline-calibrated Hull-White. -1.0 when
+          description: Calibration RMSE for inline-calibrated Hull-White. Absent when
             no inline calibration.
         used_hw_num_helpers:
           type: integer
           description: Number of calibration helpers for inline-calibrated Hull-White.
-            -1 when no inline calibration.
+            Absent when no inline calibration.
           minimum: -2147483648
           maximum: 2147483647
         used_hw_grid_rows:
           type: integer
-          description: Calibration grid rows for inline-calibrated Hull-White. -1
+          description: Calibration grid rows for inline-calibrated Hull-White. Absent
             when no inline calibration.
           minimum: -2147483648
           maximum: 2147483647
         used_hw_grid_cols:
           type: integer
           description: Calibration grid columns for inline-calibrated Hull-White.
-            -1 when no inline calibration.
+            Absent when no inline calibration.
           minimum: -2147483648
           maximum: 2147483647
         used_hw_grid_points:
           type: integer
-          description: Calibration grid points for inline-calibrated Hull-White. -1
+          description: Calibration grid points for inline-calibrated Hull-White. Absent
             when no inline calibration.
           minimum: -2147483648
           maximum: 2147483647

--- a/src/evaluators/swaption_evaluator.cpp
+++ b/src/evaluators/swaption_evaluator.cpp
@@ -649,9 +649,6 @@ SwaptionResult SwaptionEvaluator::evaluate(const SwaptionInputs& inputs,
             }
             row.dv01 = row.delta * 1.0e-4;
         }
-        if (!std::isfinite(row.impliedVolatility)) {
-            row.impliedVolatility = -1.0;
-        }
 
         if (ctx.options.swaptionPricingRebump) {
             const double bump = 1.0e-4; // 1bp

--- a/src/evaluators/swaption_evaluator.h
+++ b/src/evaluators/swaption_evaluator.h
@@ -24,8 +24,10 @@
  * IndexRegistry directly.
  */
 
+#include <limits>
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -152,7 +154,9 @@ struct SwaptionInputs {
 /// enums.h, neither of which is a *_generated.h header).
 struct SwaptionPerTrade {
     double npv = 0.0;
-    double impliedVolatility = -1.0;
+    // Non-finite (NaN) means "no implied vol available"; the mapper omits the
+    // field entirely in that case rather than emitting a sentinel.
+    double impliedVolatility = std::numeric_limits<double>::quiet_NaN();
     double atmForward = 0.0;
     double annuity = 0.0;
     double delta = 0.0;
@@ -173,13 +177,18 @@ struct SwaptionPerTrade {
         quantra::enums::SwaptionVolKind_Constant;
     quantra::enums::ModelParamMode usedModelParamMode =
         quantra::enums::ModelParamMode_Explicit;
-    double usedHwA = -1.0;
-    double usedHwSigma = -1.0;
-    double usedHwRmse = -1.0;
-    int usedHwNumHelpers = -1;
-    int usedHwGridRows = -1;
-    int usedHwGridCols = -1;
-    int usedHwGridPoints = -1;
+    // Present only when the swaption engine used a Hull-White model. The a/sigma
+    // pair is set for both explicit and inline-calibrated Hull-White; the RMSE,
+    // helper count and grid dimensions are set only for inline calibration.
+    // The mapper adds each field only when its optional holds a value, so an
+    // inapplicable field is simply absent in the response.
+    std::optional<double> usedHwA;
+    std::optional<double> usedHwSigma;
+    std::optional<double> usedHwRmse;
+    std::optional<int> usedHwNumHelpers;
+    std::optional<int> usedHwGridRows;
+    std::optional<int> usedHwGridCols;
+    std::optional<int> usedHwGridPoints;
 };
 
 /// SABR-kind vol surfaces emit a SwaptionVolDiagnostics block when the request

--- a/src/evaluators/vanilla_swap_evaluator.cpp
+++ b/src/evaluators/vanilla_swap_evaluator.cpp
@@ -160,7 +160,7 @@ void extractFixedLegFlows(
 /**
  * Pre-serialize a floating-leg coupon (IBOR or CMS). Mirrors the
  * vanilla_swap_flow_builder floating-leg path: indexFixing/spread/rate plus
- * the CmsCoupon-specific has_cms_swap_rate/cms_swap_rate fields. The fixing
+ * the CmsCoupon-specific cms_swap_rate field. The fixing
  * call is wrapped in try/catch to preserve the legacy NaN-on-fixing-error
  * fallback.
  */

--- a/src/mappers/swaption_mapper.cpp
+++ b/src/mappers/swaption_mapper.cpp
@@ -1,5 +1,6 @@
 #include "swaption_mapper.h"
 
+#include <cmath>
 #include <memory>
 #include <string>
 
@@ -367,7 +368,11 @@ flatbuffers::Offset<quantra::PriceSwaptionResponse> SwaptionMapper::toResponse(
 
         quantra::SwaptionResponseBuilder rb(builder);
         rb.add_npv(r.npv);
-        rb.add_implied_volatility(r.impliedVolatility);
+        // Non-finite implied vol (no analytic value for this setup) is omitted,
+        // matching the equity-option greeks: absent rather than a sentinel.
+        if (std::isfinite(r.impliedVolatility)) {
+            rb.add_implied_volatility(r.impliedVolatility);
+        }
         rb.add_atm_forward(r.atmForward);
         rb.add_annuity(r.annuity);
         rb.add_delta(r.delta);
@@ -385,13 +390,15 @@ flatbuffers::Offset<quantra::PriceSwaptionResponse> SwaptionMapper::toResponse(
         rb.add_used_cube_node_atm(r.usedCubeNodeAtm);
         rb.add_vol_kind(r.volKind);
         rb.add_used_model_param_mode(r.usedModelParamMode);
-        rb.add_used_hw_a(r.usedHwA);
-        rb.add_used_hw_sigma(r.usedHwSigma);
-        rb.add_used_hw_rmse(r.usedHwRmse);
-        rb.add_used_hw_num_helpers(r.usedHwNumHelpers);
-        rb.add_used_hw_grid_rows(r.usedHwGridRows);
-        rb.add_used_hw_grid_cols(r.usedHwGridCols);
-        rb.add_used_hw_grid_points(r.usedHwGridPoints);
+        // Hull-White diagnostics are added only when applicable; an unset
+        // optional leaves the field absent in the response JSON.
+        if (r.usedHwA) rb.add_used_hw_a(*r.usedHwA);
+        if (r.usedHwSigma) rb.add_used_hw_sigma(*r.usedHwSigma);
+        if (r.usedHwRmse) rb.add_used_hw_rmse(*r.usedHwRmse);
+        if (r.usedHwNumHelpers) rb.add_used_hw_num_helpers(*r.usedHwNumHelpers);
+        if (r.usedHwGridRows) rb.add_used_hw_grid_rows(*r.usedHwGridRows);
+        if (r.usedHwGridCols) rb.add_used_hw_grid_cols(*r.usedHwGridCols);
+        if (r.usedHwGridPoints) rb.add_used_hw_grid_points(*r.usedHwGridPoints);
         rowOffsets.push_back(rb.Finish());
     }
 

--- a/src/mappers/vanilla_swap_flow_builder.cpp
+++ b/src/mappers/vanilla_swap_flow_builder.cpp
@@ -91,7 +91,7 @@ VanillaSwapFlowsBuildResult buildVanillaSwapFlows(
             // indexFixing() can fail (missing historical fixing); we caught the
             // throw and left `fixing` as NaN. NaN is not valid JSON, so omit it.
             if (std::isfinite(fixing)) fb.add_index_fixing(fixing);
-            fb.add_has_cms_swap_rate(hasCmsSwapRate);
+            // CMS swap-rate fixing is added only for CMS coupons; absent otherwise.
             if (hasCmsSwapRate && std::isfinite(cmsSwapRate)) {
                 fb.add_cms_swap_rate(cmsSwapRate);
             }

--- a/src/mappers/vanilla_swap_mapper.cpp
+++ b/src/mappers/vanilla_swap_mapper.cpp
@@ -197,7 +197,7 @@ flatbuffers::Offset<quantra::SwapLegFlow> serializeFlow(
     if (f.isFloating) {
         fb.add_fixing_date(fixingDate);
         if (std::isfinite(f.indexFixing)) fb.add_index_fixing(f.indexFixing);
-        fb.add_has_cms_swap_rate(f.hasCmsSwapRate);
+        // CMS swap-rate fixing is added only for CMS coupons; absent otherwise.
         if (f.hasCmsSwapRate && std::isfinite(f.cmsSwapRate)) {
             fb.add_cms_swap_rate(f.cmsSwapRate);
         }

--- a/src/market/curve_bootstrapper.cpp
+++ b/src/market/curve_bootstrapper.cpp
@@ -217,7 +217,11 @@ BootstrappedCurves CurveBootstrapper::bootstrapAll(
     for (flatbuffers::uoffset_t i = 0; i < curves->size(); i++) {
         auto ts = curves->Get(i);
         if (!ts->id()) QUANTRA_INVALID_ARGUMENT("TermStructure.id is required for multi-curve bootstrapping");
-        curveIndex[ts->id()->str()] = ts;
+        std::string curveId = ts->id()->str();
+        if (curveIndex.count(curveId) != 0) {
+            QUANTRA_INVALID_ARGUMENT("duplicate curve id: " + curveId);
+        }
+        curveIndex[curveId] = ts;
     }
 
     // ---- 4. Create empty handles and register them ----

--- a/src/market/equity_underlying_registry.cpp
+++ b/src/market/equity_underlying_registry.cpp
@@ -21,6 +21,9 @@ std::unordered_map<std::string, EquityUnderlyingRuntime> EquityUnderlyingRegistr
         if (!u->spot_quote_id() || !u->dividend_yield_curve_id()) {
             QUANTRA_INVALID_ARGUMENT("EquityUnderlyingSpec requires spot_quote_id and dividend_yield_curve_id");
         }
+        if (out.count(u->id()->str()) != 0) {
+            QUANTRA_INVALID_ARGUMENT("duplicate equity underlying id: " + u->id()->str());
+        }
 
         auto divIt = reg.rates.curves.find(u->dividend_yield_curve_id()->str());
         if (divIt == reg.rates.curves.end()) {

--- a/src/market/index_registry_builder.h
+++ b/src/market/index_registry_builder.h
@@ -78,6 +78,9 @@ public:
             }
 
             std::string id = def->id()->str();
+            if (registry.has(id)) {
+                QUANTRA_INVALID_ARGUMENT("duplicate index id: " + id);
+            }
             std::string name = def->name()->str();
 
             // Parse currency (required field, default to EUR if somehow empty)

--- a/src/market/pricing_registry.cpp
+++ b/src/market/pricing_registry.cpp
@@ -25,6 +25,8 @@
 #include "require_scalar.h"
 #include "require_period.h"
 
+#include <unordered_set>
+
 namespace quantra {
 
 PricingRegistry PricingRegistryBuilder::build(const quantra::Pricing* pricing,
@@ -129,12 +131,16 @@ PricingRegistry PricingRegistryBuilder::build(const quantra::Pricing* pricing,
     // Parsed after rates so equity SurfaceFromPrices can resolve curve ids.
     // ==========================================================================
     if (volatility && volatility->vol_surfaces()) {
+        std::unordered_set<std::string> seenVolIds;
         for (auto it = volatility->vol_surfaces()->begin(); it != volatility->vol_surfaces()->end(); ++it) {
             const auto* spec = *it;
             if (!spec->id()) {
                 QUANTRA_INVALID_ARGUMENT("VolSurfaceSpec.id is required");
             }
             std::string id = spec->id()->str();
+            if (!seenVolIds.insert(id).second) {
+                QUANTRA_INVALID_ARGUMENT("duplicate volatility surface id: " + id);
+            }
 
             switch (spec->payload_type()) {
                 case quantra::VolPayload_OptionletVolSpec:
@@ -210,6 +216,9 @@ PricingRegistry PricingRegistryBuilder::build(const quantra::Pricing* pricing,
                 QUANTRA_INVALID_ARGUMENT("ModelSpec.id is required");
             }
             std::string id = spec->id()->str();
+            if (reg.volatility.modelDomains.count(id) != 0) {
+                QUANTRA_INVALID_ARGUMENT("duplicate model id: " + id);
+            }
 
             if (spec->payload_type() == quantra::ModelPayload_NONE) {
                 QUANTRA_INVALID_ARGUMENT("ModelSpec.payload is required for model id: " + id);
@@ -328,6 +337,9 @@ PricingRegistry PricingRegistryBuilder::build(const quantra::Pricing* pricing,
                 QUANTRA_INVALID_ARGUMENT("CreditCurveSpec.reference_date is required");
             }
             std::string id = spec->id()->str();
+            if (reg.credit.creditCurves.count(id) != 0) {
+                QUANTRA_INVALID_ARGUMENT("duplicate credit curve id: " + id);
+            }
 
             // Plain-domain mirror. QL conversions (Calendar/DayCounter/BDC/
             // Frequency/DateGeneration::Rule/TimeUnit) go through

--- a/tests/contract/error_contract_test.py
+++ b/tests/contract/error_contract_test.py
@@ -166,6 +166,27 @@ def _ec_del_index_tenor_unit():
     return f
 
 
+def _ec_dup_curve_id():
+    """Append a second curve reusing the first curve's id. Defining the same id
+    twice silently kept the first and dropped the second (first-wins), which can
+    change the price without warning; it must now be a named 400."""
+    def f(req):
+        curves = req["pricing"]["rates"]["curves"]
+        curves.append(json.loads(json.dumps(curves[0])))
+        return req
+    return f
+
+
+def _ec_dup_index_id():
+    """Append a second index reusing the first index's id. A duplicate index id
+    must be a named 400 rather than silently keeping the first definition."""
+    def f(req):
+        indices = req["pricing"]["rates"]["indices"]
+        indices.append(json.loads(json.dumps(indices[0])))
+        return req
+    return f
+
+
 def _ec_del_cds_schedule_field(field):
     """Drop a field from the CDS trade schedule (e.g. end_of_month). Presence-
     required: absent-vs-false silently changes schedule dates."""
@@ -706,6 +727,18 @@ SCENARIOS = [
      "swaption_request.json", 400, _ec_del_field("swaptions", "model")),
     ("ec:400 fixed_rate_bond missing discounting_curve field", "fixed_rate_bond",
      "fixed_rate_bond_request.json", 400, _ec_del_field("bonds", "discounting_curve")),
+    # ---- 400 INVALID_ARGUMENT: duplicate ids in a request list ----
+    # Defining the same id twice in a curves/indices list previously kept the
+    # first definition and silently dropped the rest, which can change the
+    # priced result. A duplicate id must be a named 400.
+    ("ec:400 vanilla_swap duplicate curve id", "vanilla_swap",
+     "vanilla_swap_request.json", 400,
+     _ec_dup_curve_id(),
+     _ec_body_contains("duplicate curve id")),
+    ("ec:400 vanilla_swap duplicate index id", "vanilla_swap",
+     "vanilla_swap_request.json", 400,
+     _ec_dup_index_id(),
+     _ec_body_contains("duplicate index id")),
     # ---- 400 INVALID_ARGUMENT: swap-leg convention presence ----
     # A swap-leg convention enum omitted from the request must be rejected, not
     # silently defaulted to the alphabetical-0 value.

--- a/tests/contract/response_optionals_test.py
+++ b/tests/contract/response_optionals_test.py
@@ -1,0 +1,70 @@
+"""Inapplicable response diagnostics are ABSENT, not sentinels.
+
+Several response fields used to carry a -1.0 / -1 sentinel (or a has_x flag
+pair) to mean "not applicable". They are now optional and simply omitted from
+the response JSON when they do not apply, matching how equity greeks and CDS
+fair_spread already behave. These tests pin that behaviour end-to-end:
+
+  - a swaption priced with a non-Hull-White model carries no `used_hw_*` keys;
+  - a plain vanilla (IBOR) swap carries no `used_cms_*` keys and no
+    `cms_swap_rate` / `has_cms_swap_rate` keys on any flow.
+"""
+
+import json
+
+from ql_reference import load_json
+
+HW_KEYS = [
+    "used_hw_a",
+    "used_hw_sigma",
+    "used_hw_rmse",
+    "used_hw_num_helpers",
+    "used_hw_grid_rows",
+    "used_hw_grid_cols",
+    "used_hw_grid_points",
+]
+
+CMS_KEYS = [
+    "used_cms_mean_reversion",
+    "used_cms_hagan_lower_limit",
+    "used_cms_hagan_upper_limit",
+    "used_cms_hagan_precision",
+    "used_cms_hagan_hard_upper_limit",
+]
+
+
+def test_non_hw_swaption_omits_hw_diagnostics(client, data_dir):
+    # The example swaption uses a Black model, so no Hull-White diagnostics apply.
+    request = load_json(data_dir / "swaption_request.json")
+    response = client.price("swaption", request)
+    rows = response.get("swaptions")
+    assert isinstance(rows, list) and rows, f"no swaptions in response: {response}"
+    for row in rows:
+        for key in HW_KEYS:
+            assert key not in row, (
+                f"non-Hull-White swaption unexpectedly carries {key!r}: {row}"
+            )
+
+
+def test_plain_vanilla_swap_omits_cms_diagnostics(client, data_dir):
+    request = load_json(data_dir / "vanilla_swap_request.json")
+    # Request per-leg flows so the coupon-level cms_swap_rate omission is exercised
+    # too (a plain IBOR swap has no CMS coupons).
+    request = json.loads(json.dumps(request))
+    request["include_flows"] = True
+    response = client.price("vanilla_swap", request)
+    swaps = response.get("swaps")
+    assert isinstance(swaps, list) and swaps, f"no swaps in response: {response}"
+    for swap in swaps:
+        for key in CMS_KEYS:
+            assert key not in swap, (
+                f"plain vanilla swap unexpectedly carries {key!r}: {swap}"
+            )
+        for leg_key in ("fixed_leg_flows", "floating_leg_flows"):
+            for flow in swap.get(leg_key, []):
+                assert "cms_swap_rate" not in flow, (
+                    f"non-CMS coupon unexpectedly carries cms_swap_rate: {flow}"
+                )
+                assert "has_cms_swap_rate" not in flow, (
+                    f"has_cms_swap_rate must be removed from the schema: {flow}"
+                )

--- a/tests/parity/vanilla_swap_test.cpp
+++ b/tests/parity/vanilla_swap_test.cpp
@@ -110,7 +110,9 @@ TEST_F(QuantraComparisonTest, VanillaSwap_NPVMatches) {
     std::cout << "QuantLib Fair: " << qlFairRate*100 << "% | Quantra: " << qFairRate*100 << "%" << std::endl;
     EXPECT_NEAR(qlNPV, qNPV, 0.01);
     EXPECT_NEAR(qlFairRate, qFairRate, 1e-6);
-    EXPECT_DOUBLE_EQ(-1.0, r->used_cms_mean_reversion());
+    // No CMS leg: the CMS diagnostic is omitted entirely rather than emitting a
+    // -1.0 sentinel, so the optional scalar has no value.
+    EXPECT_FALSE(r->used_cms_mean_reversion().has_value());
 }
 
 TEST_F(QuantraComparisonTest, VanillaSwap_CMS_NPVMatches) {


### PR DESCRIPTION
**Response sentinels → optional-with-presence, and duplicate-id rejection** (0.5.0 batch). Two independent hardening changes.

**Response side:** swaption Hull-White diagnostics (`used_hw_a/sigma/rmse` + helper/grid counts), the swaption `implied_volatility`, and the vanilla-swap CMS-pricer diagnostics used a `-1.0`/`-1` sentinel for "not applicable", and a CMS flow used a `has_cms_swap_rate` + `cms_swap_rate` flag-pair. All now optional and simply **absent when inapplicable** — matching equity greeks / CDS fair spread. This removes a genuine ambiguity: a legitimate `-1.0` CMS Hagan integration bound in a negative-rate market was indistinguishable from the sentinel and silently dropped. **`has_cms_swap_rate` is deleted** (the value field carries presence). New tests POST to the live server and confirm the keys are *absent* from the JSON, not a sentinel.

**Registry side:** defining the same curve / index / vol-surface / model / credit-curve / equity-underlying id twice silently kept the first and dropped the second (could change a price with no signal). A duplicate id is now a 400 naming the collection and the id.

Migration note: gRPC/FlatBuffers consumers see accessor types change (`double`/`int` → optional); JSON consumers see one visible change — the `has_cms_swap_rate` key disappears. No request JSON changed, no priced result moved. Full suite green (679 cases). Wire-breaking; part of 0.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
