### PR TITLE
Drop the GitHub Actions build cache from the release image workflow

### DIFF
--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -58,8 +58,6 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           provenance: true
           sbom: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       - name: Attest image provenance
         uses: actions/attest-build-provenance@v2


### PR DESCRIPTION
The `v0.5.0` production-image build compiled cleanly, then `buildx` failed with `failed to solve: not_found` resolving the `type=gha` build cache — GitHub changed its Actions cache-service backend since 0.4.0 published, and the cache step now aborts the whole build after the ~90-minute compile. It reproduced identically on a re-run, so it is deterministic, not a flake.

The cache is a minor optimization for a one-off per-tag build and was the only point of failure. Removing `cache-from`/`cache-to: type=gha` unblocks the publish; the shipped image content is unchanged. CI-workflow only — the test gate does not run this workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
